### PR TITLE
chore: Removes `testify` dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/onsi/ginkgo/v2 v2.27.4
 	github.com/onsi/gomega v1.39.0
 	github.com/spf13/cobra v1.10.2
-	github.com/stretchr/testify v1.8.4
 	github.com/valyala/fasthttp v1.62.0
 	go.uber.org/zap v1.27.1
 	modernc.org/sqlite v1.44.3
@@ -23,7 +22,6 @@ require (
 	github.com/andybalholm/brotli v1.1.1 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/bmatcuk/doublestar v1.3.4 // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-openapi/inflect v0.19.0 // indirect
@@ -40,7 +38,6 @@ require (
 	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
@@ -58,7 +55,6 @@ require (
 	golang.org/x/sys v0.37.0 // indirect
 	golang.org/x/text v0.30.0 // indirect
 	golang.org/x/tools v0.38.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	modernc.org/libc v1.67.6 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect

--- a/proxy/proxy_suite_test.go
+++ b/proxy/proxy_suite_test.go
@@ -1,0 +1,13 @@
+package proxy
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestProxy(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Proxy Suite")
+}


### PR DESCRIPTION
* 🧹 Looks like there were some hanging testify tests in proxy/. This removes those in favor of Ginkgo, Gomega.
* 🧹 Removes the `testify` dependency we carried in `go.mod`