### PR TITLE
fix: Removes container names from docker compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,6 @@
 services:
   ollama:
     image: ollama/ollama
-    container_name: ollama
     ports:
       - "11434:11434"
     volumes:
@@ -9,7 +8,6 @@ services:
 
   chromadb:
     image: chromadb/chroma:1.4.1
-    container_name: chromadb
     ports:
       - "8000:8000"
     environment:
@@ -21,7 +19,6 @@ services:
   tapes:
     build:
       dockerfile: dockerfiles/tapes.Dockerfile
-    container_name: tapes
     depends_on:
       - ollama
       - chromadb


### PR DESCRIPTION
* 🧹 Removes `container_name` from services as this can cause name conflicts in different worktrees. Since this is mostly for development purposes, non-hard coded container names is fine.

```
 ✘ Container chromadb                  Error response from daemon: Conflict. The container name "/...                      0.0s
Error response from daemon: Conflict. The container name "/chromadb" is already in use by container "a4ce9cd6b16ad279966e85a3b9777e6071050a3391f301faec9b3b5eff8e0ecc". You have to remove (or rename) that container to be able to reuse that name.
make: *** [makefile:56: up] Error 1
```