### PR TITLE
feat: Internal "Dag" infra for in memory loading of branches

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -140,8 +140,8 @@ func (s *Server) buildHistory(ctx context.Context, hash string) (*HistoryRespons
 			Content:    node.Bucket.Content,
 			Model:      node.Bucket.Model,
 			Provider:   node.Bucket.Provider,
-			StopReason: node.Bucket.StopReason,
-			Usage:      node.Bucket.Usage,
+			StopReason: node.StopReason,
+			Usage:      node.Usage,
 		}
 	}
 

--- a/api/mcp/mcp.go
+++ b/api/mcp/mcp.go
@@ -9,14 +9,14 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/papercomputeco/tapes/pkg/embeddings"
-	"github.com/papercomputeco/tapes/pkg/storage"
+	"github.com/papercomputeco/tapes/pkg/merkle"
 	"github.com/papercomputeco/tapes/pkg/utils"
 	"github.com/papercomputeco/tapes/pkg/vector"
 )
 
 type Config struct {
-	// Storage driver for looking up full node ancestry
-	StorageDriver storage.Driver
+	// DagLoader loads full node ancestry from search results
+	DagLoader merkle.DagLoader
 
 	// VectorDriver for semantic search
 	VectorDriver vector.VectorDriver
@@ -60,7 +60,7 @@ func NewServer(c Config) (*Server, error) {
 		return s, nil
 	}
 
-	if c.StorageDriver == nil {
+	if c.DagLoader == nil {
 		return nil, fmt.Errorf("storage driver is required")
 	}
 	if c.VectorDriver == nil {

--- a/e2e/hurls/ollama/weather.hurl
+++ b/e2e/hurls/ollama/weather.hurl
@@ -1,0 +1,62 @@
+# Ollama multi-turn conversation simulating arbitrary too calling capabilities.
+
+POST http://localhost:8080/api/chat
+{
+  "model": "ministral-3:latest",
+  "messages": [
+    {
+      "role": "user",
+      "content": "what is the weather in tokyo?"
+    },
+    {
+      "role": "assistant",
+      "content": "",
+      "tool_calls": [
+        {
+          "id": "call_abc123",
+          "type": "function",
+          "function": {
+            "name": "get_weather",
+            "arguments": {
+                "city": "tokyo"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "role": "tool",
+      "tool_call_id": "call_001",
+      "content": "{\"temperature\": 22, \"unit\": \"celsius\", \"condition\": \"partly cloudy\", \"humidity\": 65}"
+    },
+    {
+      "role": "assistant",
+      "content": "The weather in Tokyo is currently 22°C and partly cloudy with 65% humidity."
+    },
+    {
+      "role": "user",
+      "content": "How about in New York? And compare the two for me."
+    }
+  ],
+  "tools": [
+    {
+      "type": "function",
+      "function": {
+        "name": "get_weather",
+        "description": "Get the weather in a given city",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "city": {
+              "type": "string",
+              "description": "The city to get the weather for"
+            }
+          },
+          "required": ["city"]
+        }
+      }
+    }
+  ],
+  "stream": false
+}
+

--- a/pkg/merkle/bucket.go
+++ b/pkg/merkle/bucket.go
@@ -1,13 +1,15 @@
 package merkle
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/papercomputeco/tapes/pkg/llm"
 )
 
 // Bucket represents the hashable content stored in a Merkle DAG node.
-// This is the canonical storage format for LLM conversation turns.
+// This is the tapes canonical content-addressable hashing structure
+// for all LLM conversation turns.
 type Bucket struct {
 	// Type identifies the kind of content (e.g., "message")
 	Type string `json:"type"`
@@ -23,18 +25,12 @@ type Bucket struct {
 
 	// Provider identifies the API provider (e.g., "openai", "anthropic", "ollama")
 	Provider string `json:"provider"`
-
-	// StopReason indicates why generation stopped (only for responses)
-	// Values: "stop", "length", "tool_use", "end_turn", etc.
-	StopReason string `json:"stop_reason,omitempty"`
-
-	// Usage contains token counts and timing (only for responses)
-	Usage *llm.Usage `json:"usage,omitempty"`
 }
 
 // ExtractText returns the concatenated text content from the bucket's content blocks.
 // This is useful for generating embeddings for semantic search.
-// It extracts text from text blocks and tool outputs, joining them with newlines.
+// It extracts text from text blocks, tool outputs, and tool use requests,
+// joining them with newlines.
 func (b *Bucket) ExtractText() string {
 	var texts []string
 
@@ -44,8 +40,35 @@ func (b *Bucket) ExtractText() string {
 			texts = append(texts, block.Text)
 		case block.ToolOutput != "":
 			texts = append(texts, block.ToolOutput)
+		case block.ToolName != "":
+			texts = append(texts, formatToolUse(block))
 		}
 	}
 
 	return strings.Join(texts, "\n")
+}
+
+// formatToolUse creates a human-readable string representation of a tool use block.
+// This enables semantic search to find assistant messages that invoke tools.
+func formatToolUse(block llm.ContentBlock) string {
+	var sb strings.Builder
+	sb.WriteString("Tool call: ")
+	sb.WriteString(block.ToolName)
+
+	if len(block.ToolInput) > 0 {
+		sb.WriteString("(")
+		first := true
+		for key, value := range block.ToolInput {
+			if !first {
+				sb.WriteString(", ")
+			}
+			first = false
+			sb.WriteString(key)
+			sb.WriteString(": ")
+			sb.WriteString(fmt.Sprintf("%v", value))
+		}
+		sb.WriteString(")")
+	}
+
+	return sb.String()
 }

--- a/pkg/merkle/dag.go
+++ b/pkg/merkle/dag.go
@@ -1,0 +1,275 @@
+package merkle
+
+import (
+	"context"
+	"fmt"
+)
+
+// DagLoader defines the interface for loading nodes from storage.
+// This allows the Dag to be loaded from any storage implementation
+// without creating a circular dependency.
+type DagLoader interface {
+	// Get retrieves a node by its hash.
+	Get(ctx context.Context, hash string) (*Node, error)
+
+	// GetByParent retrieves all nodes that have the given parent hash.
+	// Pass nil to get root nodes.
+	GetByParent(ctx context.Context, parentHash *string) ([]*Node, error)
+
+	// Ancestry returns the path from a node back to its root (node first, root last).
+	Ancestry(ctx context.Context, hash string) ([]*Node, error)
+}
+
+// Dag is an in-memory view of a single-rooted Merkle DAG (i.e., a single branch
+// within the graph's plane).
+//
+// It is loaded on-demand from a provided BranchLoader.
+type Dag struct {
+	// Root is the single root node of this directed graph
+	Root *DagNode
+
+	// index provides O(1) lookup by node hash
+	index map[string]*DagNode
+}
+
+// DagNode wraps a "Node" with structural relationships for efficient traversal.
+type DagNode struct {
+	*Node
+
+	// Parent is the parent node in the DAG (nil for root)
+	Parent *DagNode
+
+	// Children are the child nodes (empty for leaves)
+	Children []*DagNode
+}
+
+func NewDag() *Dag {
+	return &Dag{
+		index: make(map[string]*DagNode),
+	}
+}
+
+// LoadDag loads the full branch containing the given hash from storage.
+// This includes all ancestors (up to root) and all descendants (down to leaves).
+//
+// The returned Dag has a single root and contains the complete conversation
+// branch that includes the specified node.
+func LoadDag(ctx context.Context, loader DagLoader, hash string) (*Dag, error) {
+	// First, get the ancestry (path from node to root)
+	ancestry, err := loader.Ancestry(ctx, hash)
+	if err != nil {
+		return nil, fmt.Errorf("getting ancestry for %s: %w", hash, err)
+	}
+
+	if len(ancestry) == 0 {
+		return nil, fmt.Errorf("node %s not found", hash)
+	}
+
+	dag := NewDag()
+
+	// Add nodes from root to the matched node (ancestry is node-first, root-last)
+	for i := len(ancestry) - 1; i >= 0; i-- {
+		if _, err := dag.addNode(ancestry[i]); err != nil {
+			return nil, fmt.Errorf("adding ancestor node: %w", err)
+		}
+	}
+
+	// Now load all descendants of the matched node
+	matchedNode := dag.Get(hash)
+	if matchedNode == nil {
+		return nil, fmt.Errorf("matched node %s not in DAG after adding ancestry", hash)
+	}
+
+	if err := dag.loadDescendants(ctx, loader, matchedNode); err != nil {
+		return nil, fmt.Errorf("loading descendants: %w", err)
+	}
+
+	return dag, nil
+}
+
+// Get returns the DagNode with the given hash, or nil if not found.
+func (d *Dag) Get(hash string) *DagNode {
+	return d.index[hash]
+}
+
+// Size returns the total number of nodes in the DAG.
+func (d *Dag) Size() int {
+	return len(d.index)
+}
+
+// Leaves returns all leaf nodes (nodes with no children).
+func (d *Dag) Leaves() []*DagNode {
+	leaves := []*DagNode{}
+
+	for _, node := range d.index {
+		if len(node.Children) == 0 {
+			leaves = append(leaves, node)
+		}
+	}
+
+	return leaves
+}
+
+// Walk traverses the DAG depth-first from root, calling fn for each node.
+// If the provided function returns false, traversal stops.
+// If the provided function errors, traversal stops and the error is propagated.
+func (d *Dag) Walk(f func(*DagNode) (bool, error)) {
+	if d.Root == nil {
+		return
+	}
+
+	d.walkNode(d.Root, f)
+}
+
+// walkNode recursively, depth first, traverses the given node with the provided
+// function
+func (d *Dag) walkNode(node *DagNode, f func(*DagNode) (bool, error)) (bool, error) {
+	ok, err := f(node)
+	if !ok || err != nil {
+		return false, err
+	}
+
+	for _, child := range node.Children {
+		ok, err := d.walkNode(child, f)
+		if !ok || err != nil {
+			return false, err
+		}
+	}
+
+	return true, nil
+}
+
+// Ancestors returns the path from the given node up to the root.
+// The returned slice is ordered from the node to root (node first, root last).
+// Returns nil if the hash is not found.
+func (d *Dag) Ancestors(hash string) []*DagNode {
+	node := d.Get(hash)
+	if node == nil {
+		return nil
+	}
+
+	ancestors := []*DagNode{}
+	current := node
+	for current != nil {
+		ancestors = append(ancestors, current)
+		current = current.Parent
+	}
+
+	return ancestors
+}
+
+// Descendants returns all descendants of the given node (children, grandchildren, etc.).
+// The returned slice is ordered by depth-first traversal.
+// Returns nil if the hash is not found.
+func (d *Dag) Descendants(hash string) []*DagNode {
+	node := d.Get(hash)
+	if node == nil {
+		return nil
+	}
+
+	descendants := []*DagNode{}
+	d.Walk(func(n *DagNode) (bool, error) {
+		descendants = append(descendants, n.Children...)
+		return true, nil
+	})
+
+	return descendants
+}
+
+// IsBranching returns true if the node with the given hash has multiple children.
+// Returns false if the hash is not found or has 0-1 children.
+func (d *Dag) IsBranching(hash string) bool {
+	node := d.Get(hash)
+	if node == nil {
+		return false
+	}
+	return len(node.Children) > 1
+}
+
+// BranchPoints returns all nodes that have more than one child.
+func (d *Dag) BranchPoints() []*DagNode {
+	branchPoints := []*DagNode{}
+	for _, node := range d.index {
+		if len(node.Children) > 1 {
+			branchPoints = append(branchPoints, node)
+		}
+	}
+	return branchPoints
+}
+
+// addNode is an internal method for adding a node to the DAG.
+// The node's ParentHash must reference an existing node in the DAG,
+// or be nil (making it the root).
+//
+// This method returns an error if:
+//   - The provided node is nil: this is a programmer error.
+//   - The parent hash references a node not in the DAG (this node does not belong
+//     in this branch)
+//   - Adding a root node (where node.Parent is empty) when one already exists
+//
+// This method is a noop if:
+//   - The node already exists in the DAG
+func (d *Dag) addNode(node *Node) (*DagNode, error) {
+	if node == nil {
+		return nil, fmt.Errorf("cannot add nil node to dag")
+	}
+
+	dagNode, ok := d.index[node.Hash]
+	if ok {
+		return dagNode, nil
+	}
+
+	dagNode = &DagNode{
+		Node:     node,
+		Children: make([]*DagNode, 0),
+	}
+
+	if node.ParentHash == nil {
+		// This is a root node
+		if d.Root != nil {
+			return nil, fmt.Errorf("DAG already has a root node")
+		}
+
+		d.Root = dagNode
+	} else {
+		// Find and link to parent
+		parent, ok := d.index[*node.ParentHash]
+		if !ok {
+			return nil, fmt.Errorf("parent node %s not found in dag", *node.ParentHash)
+		}
+
+		dagNode.Parent = parent
+		parent.Children = append(parent.Children, dagNode)
+	}
+
+	d.index[node.Hash] = dagNode
+	return dagNode, nil
+}
+
+// loadDescendants recursively loads all descendants of a node into the DAG.
+func (d *Dag) loadDescendants(ctx context.Context, loader DagLoader, node *DagNode) error {
+	children, err := loader.GetByParent(ctx, &node.Hash)
+	if err != nil {
+		return fmt.Errorf("getting children of %s: %w", node.Hash, err)
+	}
+
+	for _, child := range children {
+		// Skip if already in DAG. This shouldn't happen but if the branch loader
+		// brings in an invalid state, defensively continue.
+		if d.Get(child.Hash) != nil {
+			continue
+		}
+
+		childNode, err := d.addNode(child)
+		if err != nil {
+			return fmt.Errorf("adding child node %s: %w", child.Hash, err)
+		}
+
+		// Recursively load this child's descendants
+		if err := d.loadDescendants(ctx, loader, childNode); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/merkle/dag_test.go
+++ b/pkg/merkle/dag_test.go
@@ -1,0 +1,453 @@
+package merkle_test
+
+import (
+	"context"
+	"errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/papercomputeco/tapes/pkg/llm"
+	"github.com/papercomputeco/tapes/pkg/merkle"
+	"github.com/papercomputeco/tapes/pkg/storage/inmemory"
+)
+
+// dagTestBucket creates a simple bucket for testing with the given role and text
+func dagTestBucket(role, text string) merkle.Bucket {
+	return merkle.Bucket{
+		Type:     "message",
+		Role:     role,
+		Content:  []llm.ContentBlock{{Type: "text", Text: text}},
+		Model:    "test-model",
+		Provider: "test-provider",
+	}
+}
+
+// buildTestDag is a helper that stores nodes with the in-memory driver and loads
+// the DAG from the specified node hash. If loadFromHash is empty, it loads from
+// the last node in the slice.
+func buildTestDag(ctx context.Context, nodes []*merkle.Node, loadFromHash string) (*merkle.Dag, error) {
+	driver := inmemory.NewInMemoryDriver()
+	for _, node := range nodes {
+		if err := driver.Put(ctx, node); err != nil {
+			return nil, err
+		}
+	}
+
+	hash := loadFromHash
+	if hash == "" && len(nodes) > 0 {
+		hash = nodes[len(nodes)-1].Hash
+	}
+
+	return merkle.LoadDag(ctx, driver, hash)
+}
+
+var _ = Describe("Dag", func() {
+	var ctx context.Context
+
+	BeforeEach(func() {
+		ctx = context.Background()
+	})
+
+	Describe("NewDag", func() {
+		It("creates an empty DAG", func() {
+			dag := merkle.NewDag()
+			Expect(dag).NotTo(BeNil())
+			Expect(dag.Root).To(BeNil())
+			Expect(dag.Size()).To(Equal(0))
+		})
+	})
+
+	Describe("Get", func() {
+		It("returns node by hash", func() {
+			root := merkle.NewNode(dagTestBucket("user", "Hello"), nil)
+
+			dag, err := buildTestDag(ctx, []*merkle.Node{root}, "")
+			Expect(err).NotTo(HaveOccurred())
+
+			found := dag.Get(root.Hash)
+			Expect(found).NotTo(BeNil())
+			Expect(found.Hash).To(Equal(root.Hash))
+		})
+
+		It("returns nil for unknown hash", func() {
+			root := merkle.NewNode(dagTestBucket("user", "Hello"), nil)
+
+			dag, err := buildTestDag(ctx, []*merkle.Node{root}, "")
+			Expect(err).NotTo(HaveOccurred())
+
+			found := dag.Get("unknown")
+			Expect(found).To(BeNil())
+		})
+	})
+
+	Describe("Size", func() {
+		It("returns correct count for single node", func() {
+			root := merkle.NewNode(dagTestBucket("user", "Hello"), nil)
+
+			dag, err := buildTestDag(ctx, []*merkle.Node{root}, "")
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(dag.Size()).To(Equal(1))
+		})
+
+		It("returns correct count for chain", func() {
+			root := merkle.NewNode(dagTestBucket("user", "Hello"), nil)
+			child := merkle.NewNode(dagTestBucket("assistant", "Hi"), root)
+
+			dag, err := buildTestDag(ctx, []*merkle.Node{root, child}, "")
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(dag.Size()).To(Equal(2))
+		})
+	})
+
+	Describe("Leaves", func() {
+		It("returns empty for empty DAG", func() {
+			dag := merkle.NewDag()
+			Expect(dag.Leaves()).To(BeEmpty())
+		})
+
+		It("returns root if it's the only node", func() {
+			root := merkle.NewNode(dagTestBucket("user", "Hello"), nil)
+
+			dag, err := buildTestDag(ctx, []*merkle.Node{root}, "")
+			Expect(err).NotTo(HaveOccurred())
+
+			leaves := dag.Leaves()
+			Expect(leaves).To(HaveLen(1))
+			Expect(leaves[0].Hash).To(Equal(root.Hash))
+		})
+
+		It("returns leaf nodes in a chain", func() {
+			root := merkle.NewNode(dagTestBucket("user", "1"), nil)
+			child := merkle.NewNode(dagTestBucket("assistant", "2"), root)
+			grandchild := merkle.NewNode(dagTestBucket("user", "3"), child)
+
+			dag, err := buildTestDag(ctx, []*merkle.Node{root, child, grandchild}, "")
+			Expect(err).NotTo(HaveOccurred())
+
+			leaves := dag.Leaves()
+			Expect(leaves).To(HaveLen(1))
+			Expect(leaves[0].Hash).To(Equal(grandchild.Hash))
+		})
+
+		It("returns multiple leaves for branching DAG", func() {
+			root := merkle.NewNode(dagTestBucket("user", "Hello"), nil)
+			branch1 := merkle.NewNode(dagTestBucket("assistant", "Hi 1"), root)
+			branch2 := merkle.NewNode(dagTestBucket("assistant", "Hi 2"), root)
+
+			// Load from root to get both branches
+			dag, err := buildTestDag(ctx, []*merkle.Node{root, branch1, branch2}, root.Hash)
+			Expect(err).NotTo(HaveOccurred())
+
+			leaves := dag.Leaves()
+			Expect(leaves).To(HaveLen(2))
+		})
+	})
+
+	Describe("Walk", func() {
+		It("visits all nodes depth-first", func() {
+			root := merkle.NewNode(dagTestBucket("user", "1"), nil)
+			child := merkle.NewNode(dagTestBucket("assistant", "2"), root)
+			grandchild := merkle.NewNode(dagTestBucket("user", "3"), child)
+
+			dag, err := buildTestDag(ctx, []*merkle.Node{root, child, grandchild}, "")
+			Expect(err).NotTo(HaveOccurred())
+
+			var visited []string
+			dag.Walk(func(node *merkle.DagNode) (bool, error) {
+				visited = append(visited, node.Bucket.ExtractText())
+				return true, nil
+			})
+
+			Expect(visited).To(Equal([]string{"1", "2", "3"}))
+		})
+
+		It("stops when callback returns false", func() {
+			root := merkle.NewNode(dagTestBucket("user", "1"), nil)
+			child := merkle.NewNode(dagTestBucket("assistant", "2"), root)
+			grandchild := merkle.NewNode(dagTestBucket("user", "3"), child)
+
+			dag, err := buildTestDag(ctx, []*merkle.Node{root, child, grandchild}, "")
+			Expect(err).NotTo(HaveOccurred())
+
+			var visited []string
+			dag.Walk(func(node *merkle.DagNode) (bool, error) {
+				visited = append(visited, node.Bucket.ExtractText())
+
+				// Stop after we hit "2"
+				return node.Bucket.ExtractText() != "2", nil
+			})
+
+			Expect(visited).To(Equal([]string{"1", "2"}))
+		})
+
+		It("stops and propagates error from callback", func() {
+			root := merkle.NewNode(dagTestBucket("user", "1"), nil)
+			child := merkle.NewNode(dagTestBucket("assistant", "2"), root)
+			grandchild := merkle.NewNode(dagTestBucket("user", "3"), child)
+
+			dag, err := buildTestDag(ctx, []*merkle.Node{root, child, grandchild}, "")
+			Expect(err).NotTo(HaveOccurred())
+
+			testErr := errors.New("test error")
+			var visited []string
+			dag.Walk(func(node *merkle.DagNode) (bool, error) {
+				visited = append(visited, node.Bucket.ExtractText())
+				if node.Bucket.ExtractText() == "2" {
+					return false, testErr
+				}
+				return true, nil
+			})
+
+			// Should have stopped at node "2"
+			Expect(visited).To(Equal([]string{"1", "2"}))
+		})
+
+		It("does nothing for empty DAG", func() {
+			dag := merkle.NewDag()
+
+			var visited []string
+			dag.Walk(func(node *merkle.DagNode) (bool, error) {
+				visited = append(visited, node.Bucket.ExtractText())
+				return true, nil
+			})
+
+			Expect(visited).To(BeEmpty())
+		})
+	})
+
+	Describe("Ancestors", func() {
+		It("returns nil for unknown hash", func() {
+			root := merkle.NewNode(dagTestBucket("user", "Hello"), nil)
+
+			dag, err := buildTestDag(ctx, []*merkle.Node{root}, "")
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(dag.Ancestors("unknown")).To(BeNil())
+		})
+
+		It("returns just the node for root", func() {
+			root := merkle.NewNode(dagTestBucket("user", "Hello"), nil)
+
+			dag, err := buildTestDag(ctx, []*merkle.Node{root}, "")
+			Expect(err).NotTo(HaveOccurred())
+
+			ancestors := dag.Ancestors(root.Hash)
+			Expect(ancestors).To(HaveLen(1))
+			Expect(ancestors[0].Hash).To(Equal(root.Hash))
+		})
+
+		It("returns path from node to root", func() {
+			root := merkle.NewNode(dagTestBucket("user", "1"), nil)
+			child := merkle.NewNode(dagTestBucket("assistant", "2"), root)
+			grandchild := merkle.NewNode(dagTestBucket("user", "3"), child)
+
+			dag, err := buildTestDag(ctx, []*merkle.Node{root, child, grandchild}, "")
+			Expect(err).NotTo(HaveOccurred())
+
+			ancestors := dag.Ancestors(grandchild.Hash)
+			Expect(ancestors).To(HaveLen(3))
+			Expect(ancestors[0].Hash).To(Equal(grandchild.Hash))
+			Expect(ancestors[1].Hash).To(Equal(child.Hash))
+			Expect(ancestors[2].Hash).To(Equal(root.Hash))
+		})
+	})
+
+	Describe("Descendants", func() {
+		It("returns nil for unknown hash", func() {
+			root := merkle.NewNode(dagTestBucket("user", "Hello"), nil)
+
+			dag, err := buildTestDag(ctx, []*merkle.Node{root}, "")
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(dag.Descendants("unknown")).To(BeNil())
+		})
+
+		It("returns empty for leaf node", func() {
+			root := merkle.NewNode(dagTestBucket("user", "Hello"), nil)
+
+			dag, err := buildTestDag(ctx, []*merkle.Node{root}, "")
+			Expect(err).NotTo(HaveOccurred())
+
+			descendants := dag.Descendants(root.Hash)
+			Expect(descendants).To(BeEmpty())
+		})
+
+		It("returns all descendants", func() {
+			root := merkle.NewNode(dagTestBucket("user", "1"), nil)
+			child := merkle.NewNode(dagTestBucket("assistant", "2"), root)
+			grandchild := merkle.NewNode(dagTestBucket("user", "3"), child)
+
+			dag, err := buildTestDag(ctx, []*merkle.Node{root, child, grandchild}, root.Hash)
+			Expect(err).NotTo(HaveOccurred())
+
+			descendants := dag.Descendants(root.Hash)
+			Expect(descendants).To(HaveLen(2))
+
+			hashes := make(map[string]bool)
+			for _, d := range descendants {
+				hashes[d.Hash] = true
+			}
+			Expect(hashes).To(HaveKey(child.Hash))
+			Expect(hashes).To(HaveKey(grandchild.Hash))
+		})
+	})
+
+	Describe("IsBranching", func() {
+		It("returns false for unknown hash", func() {
+			root := merkle.NewNode(dagTestBucket("user", "Hello"), nil)
+
+			dag, err := buildTestDag(ctx, []*merkle.Node{root}, "")
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(dag.IsBranching("unknown")).To(BeFalse())
+		})
+
+		It("returns false for leaf", func() {
+			root := merkle.NewNode(dagTestBucket("user", "Hello"), nil)
+
+			dag, err := buildTestDag(ctx, []*merkle.Node{root}, "")
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(dag.IsBranching(root.Hash)).To(BeFalse())
+		})
+
+		It("returns false for single child", func() {
+			root := merkle.NewNode(dagTestBucket("user", "1"), nil)
+			child := merkle.NewNode(dagTestBucket("assistant", "2"), root)
+
+			dag, err := buildTestDag(ctx, []*merkle.Node{root, child}, "")
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(dag.IsBranching(root.Hash)).To(BeFalse())
+		})
+
+		It("returns true for multiple children", func() {
+			// Build a tree: root -> branch1, root -> branch2
+			root := merkle.NewNode(dagTestBucket("user", "Hello"), nil)
+			branch1 := merkle.NewNode(dagTestBucket("assistant", "Hi 1"), root)
+			branch2 := merkle.NewNode(dagTestBucket("assistant", "Hi 2"), root)
+
+			// Load from root to get both branches
+			dag, err := buildTestDag(ctx, []*merkle.Node{root, branch1, branch2}, root.Hash)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(dag.IsBranching(root.Hash)).To(BeTrue())
+		})
+	})
+
+	Describe("BranchPoints", func() {
+		It("returns empty for linear DAG", func() {
+			root := merkle.NewNode(dagTestBucket("user", "1"), nil)
+			child := merkle.NewNode(dagTestBucket("assistant", "2"), root)
+
+			dag, err := buildTestDag(ctx, []*merkle.Node{root, child}, "")
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(dag.BranchPoints()).To(BeEmpty())
+		})
+
+		It("returns nodes with multiple children", func() {
+			root := merkle.NewNode(dagTestBucket("user", "Hello"), nil)
+			branch1 := merkle.NewNode(dagTestBucket("assistant", "Hi 1"), root)
+			branch2 := merkle.NewNode(dagTestBucket("assistant", "Hi 2"), root)
+
+			// Load from root to get both branches
+			dag, err := buildTestDag(ctx, []*merkle.Node{root, branch1, branch2}, root.Hash)
+			Expect(err).NotTo(HaveOccurred())
+
+			branchPoints := dag.BranchPoints()
+			Expect(branchPoints).To(HaveLen(1))
+			Expect(branchPoints[0].Hash).To(Equal(root.Hash))
+		})
+	})
+
+	Describe("LoadDag", func() {
+		var driver *inmemory.InMemoryDriver
+
+		BeforeEach(func() {
+			driver = inmemory.NewInMemoryDriver()
+		})
+
+		It("loads a single node", func() {
+			root := merkle.NewNode(dagTestBucket("user", "Hello"), nil)
+			Expect(driver.Put(ctx, root)).To(Succeed())
+
+			dag, err := merkle.LoadDag(ctx, driver, root.Hash)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dag.Size()).To(Equal(1))
+			Expect(dag.Root.Hash).To(Equal(root.Hash))
+		})
+
+		It("loads a linear chain", func() {
+			root := merkle.NewNode(dagTestBucket("user", "1"), nil)
+			child := merkle.NewNode(dagTestBucket("assistant", "2"), root)
+			grandchild := merkle.NewNode(dagTestBucket("user", "3"), child)
+
+			Expect(driver.Put(ctx, root)).To(Succeed())
+			Expect(driver.Put(ctx, child)).To(Succeed())
+			Expect(driver.Put(ctx, grandchild)).To(Succeed())
+
+			// Load from the middle node
+			dag, err := merkle.LoadDag(ctx, driver, child.Hash)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dag.Size()).To(Equal(3))
+			Expect(dag.Root.Hash).To(Equal(root.Hash))
+
+			// Should have all nodes in correct structure
+			Expect(dag.Get(root.Hash).Children).To(HaveLen(1))
+			Expect(dag.Get(child.Hash).Children).To(HaveLen(1))
+			Expect(dag.Get(grandchild.Hash).Children).To(HaveLen(0))
+		})
+
+		It("loads a branching tree", func() {
+			//       root
+			//      /    \
+			//   child1  child2
+			//     |
+			//  grandchild
+			root := merkle.NewNode(dagTestBucket("user", "root"), nil)
+			child1 := merkle.NewNode(dagTestBucket("assistant", "child1"), root)
+			child2 := merkle.NewNode(dagTestBucket("assistant", "child2"), root)
+			grandchild := merkle.NewNode(dagTestBucket("user", "grandchild"), child1)
+
+			Expect(driver.Put(ctx, root)).To(Succeed())
+			Expect(driver.Put(ctx, child1)).To(Succeed())
+			Expect(driver.Put(ctx, child2)).To(Succeed())
+			Expect(driver.Put(ctx, grandchild)).To(Succeed())
+
+			// Load from root - should get all 4 nodes
+			dag, err := merkle.LoadDag(ctx, driver, root.Hash)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dag.Size()).To(Equal(4))
+			Expect(dag.Root.Children).To(HaveLen(2))
+		})
+
+		It("loads only relevant branch when starting from leaf", func() {
+			//       root
+			//      /    \
+			//   child1  child2
+			root := merkle.NewNode(dagTestBucket("user", "root"), nil)
+			child1 := merkle.NewNode(dagTestBucket("assistant", "child1"), root)
+			child2 := merkle.NewNode(dagTestBucket("assistant", "child2"), root)
+
+			Expect(driver.Put(ctx, root)).To(Succeed())
+			Expect(driver.Put(ctx, child1)).To(Succeed())
+			Expect(driver.Put(ctx, child2)).To(Succeed())
+
+			// Load from child1 - should get root + child1, but NOT child2
+			// (child2 is not an ancestor or descendant of child1)
+			dag, err := merkle.LoadDag(ctx, driver, child1.Hash)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dag.Size()).To(Equal(2))
+			Expect(dag.Get(child2.Hash)).To(BeNil())
+		})
+
+		It("returns error for non-existent hash", func() {
+			_, err := merkle.LoadDag(ctx, driver, "nonexistent")
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})

--- a/pkg/storage/driver.go
+++ b/pkg/storage/driver.go
@@ -22,10 +22,6 @@ type Driver interface {
 	// Has checks if a node exists by its hash.
 	Has(ctx context.Context, hash string) (bool, error)
 
-	// GetByParent retrieves all nodes that have the given parent hash.
-	// Pass nil to get root nodes (nodes with no parent).
-	GetByParent(ctx context.Context, parentHash *string) ([]*merkle.Node, error)
-
 	// List returns all nodes in the store.
 	List(ctx context.Context) ([]*merkle.Node, error)
 
@@ -37,9 +33,6 @@ type Driver interface {
 
 	// Ancestry returns the path from a node back to its root (node first, root last).
 	Ancestry(ctx context.Context, hash string) ([]*merkle.Node, error)
-
-	// Descendants returns the path from root to node (root first, node last).
-	Descendants(ctx context.Context, hash string) ([]*merkle.Node, error)
 
 	// Depth returns the depth of a node (0 for roots).
 	Depth(ctx context.Context, hash string) (int, error)

--- a/pkg/storage/inmemory/inmemory.go
+++ b/pkg/storage/inmemory/inmemory.go
@@ -150,21 +150,6 @@ func (s *InMemoryDriver) Ancestry(ctx context.Context, hash string) ([]*merkle.N
 	return path, nil
 }
 
-// Descendants returns the path from root to node (root first, node last).
-func (s *InMemoryDriver) Descendants(ctx context.Context, hash string) ([]*merkle.Node, error) {
-	path, err := s.Ancestry(ctx, hash)
-	if err != nil {
-		return nil, err
-	}
-
-	// Reverse the path
-	for i, j := 0, len(path)-1; i < j; i, j = i+1, j-1 {
-		path[i], path[j] = path[j], path[i]
-	}
-
-	return path, nil
-}
-
 // Depth returns the depth of a node (0 for roots).
 func (s *InMemoryDriver) Depth(ctx context.Context, hash string) (int, error) {
 	depth := 0

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -100,3 +100,91 @@ func TestBranchingConversations(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, leaves, 2)
 }
+
+// TestMultiTurnConversationAncestry verifies that multi-turn conversations
+// maintain proper ancestry chains when assistant responses are replayed.
+//
+// Since StopReason and Usage are stored on Node (not Bucket), they don't affect
+// the content-addressable hash. This means replaying an assistant message produces
+// the SAME hash as the original response, enabling proper DAG continuation
+// without any special matching logic.
+func TestMultiTurnConversationAncestry(t *testing.T) {
+	p := testProxy(t)
+	ctx := context.Background()
+	providerName := "test-provider"
+
+	// === Turn 1: User asks a question ===
+	req1 := &llm.ChatRequest{
+		Model: "test-model",
+		Messages: []llm.Message{
+			{Role: "system", Content: []llm.ContentBlock{{Type: "text", Text: "You are a helpful assistant."}}},
+			{Role: "user", Content: []llm.ContentBlock{{Type: "text", Text: "What is 2+2?"}}},
+		},
+	}
+	resp1 := &llm.ChatResponse{
+		Model:      "test-model",
+		StopReason: "stop",
+		Usage:      &llm.Usage{PromptTokens: 10, CompletionTokens: 5, TotalTokens: 15},
+		Message: llm.Message{
+			Role:    "assistant",
+			Content: []llm.ContentBlock{{Type: "text", Text: "2+2 equals 4."}},
+		},
+	}
+
+	hash1, err := p.storeConversationTurn(ctx, providerName, req1, resp1)
+	require.NoError(t, err)
+
+	// Verify turn 1 ancestry: system -> user -> assistant (3 nodes deep)
+	ancestry1, err := p.driver.Ancestry(ctx, hash1)
+	require.NoError(t, err)
+	assert.Len(t, ancestry1, 3, "Turn 1 should have 3 nodes in ancestry")
+	assert.Equal(t, "assistant", ancestry1[0].Bucket.Role)
+	assert.Equal(t, "user", ancestry1[1].Bucket.Role)
+	assert.Equal(t, "system", ancestry1[2].Bucket.Role)
+
+	// === Turn 2: User continues the conversation ===
+	// The assistant message from turn 1 is replayed. Since metadata (StopReason/Usage)
+	// doesn't affect the hash, this produces the SAME hash as the original response.
+	req2 := &llm.ChatRequest{
+		Model: "test-model",
+		Messages: []llm.Message{
+			{Role: "system", Content: []llm.ContentBlock{{Type: "text", Text: "You are a helpful assistant."}}},
+			{Role: "user", Content: []llm.ContentBlock{{Type: "text", Text: "What is 2+2?"}}},
+			{Role: "assistant", Content: []llm.ContentBlock{{Type: "text", Text: "2+2 equals 4."}}}, // Replayed
+			{Role: "user", Content: []llm.ContentBlock{{Type: "text", Text: "And what is 3+3?"}}},   // New
+		},
+	}
+	resp2 := &llm.ChatResponse{
+		Model:      "test-model",
+		StopReason: "stop",
+		Usage:      &llm.Usage{PromptTokens: 20, CompletionTokens: 5, TotalTokens: 25},
+		Message: llm.Message{
+			Role:    "assistant",
+			Content: []llm.ContentBlock{{Type: "text", Text: "3+3 equals 6."}},
+		},
+	}
+
+	hash2, err := p.storeConversationTurn(ctx, providerName, req2, resp2)
+	require.NoError(t, err)
+
+	// Verify turn 2 ancestry: system -> user -> assistant -> user -> assistant (5 nodes deep)
+	ancestry2, err := p.driver.Ancestry(ctx, hash2)
+	require.NoError(t, err)
+	assert.Len(t, ancestry2, 5, "Turn 2 should have 5 nodes in ancestry (full conversation history)")
+
+	// Verify the chain from newest to oldest
+	assert.Equal(t, "assistant", ancestry2[0].Bucket.Role)
+	assert.Equal(t, "3+3 equals 6.", ancestry2[0].Bucket.ExtractText())
+	assert.Equal(t, "user", ancestry2[1].Bucket.Role)
+	assert.Equal(t, "And what is 3+3?", ancestry2[1].Bucket.ExtractText())
+	assert.Equal(t, "assistant", ancestry2[2].Bucket.Role)
+	assert.Equal(t, "2+2 equals 4.", ancestry2[2].Bucket.ExtractText())
+	assert.Equal(t, "user", ancestry2[3].Bucket.Role)
+	assert.Equal(t, "What is 2+2?", ancestry2[3].Bucket.ExtractText())
+	assert.Equal(t, "system", ancestry2[4].Bucket.Role)
+
+	// Verify that the assistant from turn 1 is reused (same hash).
+	// This works because metadata (StopReason, Usage) doesn't affect the hash.
+	// The replayed assistant message produces the same hash as the original response.
+	assert.Equal(t, hash1, ancestry2[2].Hash, "Turn 2 should link to the original assistant response from turn 1")
+}


### PR DESCRIPTION
* ✨ Introduces `merkle.Dag` and `merkle.DagLoader` interface
  * `Dag` gives us implicit, in memory, and clear operations for building the whole dag "branch" (root to children, various sub branches, etc.). This also gives us `Dag.Walk` to recursively, depth first, iterate the nodes in the dag.
  * The `DagLoader` interfaces is partially refactored from the `storage.Driver` interface: the idea is that _both_ would be implemetned by the various storage implementors (SQLite, in-memory, etc.) but that we would have abit of a seperation of concerns. This helps prevent a possible circular dependency where `merkle --> storage --> merkle`. Instead, the storage implementors can just satisfy both `storage.Driver` and `merkle.DagLoader`.
  * `LoadDag` gives us the capabilities to load a fast lookup, indexed in-memory `Dag`: this way, when we search for specific nodes using `tapes search` or the MCP server, we get the actual branch. Not just singleton nodes.
* 🧹 Various layers of refactoring to make ^ possible
* 🐛 Fixes a bug where `Usage` and `StopReason` were getting hashed as part of the content-addressible dag: this is problematic since conversation turns from clients won't always include that in their followups (i.e., after getting a response from the LLM provider with usage and other metadata, the client's `messages` array won't likely have that as part of it's conversation turn). 
* 🔧 Adds `e2e/hurls/` where we can put Hurls I've been using for testing against the proxy. Useful for loading up a whole database and vector store to test against. 