### PR TITLE
feat: Bucket distribution

### DIFF
--- a/.dagger/release.go
+++ b/.dagger/release.go
@@ -1,0 +1,197 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"path"
+
+	"dagger/tapes/internal/dagger"
+)
+
+type uploadOpts struct {
+	// Directory containing build artifacts to upload
+	artifacts *dagger.Directory
+
+	// Path prefix in the bucket (e.g., "v1.0.0" or "nightly/2024-01-15")
+	prefix string
+
+	// Bucket endpoint URL
+	endpoint *dagger.Secret
+
+	// Bucket name
+	bucket *dagger.Secret
+
+	// Bucket access key ID
+	accessKeyId *dagger.Secret
+
+	// Bucket secret access key
+	secretAccessKey *dagger.Secret
+}
+
+// Upload artifacts to bucket under the specified path prefix
+func (t *Tapes) upload(
+	ctx context.Context,
+	opts *uploadOpts,
+) error {
+	bucketName, err := opts.bucket.Plaintext(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get bucket name: %w", err)
+	}
+
+	endpointUrl, err := opts.endpoint.Plaintext(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get endpoint: %w", err)
+	}
+
+	destination := fmt.Sprintf("s3://%s", path.Join(bucketName, opts.prefix))
+
+	// Use AWS CLI container for S3-compatible uploads
+	awsCli := dag.Container().
+		From("amazon/aws-cli:latest").
+		WithSecretVariable("AWS_ACCESS_KEY_ID", opts.accessKeyId).
+		WithSecretVariable("AWS_SECRET_ACCESS_KEY", opts.secretAccessKey).
+		WithEnvVariable("AWS_DEFAULT_REGION", "auto").
+		WithDirectory("/artifacts", opts.artifacts).
+		WithWorkdir("/artifacts")
+
+	// Sync the artifacts directory to bucket
+	_, err = awsCli.
+		WithExec([]string{
+			"aws", "s3", "sync", ".",
+			destination,
+			"--endpoint-url", endpointUrl,
+		}).
+		Sync(ctx)
+
+	if err != nil {
+		return fmt.Errorf("failed to upload artifacts: %w", err)
+	}
+
+	return nil
+}
+
+// Release builds release binaries and uploads to bucket
+func (t *Tapes) ReleaseLatest(
+	ctx context.Context,
+
+	// Version string (e.g., "v1.0.0")
+	version string,
+
+	// Git commit SHA
+	commit string,
+
+	// Bucket endpoint URL
+	endpoint *dagger.Secret,
+
+	// Bucket name
+	bucket *dagger.Secret,
+
+	// Bucket access key ID
+	accessKeyId *dagger.Secret,
+
+	// Bucket secret access key
+	secretAccessKey *dagger.Secret,
+) (*dagger.Directory, error) {
+	artifacts := t.BuildRelease(ctx, version, commit)
+	err := t.upload(
+		ctx,
+		&uploadOpts{
+			artifacts:       artifacts,
+			prefix:          version,
+			endpoint:        endpoint,
+			bucket:          bucket,
+			accessKeyId:     accessKeyId,
+			secretAccessKey: secretAccessKey,
+		},
+	)
+
+	if err != nil {
+		return artifacts, fmt.Errorf("could not upload versioned release artifacts: %w", err)
+	}
+
+	err = t.upload(
+		ctx,
+		&uploadOpts{
+			artifacts:       artifacts,
+			prefix:          "latest",
+			endpoint:        endpoint,
+			bucket:          bucket,
+			accessKeyId:     accessKeyId,
+			secretAccessKey: secretAccessKey,
+		},
+	)
+
+	if err != nil {
+		return artifacts, fmt.Errorf("could not upload latest release artifacts: %w", err)
+	}
+
+	return artifacts, nil
+}
+
+// Nightly builds and uploads nightly artifacts
+func (t *Tapes) Nightly(
+	ctx context.Context,
+
+	// Git commit SHA
+	commit string,
+
+	// Bucket endpoint URL
+	endpoint *dagger.Secret,
+
+	// Bucket name
+	bucket *dagger.Secret,
+
+	// Bucket access key ID
+	accessKeyId *dagger.Secret,
+
+	// Bucket secret access key
+	secretAccessKey *dagger.Secret,
+) (*dagger.Directory, error) {
+	prefix := "nightly"
+	artifacts := t.BuildRelease(ctx, prefix, commit)
+	err := t.upload(
+		ctx,
+		&uploadOpts{
+			artifacts:       artifacts,
+			prefix:          prefix,
+			endpoint:        endpoint,
+			bucket:          bucket,
+			accessKeyId:     accessKeyId,
+			secretAccessKey: secretAccessKey,
+		},
+	)
+	return artifacts, err
+}
+
+// UploadInstallSh uploads the install.sh script to the artifacts bucket
+func (t *Tapes) UploadInstallSh(
+	ctx context.Context,
+
+	// Bucket endpoint URL
+	endpoint *dagger.Secret,
+
+	// Bucket name
+	bucket *dagger.Secret,
+
+	// Bucket access key ID
+	accessKeyId *dagger.Secret,
+
+	// Bucket secret access key
+	secretAccessKey *dagger.Secret,
+) error {
+	installDir := dag.
+		Directory().
+		WithFile("install.sh", t.Source.File("install.sh"))
+
+	return t.upload(
+		ctx,
+		&uploadOpts{
+			artifacts:       installDir,
+			prefix:          "",
+			endpoint:        endpoint,
+			bucket:          bucket,
+			accessKeyId:     accessKeyId,
+			secretAccessKey: secretAccessKey,
+		},
+	)
+}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,8 @@ jobs:
 
       - name: Run tests via Dagger
         uses: dagger/dagger-for-github@v8.2.0
+        env:
+          DAGGER_CLOUD_TOKEN: ${{ secrets.DAGGER_CLOUD_TOKEN }}
         with:
           verb: call
           args: test
@@ -42,6 +44,8 @@ jobs:
 
       - name: Build binaries via Dagger
         uses: dagger/dagger-for-github@v8.2.0
+        env:
+          DAGGER_CLOUD_TOKEN: ${{ secrets.DAGGER_CLOUD_TOKEN }}
         with:
           verb: call
           args: build

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,0 +1,100 @@
+name: Nightly Build & Release
+
+on:
+  schedule:
+    # Daily at 06:00 AM UTC
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+env:
+  DAGGER_VERSION: "0.19.7"
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    outputs:
+      should_build: ${{ steps.check.outputs.should_build }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for new commits
+        id: check
+        run: |
+          LAST_SHA=$(
+            gh run list \
+              --workflow nightly.yaml \
+              --status success \
+              --limit 1 \
+              --json headSha -q '.[0].headSha' || echo ""
+          )
+
+          echo "Last successful build SHA: ${LAST_SHA:-none}"
+          echo "Current SHA: ${{ github.sha }}"
+
+          if [ "$LAST_SHA" = "${{ github.sha }}" ]; then
+            echo "should_build=false" >> $GITHUB_OUTPUT
+            echo "No new commits since last nightly!"
+          else
+            echo "should_build=true" >> $GITHUB_OUTPUT
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build:
+    needs: check
+    if: needs.check.outputs.should_build == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Move nightly tag up to HEAD
+        run: |
+          git tag -f nightly
+          git push -f origin nightly
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build upload nightly release artifacts
+        run: |
+          dagger call \
+            nightly \
+              --commit="${{ github.sha }}" \
+              --endpoint=env://BUCKET_ENDPOINT \
+              --bucket=env://BUCKET_NAME \
+              --access-key-id=env://BUCKET_ACCESS_KEY_ID \
+              --secret-access-key=env://BUCKET_SECRET_ACCESS_KEY
+            export \
+              --path=./build
+        env:
+          BUCKET_ENDPOINT: ${{ secrets.BUCKET_ENDPOINT }}
+          BUCKET_NAME: ${{ secrets.BUCKET_NAME }}
+          BUCKET_ACCESS_KEY_ID: ${{ secrets.BUCKET_ACCESS_KEY_ID }}
+          BUCKET_SECRET_ACCESS_KEY: ${{ secrets.BUCKET_SECRET_ACCESS_KEY }}
+          DAGGER_CLOUD_TOKEN: ${{ secrets.DAGGER_CLOUD_TOKEN }}
+
+      - name: Update nightly GitHub release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: nightly
+          name: "Nightly Build & Release"
+          body: |
+            **Automated nightly build**
+
+            This is an unstable development build.
+
+            Commit: ${{ github.sha }}
+
+            **Download:**
+            - Linux AMD64: `curl -LO https://download.tapes.dev/nightly/linux/amd64/tapes`
+            - Linux ARM64: `curl -LO https://download.tapes.dev/nightly/linux/arm64/tapes`
+            - macOS AMD64: `curl -LO https://download.tapes.dev/nightly/darwin/amd64/tapes`
+            - macOS ARM64: `curl -LO https://download.tapes.dev/nightly/darwin/arm64/tapes`
+          artifacts: "build/*"
+          prerelease: true
+          allowUpdates: true
+          replacesArtifacts: true
+          makeLatest: true
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,47 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+env:
+  DAGGER_VERSION: "0.19.10"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Dagger
+        uses: dagger/dagger-for-github@v7
+        with:
+          version: ${{ env.DAGGER_VERSION }}
+
+      - name: Build upload release artifacts
+        run: |
+          dagger call \
+            release-latest \
+              --version="${{ github.event.release.tag_name }}" \
+              --commit="${{ github.sha }}" \
+              --endpoint=env://BUCKET_ENDPOINT \
+              --bucket=env://BUCKET_NAME \
+              --access-key-id=env://BUCKET_ACCESS_KEY_ID \
+              --secret-access-key=env://BUCKET_SECRET_ACCESS_KEY \
+            export \
+              --path=./build
+        env:
+          BUCKET_ENDPOINT: ${{ secrets.BUCKET_ENDPOINT }}
+          BUCKET_NAME: ${{ secrets.BUCKET_NAME }}
+          BUCKET_ACCESS_KEY_ID: ${{ secrets.BUCKET_ACCESS_KEY_ID }}
+          BUCKET_SECRET_ACCESS_KEY: ${{ secrets.BUCKET_SECRET_ACCESS_KEY }}
+          DAGGER_CLOUD_TOKEN: ${{ secrets.DAGGER_CLOUD_TOKEN }}
+
+      - name: Upload artifacts to release
+        run: gh release upload "${{ github.event.release.tag_name }}" build/*
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# tapes install script for Linux based operating systems.
+# Requirements:
+# * curl
+# * uname
+# * /tmp directory
+
+set -e
+
+VERSION="${TAPES_VERSION:-latest}"
+BASE_URL="https://download.tapes.dev"
+
+# Detect OS
+OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+case "$OS" in
+  linux*) OS="linux" ;;
+  darwin*) OS="darwin" ;;
+  *) echo "Unsupported OS: $OS"; exit 1 ;;
+esac
+
+# Detect architecture
+ARCH="$(uname -m)"
+case "$ARCH" in
+  x86_64) ARCH="amd64" ;;
+  aarch64|arm64) ARCH="arm64" ;;
+  *) echo "Unsupported architecture: $ARCH"; exit 1 ;;
+esac
+
+# Download and install
+DOWNLOAD_URL="$BASE_URL/$VERSION/$OS/$ARCH/tapes"
+INSTALL_DIR="${TAPES_INSTALL_DIR:-/usr/local/bin}"
+
+echo "Downloading tapes $VERSION for $OS/$ARCH ..."
+curl -fsSL "$DOWNLOAD_URL" -o /tmp/tapes
+chmod +x /tmp/tapes
+
+echo "Installing to $INSTALL_DIR ..."
+sudo mv /tmp/tapes "$INSTALL_DIR/tapes"
+
+echo "Installed tapes version:"
+tapes version

--- a/makefile
+++ b/makefile
@@ -20,6 +20,36 @@ build: ## Builds all artifacts
 		export \
 			--path ./build
 
+.PHONY: nightly
+nightly: ## Builds and releases nightly tapes artifacts
+	dagger call \
+		nightly \
+			--commit=${COMMIT} \
+			--endpoint=env://BUCKET_ENDPOINT \
+			--bucket=env://BUCKET_NAME \
+			--access-key-id=env://BUCKET_ACCESS_KEY_ID \
+			--secret-access-key=env://BUCKET_SECRET_ACCESS_KEY
+
+.PHONY: upload-install-script
+upload-install-script: ## Uploads the install script
+	dagger call \
+		upload-install-sh \
+			--endpoint=env://BUCKET_ENDPOINT \
+			--bucket=env://BUCKET_NAME \
+			--access-key-id=env://BUCKET_ACCESS_KEY_ID \
+			--secret-access-key=env://BUCKET_SECRET_ACCESS_KEY
+
+.PHONY: release
+release: ## Builds and releases tapes artifacts
+	dagger call \
+		release-latest \
+			--version=${VERSION} \
+			--commit=${COMMIT} \
+			--endpoint=env://BUCKET_ENDPOINT \
+			--bucket=env://BUCKET_NAME \
+			--access-key-id=env://BUCKET_ACCESS_KEY_ID \
+			--secret-access-key=env://BUCKET_SECRET_ACCESS_KEY
+
 .PHONY: build-containers
 build-containers: build-proxy-container ## Builds all container artifacts
 


### PR DESCRIPTION
* ✨ Build pipeline now has checksum builds
* ✨ Bucket upload operations for artifacts from build pipeline in dagger
* ✨ Dagger `DAGGER_CLOUD_TOKEN` secret for cloud traces
* ✨ Nightly releases and artifact builds
* ✨ On GitHub release creation, release action for building and uploading artifacts
* ✨ `install.sh` script (pretty simple, but this should go a long way for now!)
* ✨ Manual makefile targets for build and upload for manual operations just in case