### PR TITLE
fix: goimports now uses the right package name

### DIFF
--- a/cmd/tapes/tapes.go
+++ b/cmd/tapes/tapes.go
@@ -2,9 +2,10 @@
 package tapescmder
 
 import (
+	"github.com/spf13/cobra"
+
 	servecmder "github.com/papercomputeco/tapes/cmd/tapes/serve"
 	versioncmder "github.com/papercomputeco/tapes/cmd/version"
-	"github.com/spf13/cobra"
 )
 
 const tapesLongDesc string = `Tapes is automatic telemetry for your agents.

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -4,8 +4,9 @@ package versioncmder
 import (
 	"fmt"
 
-	"github.com/papercomputeco/tapes/pkg/utils"
 	"github.com/spf13/cobra"
+
+	"github.com/papercomputeco/tapes/pkg/utils"
 )
 
 type VersionCommander struct {

--- a/makefile
+++ b/makefile
@@ -9,7 +9,7 @@ GO_BUILD_FLAGS = -ldflags="-s -w"
 
 .PHONY: format
 format:
-	find . -type f -name "*.go" -exec goimports -local github.com/papercompute/tapes -w {} \;
+	find . -type f -name "*.go" -exec goimports -local github.com/papercomputeco/tapes -w {} \;
 
 .PHONY: build
 build: ## Builds all artifacts


### PR DESCRIPTION
* 🧹 `goimports` now uses the right package name to cluster local package imports on `make format`