### PR TITLE
fix: Nightly and release github actions fixup

### DIFF
--- a/.dagger/release.go
+++ b/.dagger/release.go
@@ -181,7 +181,7 @@ func (t *Tapes) UploadInstallSh(
 ) error {
 	installDir := dag.
 		Directory().
-		WithFile("install.sh", t.Source.File("install.sh"))
+		WithFile("install", t.Source.File("install.sh"))
 
 	return t.upload(
 		ctx,

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -57,6 +57,12 @@ jobs:
           git push -f origin nightly
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Dagger
+        uses: dagger/dagger-for-github@v8.2.0
+        with:
+          version: ${{ env.DAGGER_VERSION }}
+
       - name: Build upload nightly release artifacts
         run: |
           dagger call \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Dagger
-        uses: dagger/dagger-for-github@v7
+        uses: dagger/dagger-for-github@v8.2.0
         with:
           version: ${{ env.DAGGER_VERSION }}
 
@@ -42,6 +42,24 @@ jobs:
           DAGGER_CLOUD_TOKEN: ${{ secrets.DAGGER_CLOUD_TOKEN }}
 
       - name: Upload artifacts to release
-        run: gh release upload "${{ github.event.release.tag_name }}" build/*
+        run: |
+          mkdir -p dist
+          for file in $(find build -type f); do
+            rel_path="${file#build/}"
+            os=$(dirname "$rel_path" | cut -d'/' -f1)
+            arch=$(dirname "$rel_path" | cut -d'/' -f2)
+            filename=$(basename "$file")
+
+            if [[ "$filename" == *.sha256 ]]; then
+              base="${filename%.sha256}"
+              new_name="${base}-${os}-${arch}.sha256"
+            else
+              new_name="${filename}-${os}-${arch}"
+            fi
+
+            cp "$file" "dist/$new_name"
+          done
+
+          gh release upload "${{ github.event.release.tag_name }}" dist/*
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Followup to #17 

* 🧹 adds missing `dagger-for-github` action to nightly builds
* 🧹 upgrades release action `dagger-for-github` to v8.2.0
* 🧹 `gh release upload` should now work with squashed artifacts