### PR TITLE
feat: Implements canonical JSON for merkle node hashes

### DIFF
--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -45,6 +45,7 @@ func (t *Tapes) testContainer() *dagger.Container {
 		From("golang:1.25-alpine").
 		WithExec([]string{"apk", "add", "--no-cache", "gcc", "musl-dev", "sqlite-dev"}).
 		WithEnvVariable("CGO_ENABLED", "1").
+		WithEnvVariable("GOEXPERIMENT", "jsonv2").
 		WithMountedCache("/go/pkg/mod", dag.CacheVolume("go-mod")).
 		WithMountedCache("/root/.cache/go-build", dag.CacheVolume("go-build")).
 		WithWorkdir("/src").

--- a/flake.nix
+++ b/flake.nix
@@ -32,6 +32,9 @@
           # Enable cgo for sqlite3 support
           CGO_ENABLED = "1";
 
+          # Enable Go's experimental JSON v2 implementation
+          GOEXPERIMENT = "jsonv2";
+
           shellHook = ''
             echo "Tapes development environment"
             echo ""

--- a/makefile
+++ b/makefile
@@ -3,6 +3,7 @@
 
 VERSION ?= dev
 
+GOENV = GOEXPERIMENT="jsonv2"
 GO_BUILD_FLAGS = -ldflags="-s -w"
 
 .PHONY: format
@@ -22,17 +23,17 @@ build-containers: build-proxy-container ## Builds all container artifacts
 .PHONY: build-proxy
 build-proxy: | build-dir ## Build proxy server artifact
 	$(call print-target)
-	go build -o build/tapesprox ${GO_BUILD_FLAGS} ./cli/tapesprox
+	${GOENV} go build -o build/tapesprox ${GO_BUILD_FLAGS} ./cli/tapesprox
 
 .PHONY: build-api
 build-api: | build-dir ## Build API server artifact
 	$(call print-target)
-	go build -o build/tapesapi ${GO_BUILD_FLAGS} ./cli/tapesapi
+	${GOENV} go build -o build/tapesapi ${GO_BUILD_FLAGS} ./cli/tapesapi
 
 .PHONY: build-cli
 build-cli: | build-dir ## Build CLI artifact
 	$(call print-target)
-	go build -o build/tapes ${GO_BUILD_FLAGS} ./cli/tapes
+	${GOENV} go build -o build/tapes ${GO_BUILD_FLAGS} ./cli/tapes
 
 .PHONY: build-proxy-container
 build-proxy-container: ## Build the tapesprox container artifact


### PR DESCRIPTION
* ✨ Implements canonical JSON for merkle node's `computeHash`: this should ensure that the JSON payload being hashed from proxy to proxy and run to run is the same. This is very important since we utilize the JSON payload hashes to create the ancestry tree.
  * Utilizes the experimental JSON v2 packages from Go with `Value.Canonicalize` enabling this to work
  * Sets the `GOEXPERIMENT=jsonv2` environment var throughout build and test envs
  
Closes PCC-24