### PR TITLE
docs: Update tapes.dev for API server and CLI structure

### DIFF
--- a/tapes.dev/src/layouts/Layout.astro
+++ b/tapes.dev/src/layouts/Layout.astro
@@ -57,6 +57,32 @@ const { title } = Astro.props;
   </head>
   <body>
     <div id="toast" class="toast">Copied to clipboard</div>
+    <div id="nav-overlay" class="nav-overlay"></div>
+    <nav id="nav-drawer" class="nav-drawer">
+      <div class="nav-header">
+        <span>Navigation</span>
+        <button id="nav-close" aria-label="Close navigation">
+          <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2">
+            <line x1="18" y1="6" x2="6" y2="18"/>
+            <line x1="6" y1="6" x2="18" y2="18"/>
+          </svg>
+        </button>
+      </div>
+      <ul class="nav-links">
+        <li><a href="#install">Install</a></li>
+        <li><a href="#run">Run</a></li>
+        <li><a href="#use">Use</a></li>
+        <li><a href="#inspect">Inspect</a></li>
+        <li><a href="#architecture">Architecture</a></li>
+      </ul>
+    </nav>
+    <button id="nav-toggle" class="nav-toggle" aria-label="Open navigation">
+      <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2">
+        <line x1="3" y1="6" x2="21" y2="6"/>
+        <line x1="3" y1="12" x2="21" y2="12"/>
+        <line x1="3" y1="18" x2="21" y2="18"/>
+      </svg>
+    </button>
     <button id="theme-toggle" aria-label="Toggle theme">
       <svg class="sun-icon" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2">
         <circle cx="12" cy="12" r="5"/>
@@ -74,7 +100,7 @@ const { title } = Astro.props;
       </svg>
     </button>
     <slot />
-    <script>
+    <script is:inline>
       // Listen for system preference changes
       window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
         if (!localStorage.getItem('theme')) {
@@ -88,6 +114,47 @@ const { title } = Astro.props;
         const next = current === 'dark' ? 'light' : 'dark';
         document.documentElement.setAttribute('data-theme', next);
         localStorage.setItem('theme', next);
+      });
+
+      // Navigation drawer
+      document.addEventListener('DOMContentLoaded', () => {
+        const navToggle = document.getElementById('nav-toggle');
+        const navClose = document.getElementById('nav-close');
+        const navDrawer = document.getElementById('nav-drawer');
+        const navOverlay = document.getElementById('nav-overlay');
+        const navLinks = document.querySelectorAll('.nav-links a');
+
+        function openNav() {
+          navDrawer?.classList.add('open');
+          navOverlay?.classList.add('open');
+          document.body.style.overflow = 'hidden';
+        }
+
+        function closeNav() {
+          navDrawer?.classList.remove('open');
+          navOverlay?.classList.remove('open');
+          document.body.style.overflow = '';
+        }
+
+        navToggle?.addEventListener('click', openNav);
+        navClose?.addEventListener('click', closeNav);
+        navOverlay?.addEventListener('click', closeNav);
+
+        navLinks.forEach(link => {
+          link.addEventListener('click', (e) => {
+            e.preventDefault();
+            const targetId = link.getAttribute('href');
+            if (targetId) {
+              const target = document.querySelector(targetId);
+              if (target) {
+                closeNav();
+                setTimeout(() => {
+                  target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                }, 150);
+              }
+            }
+          });
+        });
       });
 
       // Add copy buttons to all code blocks
@@ -250,6 +317,7 @@ const { title } = Astro.props;
 
   .code-block {
     position: relative;
+    margin-bottom: 1.5rem;
   }
 
   .copy-button {
@@ -310,5 +378,121 @@ const { title } = Astro.props;
   .toast.show {
     transform: translateY(0);
     opacity: 1;
+  }
+
+  /* Navigation Toggle */
+  .nav-toggle {
+    position: fixed;
+    top: 1rem;
+    left: 1rem;
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 0.5rem;
+    cursor: pointer;
+    color: var(--text-secondary);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all 0.15s ease;
+    z-index: 100;
+  }
+
+  .nav-toggle:hover {
+    color: var(--text);
+    border-color: var(--text-secondary);
+  }
+
+  /* Navigation Overlay */
+  .nav-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.5);
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.2s ease, visibility 0.2s ease;
+    z-index: 200;
+  }
+
+  .nav-overlay.open {
+    opacity: 1;
+    visibility: visible;
+  }
+
+  /* Navigation Drawer */
+  .nav-drawer {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 280px;
+    height: 100%;
+    background: var(--bg);
+    border-right: 1px solid var(--border);
+    transform: translateX(-100%);
+    transition: transform 0.2s ease;
+    z-index: 300;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .nav-drawer.open {
+    transform: translateX(0);
+  }
+
+  .nav-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1rem 1.25rem;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .nav-header span {
+    font-weight: 600;
+    font-size: 1rem;
+  }
+
+  .nav-header button {
+    background: none;
+    border: none;
+    color: var(--text-secondary);
+    cursor: pointer;
+    padding: 0.25rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: color 0.15s ease;
+  }
+
+  .nav-header button:hover {
+    color: var(--text);
+  }
+
+  .nav-links {
+    list-style: none;
+    padding: 1rem 0;
+    flex: 1;
+    overflow-y: auto;
+  }
+
+  .nav-links li {
+    margin: 0;
+  }
+
+  .nav-links a {
+    display: block;
+    padding: 0.75rem 1.25rem;
+    color: var(--text-secondary);
+    font-size: 0.95rem;
+    transition: all 0.15s ease;
+  }
+
+  .nav-links a:hover {
+    color: var(--text);
+    background: var(--bg-secondary);
+    text-decoration: none;
   }
 </style>

--- a/tapes.dev/src/pages/index.astro
+++ b/tapes.dev/src/pages/index.astro
@@ -10,43 +10,67 @@ import Layout from '../layouts/Layout.astro';
     </header>
 
     <main>
-      <section>
+      <section id="install">
         <h2>Install</h2>
-        <p>Build from source with Go 1.25+:</p>
+        <p>Build from source with Go 1.22+:</p>
         <pre><code>git clone https://github.com/papercomputeco/tapes.git
 cd tapes
-go build -o tapesprox ./cmd/proxy</code></pre>
+make build</code></pre>
+        <p class="hint">This builds <code>tapes</code>, <code>tapesprox</code>, and <code>tapesapi</code> binaries in <code>./build/</code></p>
         <p class="hint">Or use <code>nix develop</code> if you have Nix installed.</p>
       </section>
 
-      <section>
+      <section id="run">
         <h2>Run</h2>
-        <p>Start the proxy pointing to your LLM provider (defaults to Ollama):</p>
-        <pre><code>./tapesprox \
-  -listen ":8080" \
-  -upstream "http://localhost:11434" \
-  -db "./tapes.db"</code></pre>
+        <p>Start both the proxy and API server together:</p>
+        <pre><code>./build/tapes serve \
+  --proxy-listen ":8080" \
+  --api-listen ":8081" \
+  --upstream "http://localhost:11434" \
+  --sqlite "./tapes.db"</code></pre>
+        <p class="hint">Or run them separately:</p>
+        <div class="commands">
+          <div class="command">
+            <code>tapes serve proxy</code>
+            <span>Run just the proxy server</span>
+          </div>
+          <div class="command">
+            <code>tapes serve api</code>
+            <span>Run just the API server</span>
+          </div>
+        </div>
+        <h3>Proxy Flags</h3>
         <div class="flags">
-          <div class="flag"><code>-listen</code> <span>Address to listen on (default: :8080)</span></div>
-          <div class="flag"><code>-upstream</code> <span>LLM provider URL (default: localhost:11434)</span></div>
-          <div class="flag"><code>-db</code> <span>SQLite database path (empty = in-memory)</span></div>
-          <div class="flag"><code>-debug</code> <span>Enable debug logging</span></div>
+          <div class="flag"><code>-l, --listen</code> <span>Address to listen on (default: :8080)</span></div>
+          <div class="flag"><code>-u, --upstream</code> <span>LLM provider URL (default: localhost:11434)</span></div>
+          <div class="flag"><code>-s, --sqlite</code> <span>SQLite database path (empty = in-memory)</span></div>
+          <div class="flag"><code>-d, --debug</code> <span>Enable debug logging</span></div>
+        </div>
+        <h3>API Server Flags</h3>
+        <div class="flags">
+          <div class="flag"><code>-l, --listen</code> <span>Address to listen on (default: :8081)</span></div>
+          <div class="flag"><code>-s, --sqlite</code> <span>SQLite database path (empty = in-memory)</span></div>
+          <div class="flag"><code>-d, --debug</code> <span>Enable debug logging</span></div>
         </div>
       </section>
 
-      <section>
+      <section id="use">
         <h2>Use</h2>
         <p>Send chat requests to the proxy instead of directly to your LLM:</p>
         <pre><code>curl -X POST http://localhost:8080/api/chat \
   -H "Content-Type: application/json" \
   -d '{"{"}"model": "llama2", "messages": [{"{"}"role": "user", "content": "Hello!"{"}"}], "stream": false{"}"}'</code></pre>
-        <p>The proxy forwards to your upstream LLM and stores both request and response in the DAG.</p>
+        <p>The proxy forwards to your upstream LLM and stores both request and response in the Merkle DAG.</p>
       </section>
 
-      <section>
+      <section id="inspect">
         <h2>Inspect</h2>
-        <p>Query the DAG to explore stored conversations:</p>
+        <p>Query the API server to explore stored conversations:</p>
         <div class="endpoints">
+          <div class="endpoint">
+            <code>GET /health</code>
+            <span>Health check endpoint</span>
+          </div>
           <div class="endpoint">
             <code>GET /dag/stats</code>
             <span>Total nodes, roots, and leaves</span>
@@ -64,6 +88,23 @@ go build -o tapesprox ./cmd/proxy</code></pre>
             <span>Get a single node by hash</span>
           </div>
         </div>
+        <p class="hint">API server runs on port 8081 by default when using <code>tapes serve</code></p>
+      </section>
+
+      <section id="architecture">
+        <h2>Architecture</h2>
+        <p>Tapes consists of two main components:</p>
+        <div class="architecture">
+          <div class="component">
+            <strong>Proxy Server</strong>
+            <span>Intercepts LLM requests, forwards to upstream provider, and stores conversation turns in the Merkle DAG</span>
+          </div>
+          <div class="component">
+            <strong>API Server</strong>
+            <span>Provides HTTP endpoints for inspecting and querying the stored conversation data</span>
+          </div>
+        </div>
+        <p>Both servers share the same storage backend (SQLite or in-memory) when run together via <code>tapes serve</code>.</p>
       </section>
 
       <section class="cta">
@@ -117,6 +158,14 @@ go build -o tapesprox ./cmd/proxy</code></pre>
     letter-spacing: -0.01em;
   }
 
+  section h3 {
+    font-size: 1rem;
+    font-weight: 600;
+    margin-top: 2.5rem;
+    margin-bottom: 0.75rem;
+    color: var(--text-secondary);
+  }
+
   section p {
     color: var(--text-secondary);
     margin-bottom: 1rem;
@@ -131,27 +180,53 @@ go build -o tapesprox ./cmd/proxy</code></pre>
     margin-top: 0.75rem;
   }
 
-  .flags, .endpoints {
+  .flags, .endpoints, .commands {
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
     margin-top: 1rem;
   }
 
-  .flag, .endpoint {
+  .architecture {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    margin-top: 1rem;
+    margin-bottom: 1.5rem;
+  }
+
+  .flag, .endpoint, .command, .component {
     display: flex;
     gap: 1rem;
     align-items: baseline;
     font-size: 0.95rem;
   }
 
-  .flag code, .endpoint code {
+  .flag code, .endpoint code, .command code {
     flex-shrink: 0;
-    min-width: 160px;
+    min-width: 180px;
   }
 
-  .flag span, .endpoint span {
+  .flag span, .endpoint span, .command span {
     color: var(--text-secondary);
+  }
+
+  .component {
+    flex-direction: column;
+    gap: 0.25rem;
+    padding: 1rem;
+    background: var(--bg-secondary);
+    border-radius: 8px;
+    border: 1px solid var(--border);
+  }
+
+  .component strong {
+    font-weight: 600;
+  }
+
+  .component span {
+    color: var(--text-secondary);
+    font-size: 0.9rem;
   }
 
   .cta {
@@ -190,12 +265,12 @@ go build -o tapesprox ./cmd/proxy</code></pre>
       padding: 2rem 1rem;
     }
 
-    .flag, .endpoint {
+    .flag, .endpoint, .command {
       flex-direction: column;
       gap: 0.25rem;
     }
 
-    .flag code, .endpoint code {
+    .flag code, .endpoint code, .command code {
       min-width: auto;
     }
   }


### PR DESCRIPTION
## Summary

Updates the tapes.dev documentation site to reflect the new CLI structure and API server from PR #7:

- Install section now shows `make build` for building all binaries
- Run section documents `tapes serve` with `--proxy-listen` and `--api-listen` flags
- Added separate Proxy Flags and API Server Flags documentation
- Added API endpoints section with all DAG inspection endpoints
- New Architecture section explaining Proxy Server and API Server components
- Added hamburger navigation menu with smooth scroll to page sections

## Test plan

- [x] Run `npm run dev` in tapes.dev folder
- [x] Verify hamburger menu opens/closes properly
- [x] Verify navigation links scroll to correct sections
- [x] Check all documentation reflects PR #7 CLI changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)