### PR TITLE
feat: VectorDriver and Embedder for integrated semantic search

### DIFF
--- a/cmd/tapes/search/search.go
+++ b/cmd/tapes/search/search.go
@@ -1,0 +1,200 @@
+// Package searchcmder provides the search command for semantic search over sessions.
+package searchcmder
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+
+	"github.com/papercomputeco/tapes/pkg/embeddings/ollama"
+	embeddingutils "github.com/papercomputeco/tapes/pkg/embeddings/utils"
+	"github.com/papercomputeco/tapes/pkg/logger"
+	"github.com/papercomputeco/tapes/pkg/merkle"
+	"github.com/papercomputeco/tapes/pkg/storage/sqlite"
+	"github.com/papercomputeco/tapes/pkg/vector"
+	vectorutils "github.com/papercomputeco/tapes/pkg/vector/utils"
+)
+
+type searchCommander struct {
+	query string
+	topK  int
+
+	vectorStoreProvider string
+	vectorStoreTarget   string
+
+	embeddingProvider string
+	embeddingTarget   string
+	embeddingModel    string
+
+	sqlitePath string
+	debug      bool
+	logger     *zap.Logger
+}
+
+const searchLongDesc string = `Search session data.
+
+Search over stored sessions, returning the most relevant sessions based on the
+query text. Requires a configured vector store provider, embedding provider,
+and storage provider.
+
+For each result, the full session ancestry (from matched node to root) is displayed.
+
+Example:
+  tapes search "how to configure logging" \
+	--vector-store-provider chroma \
+	--vector-store-target http://localhost:8000 \
+	--embedding-provider ollama \
+	--embedding-target http://localhost:11434 \
+	--embedding-model nomic-embed-text \
+	--sqlite ./tapes.sqlite`
+
+const searchShortDesc string = "Search session data"
+
+func NewSearchCmd() *cobra.Command {
+	cmder := &searchCommander{}
+
+	cmd := &cobra.Command{
+		Use:   "search <query>",
+		Short: searchShortDesc,
+		Long:  searchLongDesc,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmder.query = args[0]
+
+			var err error
+			cmder.debug, err = cmd.Flags().GetBool("debug")
+			if err != nil {
+				return fmt.Errorf("could not get debug flag: %v", err)
+			}
+
+			return cmder.run()
+		},
+	}
+
+	cmd.Flags().IntVarP(&cmder.topK, "top", "k", 5, "Number of results to return")
+	cmd.Flags().StringVar(&cmder.vectorStoreProvider, "vector-store-provider", "", "Vector store provider type (e.g., chroma)")
+	cmd.Flags().StringVar(&cmder.vectorStoreTarget, "vector-store-target", "", "Vector store URL (e.g., http://localhost:8000)")
+	cmd.Flags().StringVar(&cmder.embeddingProvider, "embedding-provider", "ollama", "Embedding provider type (e.g., ollama)")
+	cmd.Flags().StringVar(&cmder.embeddingTarget, "embedding-target", ollama.DefaultBaseURL, "Embedding provider URL")
+	cmd.Flags().StringVar(&cmder.embeddingModel, "embedding-model", ollama.DefaultEmbeddingModel, "Embedding model name (e.g., nomic-embed-text)")
+	cmd.Flags().StringVarP(&cmder.sqlitePath, "sqlite", "s", "", "Path to SQLite database (required)")
+
+	cmd.MarkFlagRequired("vector-store-provider")
+	cmd.MarkFlagRequired("vector-store-target")
+	cmd.MarkFlagRequired("embedding-provider")
+	cmd.MarkFlagRequired("embedding-target")
+	cmd.MarkFlagRequired("embedding-model")
+	cmd.MarkFlagRequired("sqlite")
+
+	return cmd
+}
+
+func (c *searchCommander) run() error {
+	ctx := context.Background()
+	c.logger = logger.NewLogger(c.debug)
+	defer c.logger.Sync()
+
+	embedder, err := embeddingutils.NewEmbedder(&embeddingutils.NewEmbedderOpts{
+		ProviderType: c.embeddingProvider,
+		TargetURL:    c.embeddingTarget,
+		Model:        c.embeddingModel,
+	})
+	if err != nil {
+		return fmt.Errorf("could not create embedder: %w", err)
+	}
+	defer embedder.Close()
+
+	// Embed the query
+	c.logger.Debug("embedding query", zap.String("query", c.query))
+	queryEmbedding, err := embedder.Embed(ctx, c.query)
+	if err != nil {
+		return fmt.Errorf("embedding query: %w", err)
+	}
+
+	// Create vector driver and query
+	vectorDriver, err := vectorutils.NewVectorDriver(&vectorutils.NewVectorDriverOpts{
+		ProviderType: c.vectorStoreProvider,
+		TargetURL:    c.vectorStoreTarget,
+		Logger:       c.logger,
+	})
+	if err != nil {
+		return fmt.Errorf("creating vector driver: %w", err)
+	}
+	defer vectorDriver.Close()
+
+	c.logger.Debug("querying vector store", zap.Int("topK", c.topK))
+	results, err := vectorDriver.Query(ctx, queryEmbedding, c.topK)
+	if err != nil {
+		return fmt.Errorf("querying vector store: %w", err)
+	}
+
+	if len(results) == 0 {
+		fmt.Println("No results found.")
+		return nil
+	}
+
+	// Create storage driver to look up full nodes
+	storageDriver, err := sqlite.NewSQLiteDriver(c.sqlitePath)
+	if err != nil {
+		return fmt.Errorf("opening SQLite database: %w", err)
+	}
+	defer storageDriver.Close()
+
+	// Print results header
+	fmt.Printf("\nSearch Results for: %q\n", c.query)
+	fmt.Println(strings.Repeat("=", 60))
+
+	// For each result, get the full ancestry and print
+	for i, result := range results {
+		ancestry, err := storageDriver.Ancestry(ctx, result.Hash)
+		if err != nil {
+			c.logger.Warn("failed to get ancestry for result",
+				zap.String("hash", result.Hash),
+				zap.Error(err),
+			)
+			continue
+		}
+
+		c.printResult(i+1, result, ancestry)
+	}
+
+	return nil
+}
+
+func (c *searchCommander) printResult(rank int, result vector.QueryResult, ancestry []*merkle.Node) {
+	fmt.Printf("\n[%d] Score: %.4f\n", rank, result.Score)
+	fmt.Printf("    Hash: %s\n", result.Hash)
+
+	if len(ancestry) == 0 {
+		fmt.Println("    (No ancestry found)")
+		return
+	}
+
+	// The first node is the matched node itself
+	matchedNode := ancestry[0]
+	fmt.Printf("    Role: %s\n", matchedNode.Bucket.Role)
+	fmt.Printf("    Preview: %s\n", matchedNode.Bucket.ExtractText())
+
+	fmt.Printf("\n    Session (%d turns):\n", len(ancestry))
+
+	// Print ancestry from root to matched node (reverse order)
+	for i := len(ancestry) - 1; i >= 0; i-- {
+		node := ancestry[i]
+		prefix := "    |-- "
+		if i == 0 {
+			prefix = "    `-> " // Mark the matched node
+		}
+
+		text := node.Bucket.ExtractText()
+		if text == "" {
+			text = "(no text content)"
+		}
+
+		fmt.Printf("%s[%s] %s\n", prefix, node.Bucket.Role, text)
+	}
+
+	fmt.Println()
+}

--- a/cmd/tapes/tapes.go
+++ b/cmd/tapes/tapes.go
@@ -4,6 +4,7 @@ package tapescmder
 import (
 	"github.com/spf13/cobra"
 
+	searchcmder "github.com/papercomputeco/tapes/cmd/tapes/search"
 	servecmder "github.com/papercomputeco/tapes/cmd/tapes/serve"
 	versioncmder "github.com/papercomputeco/tapes/cmd/version"
 )
@@ -13,7 +14,10 @@ const tapesLongDesc string = `Tapes is automatic telemetry for your agents.
 Run services using:
   tapes serve api      Run the API server
   tapes serve proxy    Run the proxy server
-  tapes serve          Run both servers together`
+  tapes serve          Run both servers together
+
+Search sessions:
+  tapes search         Search sessions using semantic similarity`
 
 const tapesShortDesc string = "Tapes - Agent Telemetry"
 
@@ -29,6 +33,7 @@ func NewTapesCmd() *cobra.Command {
 
 	// Add subcommands
 	cmd.AddCommand(servecmder.NewServeCmd())
+	cmd.AddCommand(searchcmder.NewSearchCmd())
 	cmd.AddCommand(versioncmder.NewVersionCmd())
 
 	return cmd

--- a/pkg/embeddings/embedder.go
+++ b/pkg/embeddings/embedder.go
@@ -1,0 +1,13 @@
+// Package embeddings
+package embeddings
+
+import "context"
+
+// Embedder provides text embedding capabilities.
+type Embedder interface {
+	// Embed converts text into a vector embedding.
+	Embed(ctx context.Context, text string) ([]float32, error)
+
+	// Close releases any resources held by the embedder.
+	Close() error
+}

--- a/pkg/embeddings/ollama/ollama.go
+++ b/pkg/embeddings/ollama/ollama.go
@@ -1,0 +1,123 @@
+// Package ollama implements pkg/embedding's Embedder client for Ollama's embedding APIs
+package ollama
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/papercomputeco/tapes/pkg/embeddings"
+	"github.com/papercomputeco/tapes/pkg/vector"
+)
+
+const (
+	// DefaultEmbeddingModel is the default model used for embeddings.
+	DefaultEmbeddingModel = "nomic-embed-text"
+
+	// DefaultBaseURL is the default Ollama API URL.
+	DefaultBaseURL = "http://localhost:11434"
+)
+
+// Embedder wraps Ollama's embedding API.
+type Embedder struct {
+	baseURL    string
+	model      string
+	httpClient *http.Client
+}
+
+// EmbedderConfig holds configuration for the Ollama embedder.
+type EmbedderConfig struct {
+	// BaseURL is the Ollama API URL (e.g., "http://localhost:11434").
+	// Defaults to DefaultBaseURL if empty.
+	BaseURL string
+
+	// Model is the embedding model to use (e.g., "nomic-embed-text", "all-minilm").
+	// Defaults to DefaultEmbeddingModel if empty.
+	Model string
+}
+
+// embedRequest is the request body for Ollama's embedding API.
+type embedRequest struct {
+	Model string `json:"model"`
+	Input string `json:"input"`
+}
+
+// embedResponse is the response from Ollama's embedding API.
+type embedResponse struct {
+	Embeddings [][]float32 `json:"embeddings"`
+}
+
+// NewEmbedder creates a new embedder using Ollama's embedding API.
+func NewEmbedder(cfg EmbedderConfig) (*Embedder, error) {
+	baseURL := cfg.BaseURL
+	if baseURL == "" {
+		baseURL = DefaultBaseURL
+	}
+
+	model := cfg.Model
+	if model == "" {
+		model = DefaultEmbeddingModel
+	}
+
+	return &Embedder{
+		baseURL: baseURL,
+		model:   model,
+		httpClient: &http.Client{
+			Timeout: 120 * time.Second,
+		},
+	}, nil
+}
+
+// Embed converts text into a vector embedding.
+func (e *Embedder) Embed(ctx context.Context, text string) ([]float32, error) {
+	reqBody := embedRequest{
+		Model: e.model,
+		Input: text,
+	}
+
+	jsonBody, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("%w: marshaling request: %v", vector.ErrEmbedding, err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", e.baseURL+"/api/embed", bytes.NewReader(jsonBody))
+	if err != nil {
+		return nil, fmt.Errorf("%w: creating request: %v", vector.ErrEmbedding, err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := e.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("%w: sending request: %v", vector.ErrEmbedding, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("%w: ollama returned status %d: %s", vector.ErrEmbedding, resp.StatusCode, string(body))
+	}
+
+	var embedResp embedResponse
+	if err := json.NewDecoder(resp.Body).Decode(&embedResp); err != nil {
+		return nil, fmt.Errorf("%w: decoding response: %v", vector.ErrEmbedding, err)
+	}
+
+	if len(embedResp.Embeddings) == 0 {
+		return nil, fmt.Errorf("%w: no embeddings returned", vector.ErrEmbedding)
+	}
+
+	return embedResp.Embeddings[0], nil
+}
+
+// Close releases resources held by the embedder.
+func (e *Embedder) Close() error {
+	// HTTP client doesn't require explicit cleanup
+	return nil
+}
+
+// Ensure Embedder implements vector.Embedder
+var _ embeddings.Embedder = (*Embedder)(nil)

--- a/pkg/embeddings/utils/new.go
+++ b/pkg/embeddings/utils/new.go
@@ -1,0 +1,27 @@
+// Package embeddingutils is the embeddings utility package
+package embeddingutils
+
+import (
+	"fmt"
+
+	"github.com/papercomputeco/tapes/pkg/embeddings"
+	"github.com/papercomputeco/tapes/pkg/embeddings/ollama"
+)
+
+type NewEmbedderOpts struct {
+	ProviderType string
+	TargetURL    string
+	Model        string
+}
+
+func NewEmbedder(o *NewEmbedderOpts) (embeddings.Embedder, error) {
+	switch o.ProviderType {
+	case "ollama":
+		return ollama.NewEmbedder(ollama.EmbedderConfig{
+			BaseURL: o.TargetURL,
+			Model:   o.Model,
+		})
+	default:
+		return nil, fmt.Errorf("unsupported embedding provider: %s", o.ProviderType)
+	}
+}

--- a/pkg/merkle/bucket.go
+++ b/pkg/merkle/bucket.go
@@ -1,6 +1,10 @@
 package merkle
 
-import "github.com/papercomputeco/tapes/pkg/llm"
+import (
+	"strings"
+
+	"github.com/papercomputeco/tapes/pkg/llm"
+)
 
 // Bucket represents the hashable content stored in a Merkle DAG node.
 // This is the canonical storage format for LLM conversation turns.
@@ -26,4 +30,22 @@ type Bucket struct {
 
 	// Usage contains token counts and timing (only for responses)
 	Usage *llm.Usage `json:"usage,omitempty"`
+}
+
+// ExtractText returns the concatenated text content from the bucket's content blocks.
+// This is useful for generating embeddings for semantic search.
+// It extracts text from text blocks and tool outputs, joining them with newlines.
+func (b *Bucket) ExtractText() string {
+	var texts []string
+
+	for _, block := range b.Content {
+		switch {
+		case block.Text != "":
+			texts = append(texts, block.Text)
+		case block.ToolOutput != "":
+			texts = append(texts, block.ToolOutput)
+		}
+	}
+
+	return strings.Join(texts, "\n")
 }

--- a/pkg/merkle/node_test.go
+++ b/pkg/merkle/node_test.go
@@ -135,3 +135,68 @@ var _ = Describe("Node", func() {
 		})
 	})
 })
+
+var _ = Describe("Bucket", func() {
+	Describe("ExtractText", func() {
+		It("extracts text from a single text content block", func() {
+			bucket := merkle.Bucket{
+				Content: []llm.ContentBlock{
+					{Type: "text", Text: "Hello, world!"},
+				},
+			}
+
+			Expect(bucket.ExtractText()).To(Equal("Hello, world!"))
+		})
+
+		It("joins multiple text blocks with newlines", func() {
+			bucket := merkle.Bucket{
+				Content: []llm.ContentBlock{
+					{Type: "text", Text: "First line"},
+					{Type: "text", Text: "Second line"},
+				},
+			}
+
+			Expect(bucket.ExtractText()).To(Equal("First line\nSecond line"))
+		})
+
+		It("extracts tool output content", func() {
+			bucket := merkle.Bucket{
+				Content: []llm.ContentBlock{
+					{Type: "tool_result", ToolOutput: "Tool returned: success"},
+				},
+			}
+
+			Expect(bucket.ExtractText()).To(Equal("Tool returned: success"))
+		})
+
+		It("combines text and tool output", func() {
+			bucket := merkle.Bucket{
+				Content: []llm.ContentBlock{
+					{Type: "text", Text: "Running tool..."},
+					{Type: "tool_result", ToolOutput: "Tool output here"},
+				},
+			}
+
+			Expect(bucket.ExtractText()).To(Equal("Running tool...\nTool output here"))
+		})
+
+		It("returns empty string for empty content", func() {
+			bucket := merkle.Bucket{
+				Content: []llm.ContentBlock{},
+			}
+
+			Expect(bucket.ExtractText()).To(Equal(""))
+		})
+
+		It("skips content blocks without text or tool output", func() {
+			bucket := merkle.Bucket{
+				Content: []llm.ContentBlock{
+					{Type: "image", ImageURL: "http://example.com/image.png"},
+					{Type: "text", Text: "Some text"},
+				},
+			}
+
+			Expect(bucket.ExtractText()).To(Equal("Some text"))
+		})
+	})
+})

--- a/pkg/vector/chroma/chroma.go
+++ b/pkg/vector/chroma/chroma.go
@@ -1,0 +1,389 @@
+// Package chroma provides a Chroma vector database driver implementation.
+package chroma
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/papercomputeco/tapes/pkg/vector"
+)
+
+const (
+	// DefaultCollectionName is the default collection name for storing tapes embeddings.
+	DefaultCollectionName = "tapes"
+)
+
+// ChromaDriver implements vector.VectorDriver using Chroma's REST API.
+type ChromaDriver struct {
+	baseURL        string
+	collectionName string
+	collectionID   string
+	httpClient     *http.Client
+	logger         *zap.Logger
+}
+
+// Config holds configuration for the Chroma driver.
+type Config struct {
+	// URL is the Chroma server URL (e.g., "http://localhost:8000").
+	URL string
+
+	// CollectionName is the name of the collection to use.
+	// Defaults to DefaultCollectionName if empty.
+	CollectionName string
+}
+
+// NewChromaDriver creates a new Chroma vector driver.
+func NewChromaDriver(c Config, logger *zap.Logger) (*ChromaDriver, error) {
+	if c.URL == "" {
+		return nil, fmt.Errorf("chroma URL is required")
+	}
+
+	collectionName := c.CollectionName
+	if collectionName == "" {
+		collectionName = DefaultCollectionName
+	}
+
+	d := &ChromaDriver{
+		baseURL:        c.URL,
+		collectionName: collectionName,
+		httpClient: &http.Client{
+			Timeout: 60 * time.Second,
+		},
+		logger: logger,
+	}
+
+	// Get or create the collection
+	collectionID, err := d.getOrCreateCollection(context.Background())
+	if err != nil {
+		return nil, fmt.Errorf("getting or creating collection %q: %w", collectionName, err)
+	}
+	d.collectionID = collectionID
+
+	logger.Info("connected to Chroma",
+		zap.String("url", c.URL),
+		zap.String("collection", collectionName),
+		zap.String("collection_id", collectionID),
+	)
+
+	return d, nil
+}
+
+// getOrCreateCollection gets an existing collection or creates a new one.
+func (d *ChromaDriver) getOrCreateCollection(ctx context.Context) (string, error) {
+	// Try to get existing collection first
+	url := fmt.Sprintf("%s/api/v2/tenants/default_tenant/databases/default_database/collections/%s", d.baseURL, d.collectionName)
+
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return "", fmt.Errorf("creating get request: %w", err)
+	}
+
+	resp, err := d.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("sending get request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusOK {
+		var collection chromaCollection
+		if err := json.NewDecoder(resp.Body).Decode(&collection); err != nil {
+			return "", fmt.Errorf("decoding collection response: %w", err)
+		}
+		return collection.ID, nil
+	}
+
+	// Collection doesn't exist, create it
+	createURL := fmt.Sprintf("%s/api/v2/tenants/default_tenant/databases/default_database/collections", d.baseURL)
+	createBody := map[string]string{"name": d.collectionName}
+	jsonBody, err := json.Marshal(createBody)
+	if err != nil {
+		return "", fmt.Errorf("marshaling create request: %w", err)
+	}
+
+	req, err = http.NewRequestWithContext(ctx, "POST", createURL, bytes.NewReader(jsonBody))
+	if err != nil {
+		return "", fmt.Errorf("creating create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err = d.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("sending create request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("failed to create collection: status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var collection chromaCollection
+	if err := json.NewDecoder(resp.Body).Decode(&collection); err != nil {
+		return "", fmt.Errorf("decoding create response: %w", err)
+	}
+
+	return collection.ID, nil
+}
+
+// Add stores documents with their embeddings.
+func (d *ChromaDriver) Add(ctx context.Context, docs []vector.Document) error {
+	if len(docs) == 0 {
+		return nil
+	}
+
+	ids := make([]string, len(docs))
+	embeddings := make([][]float32, len(docs))
+	metadatas := make([]map[string]any, len(docs))
+
+	for i, doc := range docs {
+		ids[i] = doc.ID
+		embeddings[i] = doc.Embedding
+		metadatas[i] = map[string]any{"hash": doc.Hash}
+	}
+
+	reqBody := chromaAddRequest{
+		IDs:        ids,
+		Embeddings: embeddings,
+		Metadatas:  metadatas,
+	}
+
+	jsonBody, err := json.Marshal(reqBody)
+	if err != nil {
+		return fmt.Errorf("marshaling add request: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/api/v2/tenants/default_tenant/databases/default_database/collections/%s/add", d.baseURL, d.collectionID)
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(jsonBody))
+	if err != nil {
+		return fmt.Errorf("creating add request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := d.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("sending add request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("failed to add documents: status %d: %s", resp.StatusCode, string(body))
+	}
+
+	d.logger.Debug("added documents to chroma",
+		zap.Int("count", len(docs)),
+	)
+
+	return nil
+}
+
+// Query finds the topK most similar documents to the given embedding.
+func (d *ChromaDriver) Query(ctx context.Context, embedding []float32, topK int) ([]vector.QueryResult, error) {
+	if topK <= 0 {
+		topK = 10
+	}
+
+	reqBody := chromaQueryRequest{
+		QueryEmbeddings: [][]float32{embedding},
+		NResults:        topK,
+		Include:         []string{"metadatas", "distances", "embeddings"},
+	}
+
+	jsonBody, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling query request: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/api/v2/tenants/default_tenant/databases/default_database/collections/%s/query", d.baseURL, d.collectionID)
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(jsonBody))
+	if err != nil {
+		return nil, fmt.Errorf("creating query request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := d.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("sending query request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("failed to query: status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var queryResp chromaQueryResponse
+	if err := json.NewDecoder(resp.Body).Decode(&queryResp); err != nil {
+		return nil, fmt.Errorf("decoding query response: %w", err)
+	}
+
+	var results []vector.QueryResult
+
+	// Process first group (we only query with one embedding)
+	if len(queryResp.IDs) == 0 || len(queryResp.IDs[0]) == 0 {
+		return results, nil
+	}
+
+	ids := queryResp.IDs[0]
+	distances := queryResp.Distances[0]
+
+	var metadatas []map[string]any
+	if len(queryResp.Metadatas) > 0 {
+		metadatas = queryResp.Metadatas[0]
+	}
+
+	var embeddings [][]float32
+	if len(queryResp.Embeddings) > 0 {
+		embeddings = queryResp.Embeddings[0]
+	}
+
+	for i, id := range ids {
+		result := vector.QueryResult{
+			Document: vector.Document{
+				ID:   id,
+				Hash: id, // Default to ID
+			},
+		}
+
+		// Extract hash from metadata
+		if i < len(metadatas) && metadatas[i] != nil {
+			if hash, ok := metadatas[i]["hash"].(string); ok {
+				result.Hash = hash
+			}
+		}
+
+		// Add embedding if available
+		if i < len(embeddings) {
+			result.Embedding = embeddings[i]
+		}
+
+		// Convert distance to similarity score
+		// Lower distance = higher similarity
+		if i < len(distances) {
+			result.Score = 1.0 / (1.0 + distances[i])
+		}
+
+		results = append(results, result)
+	}
+
+	d.logger.Debug("queried chroma",
+		zap.Int("results", len(results)),
+	)
+
+	return results, nil
+}
+
+// Get retrieves documents by their IDs.
+func (d *ChromaDriver) Get(ctx context.Context, ids []string) ([]vector.Document, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+
+	reqBody := chromaGetRequest{
+		IDs:     ids,
+		Include: []string{"metadatas", "embeddings"},
+	}
+
+	jsonBody, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling get request: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/api/v2/tenants/default_tenant/databases/default_database/collections/%s/get", d.baseURL, d.collectionID)
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(jsonBody))
+	if err != nil {
+		return nil, fmt.Errorf("creating get request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := d.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("sending get request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("failed to get documents: status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var getResp chromaGetResponse
+	if err := json.NewDecoder(resp.Body).Decode(&getResp); err != nil {
+		return nil, fmt.Errorf("decoding get response: %w", err)
+	}
+
+	docs := make([]vector.Document, len(getResp.IDs))
+	for i, id := range getResp.IDs {
+		docs[i] = vector.Document{
+			ID:   id,
+			Hash: id, // Default to ID
+		}
+
+		// Extract hash from metadata
+		if i < len(getResp.Metadatas) && getResp.Metadatas[i] != nil {
+			if hash, ok := getResp.Metadatas[i]["hash"].(string); ok {
+				docs[i].Hash = hash
+			}
+		}
+
+		// Add embedding if available
+		if i < len(getResp.Embeddings) {
+			docs[i].Embedding = getResp.Embeddings[i]
+		}
+	}
+
+	return docs, nil
+}
+
+// Delete removes documents by their IDs.
+func (d *ChromaDriver) Delete(ctx context.Context, ids []string) error {
+	if len(ids) == 0 {
+		return nil
+	}
+
+	reqBody := chromaDeleteRequest{
+		IDs: ids,
+	}
+
+	jsonBody, err := json.Marshal(reqBody)
+	if err != nil {
+		return fmt.Errorf("marshaling delete request: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/api/v2/tenants/default_tenant/databases/default_database/collections/%s/delete", d.baseURL, d.collectionID)
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(jsonBody))
+	if err != nil {
+		return fmt.Errorf("creating delete request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := d.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("sending delete request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("failed to delete documents: status %d: %s", resp.StatusCode, string(body))
+	}
+
+	d.logger.Debug("deleted documents from chroma",
+		zap.Int("count", len(ids)),
+	)
+
+	return nil
+}
+
+// Close releases resources held by the driver.
+func (d *ChromaDriver) Close() error {
+	// HTTP client doesn't require explicit cleanup
+	return nil
+}

--- a/pkg/vector/chroma/chroma_suite_test.go
+++ b/pkg/vector/chroma/chroma_suite_test.go
@@ -1,0 +1,13 @@
+package chroma_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestChroma(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Chroma Vector Suite")
+}

--- a/pkg/vector/chroma/chroma_test.go
+++ b/pkg/vector/chroma/chroma_test.go
@@ -1,0 +1,39 @@
+package chroma_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/zap"
+
+	"github.com/papercomputeco/tapes/pkg/vector"
+	"github.com/papercomputeco/tapes/pkg/vector/chroma"
+)
+
+var _ = Describe("ChromaDriver", func() {
+	var logger *zap.Logger
+
+	BeforeEach(func() {
+		logger = zap.NewNop()
+	})
+
+	Describe("NewChromaDriver", func() {
+		It("should return an error when URL is empty", func() {
+			_, err := chroma.NewChromaDriver(chroma.Config{URL: ""}, logger)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("chroma URL is required"))
+		})
+
+		It("should use default collection name when not specified", func() {
+			// This test would require a running Chroma instance
+			// Skipping for unit tests - should be covered in integration tests
+			Skip("Requires running Chroma instance")
+		})
+	})
+
+	Describe("Interface compliance", func() {
+		It("should implement vector.VectorDriver interface", func() {
+			// Compile-time check that ChromaDriver implements VectorDriver
+			var _ vector.VectorDriver = (*chroma.ChromaDriver)(nil)
+		})
+	})
+})

--- a/pkg/vector/chroma/types.go
+++ b/pkg/vector/chroma/types.go
@@ -1,0 +1,48 @@
+package chroma
+
+// chromaCollection represents a Chroma collection response.
+type chromaCollection struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// chromaAddRequest is the request body for adding documents.
+type chromaAddRequest struct {
+	IDs        []string         `json:"ids"`
+	Embeddings [][]float32      `json:"embeddings"`
+	Metadatas  []map[string]any `json:"metadatas,omitempty"`
+	Documents  []string         `json:"documents,omitempty"`
+}
+
+// chromaQueryRequest is the request body for querying.
+type chromaQueryRequest struct {
+	QueryEmbeddings [][]float32 `json:"query_embeddings"`
+	NResults        int         `json:"n_results"`
+	Include         []string    `json:"include"`
+}
+
+// chromaQueryResponse is the response from a query.
+type chromaQueryResponse struct {
+	IDs        [][]string         `json:"ids"`
+	Distances  [][]float32        `json:"distances"`
+	Metadatas  [][]map[string]any `json:"metadatas"`
+	Embeddings [][][]float32      `json:"embeddings"`
+}
+
+// chromaGetRequest is the request body for getting documents.
+type chromaGetRequest struct {
+	IDs     []string `json:"ids"`
+	Include []string `json:"include"`
+}
+
+// chromaGetResponse is the response from getting documents.
+type chromaGetResponse struct {
+	IDs        []string         `json:"ids"`
+	Metadatas  []map[string]any `json:"metadatas"`
+	Embeddings [][]float32      `json:"embeddings"`
+}
+
+// chromaDeleteRequest is the request body for deleting documents.
+type chromaDeleteRequest struct {
+	IDs []string `json:"ids"`
+}

--- a/pkg/vector/driver.go
+++ b/pkg/vector/driver.go
@@ -1,0 +1,44 @@
+// Package vector provides interfaces and implementations for vector storage and embedding.
+package vector
+
+import "context"
+
+// Document represents a stored item with its embedding and metadata.
+type Document struct {
+	// ID is a unique identifier for the document (typically the node hash).
+	ID string
+
+	// Hash is the merkle node hash this document corresponds to.
+	Hash string
+
+	// Embedding is the vector representation of the document content.
+	Embedding []float32
+}
+
+// QueryResult represents a search result with similarity score.
+type QueryResult struct {
+	Document
+
+	// Score represents the similarity score (higher = more similar).
+	Score float32
+}
+
+// VectorDriver handles storage and retrieval of vector embeddings.
+type VectorDriver interface {
+	// Add stores documents with their embeddings.
+	// If a document with the same ID already exists, implementers should update
+	// the document.
+	Add(ctx context.Context, docs []Document) error
+
+	// Query finds the topK most similar documents to the given embedding.
+	Query(ctx context.Context, embedding []float32, topK int) ([]QueryResult, error)
+
+	// Get retrieves documents by their IDs.
+	Get(ctx context.Context, ids []string) ([]Document, error)
+
+	// Delete removes documents by their IDs.
+	Delete(ctx context.Context, ids []string) error
+
+	// Close releases any resources held by the driver.
+	Close() error
+}

--- a/pkg/vector/error.go
+++ b/pkg/vector/error.go
@@ -1,0 +1,14 @@
+package vector
+
+import "errors"
+
+var (
+	// ErrNotFound is returned when a document is not found in the vector store.
+	ErrNotFound = errors.New("document not found")
+
+	// ErrEmbedding is returned when embedding generation fails.
+	ErrEmbedding = errors.New("embedding failed")
+
+	// ErrConnection is returned when the vector store connection fails.
+	ErrConnection = errors.New("vector store connection failed")
+)

--- a/pkg/vector/utils/new.go
+++ b/pkg/vector/utils/new.go
@@ -1,0 +1,27 @@
+package vectorutils
+
+import (
+	"fmt"
+
+	"go.uber.org/zap"
+
+	"github.com/papercomputeco/tapes/pkg/vector"
+	"github.com/papercomputeco/tapes/pkg/vector/chroma"
+)
+
+type NewVectorDriverOpts struct {
+	ProviderType string
+	TargetURL    string
+	Logger       *zap.Logger
+}
+
+func NewVectorDriver(o *NewVectorDriverOpts) (vector.VectorDriver, error) {
+	switch o.ProviderType {
+	case "chroma":
+		return chroma.NewChromaDriver(chroma.Config{
+			URL: o.TargetURL,
+		}, o.Logger)
+	default:
+		return nil, fmt.Errorf("unsupported vector store provider: %s", o.ProviderType)
+	}
+}

--- a/proxy/config.go
+++ b/proxy/config.go
@@ -1,5 +1,10 @@
 package proxy
 
+import (
+	"github.com/papercomputeco/tapes/pkg/embeddings"
+	"github.com/papercomputeco/tapes/pkg/vector"
+)
+
 // Config is the proxy server configuration.
 type Config struct {
 	// ListenAddr is the address to listen on (e.g., ":8080")
@@ -11,4 +16,12 @@ type Config struct {
 	// ProviderType specifies the LLM provider type (e.g., "anthropic", "openai", "ollama")
 	// This determines how requests and responses are parsed.
 	ProviderType string
+
+	// VectorDriver is an optional vector store for storing embeddings.
+	// If nil, vector storage is disabled.
+	VectorDriver vector.VectorDriver
+
+	// Embedder is an optional embedder for generating embeddings.
+	// Required if VectorDriver is set.
+	Embedder embeddings.Embedder
 }


### PR DESCRIPTION
* ✨ Introduces vector and embedding capabilities off the proxy for content through conversation turns
  * `serve` and `serve proxy` commands now support `--vector-store-provider` to define the vector storage type (i.e. chroma), `--vector-store-target` for the target URL, `--embedding-provider` to define the embedding provider type (i.e., ollama), `--embedding-target` for the target URL of the embedding service, `--embedding-model` for the embedding model
  * This punts on utilizing the on CPU embedding functions from chroma since the mostly widely available Go SDK requires the Onnx and most people won't have that available locally (nor in our build pipelines). It was easier to just build the interface for API providers (i.e., Ollama)
* ✨ New `search` command for semantic search over sessions

To test, you can run the following:

Ollama locally:

```
ollama serve
```

Chroma:

```sh
docker run \
  -it \
  --rm \
  --name chromadb \
  -p 8000:8000 \
  -e IS_PERSISTENT=TRUE \
  -e ANONYMIZED_TELEMETRY=TRUE \
  chromadb/chroma:1.4.1
```

and the proxy:

```
tapes serve \
  --sqlite "./tapes.db" \
  --vector-store-provider chroma \
  --vector-store-target http://localhost:8000 \
  --embedding-provider ollama \
  --embedding-target http://localhost:11434 \
  --embedding-model nomic-embed-text
```

Then can search with:

```
tapes search "weather in tokyo" \
  --vector-store-provider chroma 
  --vector-store-target http://localhost:8000 \
  --embedding-provider ollama \
  --embedding-target http://localhost:11434 \
  --embedding-model nomic-embed-text \
  --sqlite tapes.db
```

---

Next steps would probably be: 
* throw all three of these in a docker compose to make it easy to bring up the whole stack.
* and think about a `config.toml` with some sort of `tapes config` command to make configuring that easier. The flag options are abit unwiedly right now.