### PR TITLE
chore: Rename `vector.VectorDriver` to `vector.Driver`

### DIFF
--- a/api/config.go
+++ b/api/config.go
@@ -12,7 +12,7 @@ type Config struct {
 	ListenAddr string
 
 	// VectorDriver for semantic search (optional, enables MCP server)
-	VectorDriver vector.VectorDriver
+	VectorDriver vector.Driver
 
 	// Embedder for converting query text to vectors (optional, enables MCP server)
 	Embedder embeddings.Embedder

--- a/api/mcp/mcp.go
+++ b/api/mcp/mcp.go
@@ -19,7 +19,7 @@ type Config struct {
 	DagLoader merkle.DagLoader
 
 	// VectorDriver for semantic search
-	VectorDriver vector.VectorDriver
+	VectorDriver vector.Driver
 
 	// Embedder for converting query text to vectors for semantic search with
 	// configured VectorDriver

--- a/api/mcp/mcp_suite_test.go
+++ b/api/mcp/mcp_suite_test.go
@@ -1,0 +1,13 @@
+package mcp_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestMcp(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "MCP Suite")
+}

--- a/api/mcp/mcp_test.go
+++ b/api/mcp/mcp_test.go
@@ -1,113 +1,31 @@
-package mcp
+package mcp_test
 
 import (
-	"context"
-	"testing"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"go.uber.org/zap"
 
-	"github.com/papercomputeco/tapes/pkg/llm"
-	"github.com/papercomputeco/tapes/pkg/merkle"
+	"github.com/papercomputeco/tapes/api/mcp"
 	"github.com/papercomputeco/tapes/pkg/storage/inmemory"
-	"github.com/papercomputeco/tapes/pkg/vector"
+	testutils "github.com/papercomputeco/tapes/pkg/utils/test"
 )
-
-func TestMCP(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "MCP Suite")
-}
-
-// mockEmbedder is a test embedder that returns predictable embeddings
-type mockEmbedder struct {
-	embeddings map[string][]float32
-}
-
-func newMockEmbedder() *mockEmbedder {
-	return &mockEmbedder{
-		embeddings: make(map[string][]float32),
-	}
-}
-
-func (m *mockEmbedder) Embed(_ context.Context, text string) ([]float32, error) {
-	if emb, ok := m.embeddings[text]; ok {
-		return emb, nil
-	}
-	// Return a default embedding for any text
-	return []float32{0.1, 0.2, 0.3}, nil
-}
-
-func (m *mockEmbedder) Close() error {
-	return nil
-}
-
-// mockVectorDriver is a test vector driver
-type mockVectorDriver struct {
-	documents []vector.Document
-	results   []vector.QueryResult
-}
-
-func newMockVectorDriver() *mockVectorDriver {
-	return &mockVectorDriver{
-		documents: make([]vector.Document, 0),
-		results:   make([]vector.QueryResult, 0),
-	}
-}
-
-func (m *mockVectorDriver) Add(_ context.Context, docs []vector.Document) error {
-	m.documents = append(m.documents, docs...)
-	return nil
-}
-
-func (m *mockVectorDriver) Query(_ context.Context, _ []float32, topK int) ([]vector.QueryResult, error) {
-	if len(m.results) < topK {
-		return m.results, nil
-	}
-	return m.results[:topK], nil
-}
-
-func (m *mockVectorDriver) Get(_ context.Context, _ []string) ([]vector.Document, error) {
-	return m.documents, nil
-}
-
-func (m *mockVectorDriver) Delete(_ context.Context, _ []string) error {
-	return nil
-}
-
-func (m *mockVectorDriver) Close() error {
-	return nil
-}
-
-// testBucket creates a simple bucket for testing
-func testBucket(role, text string) merkle.Bucket {
-	return merkle.Bucket{
-		Type:     "message",
-		Role:     role,
-		Content:  []llm.ContentBlock{{Type: "text", Text: text}},
-		Model:    "test-model",
-		Provider: "test-provider",
-	}
-}
 
 var _ = Describe("MCP Server", func() {
 	var (
-		server       *Server
+		server       *mcp.Server
 		driver       *inmemory.InMemoryDriver
-		vectorDriver *mockVectorDriver
-		embedder     *mockEmbedder
-		ctx          context.Context
+		vectorDriver *testutils.MockVectorDriver
+		embedder     *testutils.MockEmbedder
 	)
 
 	BeforeEach(func() {
 		logger, _ := zap.NewDevelopment()
 		driver = inmemory.NewInMemoryDriver()
-		vectorDriver = newMockVectorDriver()
-		embedder = newMockEmbedder()
-		ctx = context.Background()
+		vectorDriver = testutils.NewMockVectorDriver()
+		embedder = testutils.NewMockEmbedder()
 
 		var err error
-		server, err = NewServer(Config{
+		server, err = mcp.NewServer(mcp.Config{
 			DagLoader:    driver,
 			VectorDriver: vectorDriver,
 			Embedder:     embedder,
@@ -119,7 +37,7 @@ var _ = Describe("MCP Server", func() {
 	Describe("NewServer", func() {
 		It("returns an error when storage driver is nil", func() {
 			logger, _ := zap.NewDevelopment()
-			_, err := NewServer(Config{
+			_, err := mcp.NewServer(mcp.Config{
 				VectorDriver: vectorDriver,
 				Embedder:     embedder,
 				Logger:       logger,
@@ -130,7 +48,7 @@ var _ = Describe("MCP Server", func() {
 
 		It("returns an error when vector driver is nil", func() {
 			logger, _ := zap.NewDevelopment()
-			_, err := NewServer(Config{
+			_, err := mcp.NewServer(mcp.Config{
 				DagLoader: driver,
 				Embedder:  embedder,
 				Logger:    logger,
@@ -141,7 +59,7 @@ var _ = Describe("MCP Server", func() {
 
 		It("returns an error when embedder is nil", func() {
 			logger, _ := zap.NewDevelopment()
-			_, err := NewServer(Config{
+			_, err := mcp.NewServer(mcp.Config{
 				DagLoader:    driver,
 				VectorDriver: vectorDriver,
 				Logger:       logger,
@@ -151,7 +69,7 @@ var _ = Describe("MCP Server", func() {
 		})
 
 		It("returns an error when logger is nil", func() {
-			_, err := NewServer(Config{
+			_, err := mcp.NewServer(mcp.Config{
 				DagLoader:    driver,
 				VectorDriver: vectorDriver,
 				Embedder:     embedder,
@@ -167,89 +85,6 @@ var _ = Describe("MCP Server", func() {
 		It("returns an HTTP handler", func() {
 			handler := server.Handler()
 			Expect(handler).NotTo(BeNil())
-		})
-	})
-
-	Describe("buildSearchResult", func() {
-		It("builds a result from a single node", func() {
-			node := merkle.NewNode(testBucket("user", "Hello world"), nil)
-			Expect(driver.Put(ctx, node)).To(Succeed())
-
-			result := vector.QueryResult{
-				Document: vector.Document{
-					ID:   node.Hash,
-					Hash: node.Hash,
-				},
-				Score: 0.95,
-			}
-
-			dag, err := merkle.LoadDag(ctx, driver, node.Hash)
-			Expect(err).NotTo(HaveOccurred())
-
-			searchResult := buildSearchResult(result, dag)
-
-			Expect(searchResult.Hash).To(Equal(node.Hash))
-			Expect(searchResult.Score).To(Equal(float32(0.95)))
-			Expect(searchResult.Role).To(Equal("user"))
-			Expect(searchResult.Preview).To(Equal("Hello world"))
-			Expect(searchResult.Turns).To(Equal(1))
-			Expect(searchResult.Branch).To(HaveLen(1))
-		})
-
-		It("builds a result from a conversation chain", func() {
-			node1 := merkle.NewNode(testBucket("user", "Hello"), nil)
-			node2 := merkle.NewNode(testBucket("assistant", "Hi there"), node1)
-			node3 := merkle.NewNode(testBucket("user", "How are you?"), node2)
-
-			Expect(driver.Put(ctx, node1)).To(Succeed())
-			Expect(driver.Put(ctx, node2)).To(Succeed())
-			Expect(driver.Put(ctx, node3)).To(Succeed())
-
-			result := vector.QueryResult{
-				Document: vector.Document{
-					ID:   node3.Hash,
-					Hash: node3.Hash,
-				},
-				Score: 0.85,
-			}
-
-			dag, err := merkle.LoadDag(ctx, driver, node3.Hash)
-			Expect(err).NotTo(HaveOccurred())
-
-			searchResult := buildSearchResult(result, dag)
-
-			Expect(searchResult.Hash).To(Equal(node3.Hash))
-			Expect(searchResult.Turns).To(Equal(3))
-			Expect(searchResult.Role).To(Equal("user"))
-			Expect(searchResult.Preview).To(Equal("How are you?"))
-
-			// Dag branch should be in chronological order (root to leaves)
-			Expect(searchResult.Branch).To(HaveLen(3))
-			Expect(searchResult.Branch[0].Text).To(Equal("Hello"))
-			Expect(searchResult.Branch[1].Text).To(Equal("Hi there"))
-			Expect(searchResult.Branch[2].Text).To(Equal("How are you?"))
-			Expect(searchResult.Branch[2].Matched).To(BeTrue())
-			Expect(searchResult.Branch[0].Matched).To(BeFalse())
-			Expect(searchResult.Branch[1].Matched).To(BeFalse())
-		})
-
-		It("handles empty DAG gracefully", func() {
-			result := vector.QueryResult{
-				Document: vector.Document{
-					ID:   "empty-hash",
-					Hash: "empty-hash",
-				},
-				Score: 0.5,
-			}
-
-			dag := merkle.NewDag()
-			searchResult := buildSearchResult(result, dag)
-
-			Expect(searchResult.Hash).To(Equal("empty-hash"))
-			Expect(searchResult.Turns).To(Equal(0))
-			Expect(searchResult.Role).To(BeEmpty())
-			Expect(searchResult.Preview).To(BeEmpty())
-			Expect(searchResult.Branch).To(BeEmpty())
 		})
 	})
 })

--- a/api/mcp/search_test.go
+++ b/api/mcp/search_test.go
@@ -1,0 +1,111 @@
+package mcp
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/papercomputeco/tapes/pkg/merkle"
+	"github.com/papercomputeco/tapes/pkg/storage/inmemory"
+	testutils "github.com/papercomputeco/tapes/pkg/utils/test"
+	"github.com/papercomputeco/tapes/pkg/vector"
+)
+
+var _ = Describe("Search tool", func() {
+	var (
+		driver *inmemory.InMemoryDriver
+		ctx    context.Context
+	)
+
+	BeforeEach(func() {
+		driver = inmemory.NewInMemoryDriver()
+
+		var err error
+		Expect(err).NotTo(HaveOccurred())
+		ctx = context.TODO()
+	})
+
+	Describe("buildSearchResult", func() {
+		It("builds a result from a single node", func() {
+			node := merkle.NewNode(testutils.NewTestBucket("user", "Hello world"), nil)
+			Expect(driver.Put(ctx, node)).To(Succeed())
+
+			result := vector.QueryResult{
+				Document: vector.Document{
+					ID:   node.Hash,
+					Hash: node.Hash,
+				},
+				Score: 0.95,
+			}
+
+			dag, err := merkle.LoadDag(ctx, driver, node.Hash)
+			Expect(err).NotTo(HaveOccurred())
+
+			searchResult := buildSearchResult(result, dag)
+
+			Expect(searchResult.Hash).To(Equal(node.Hash))
+			Expect(searchResult.Score).To(Equal(float32(0.95)))
+			Expect(searchResult.Role).To(Equal("user"))
+			Expect(searchResult.Preview).To(Equal("Hello world"))
+			Expect(searchResult.Turns).To(Equal(1))
+			Expect(searchResult.Branch).To(HaveLen(1))
+		})
+
+		It("builds a result from a conversation chain", func() {
+			node1 := merkle.NewNode(testutils.NewTestBucket("user", "Hello"), nil)
+			node2 := merkle.NewNode(testutils.NewTestBucket("assistant", "Hi there"), node1)
+			node3 := merkle.NewNode(testutils.NewTestBucket("user", "How are you?"), node2)
+
+			Expect(driver.Put(ctx, node1)).To(Succeed())
+			Expect(driver.Put(ctx, node2)).To(Succeed())
+			Expect(driver.Put(ctx, node3)).To(Succeed())
+
+			result := vector.QueryResult{
+				Document: vector.Document{
+					ID:   node3.Hash,
+					Hash: node3.Hash,
+				},
+				Score: 0.85,
+			}
+
+			dag, err := merkle.LoadDag(ctx, driver, node3.Hash)
+			Expect(err).NotTo(HaveOccurred())
+
+			searchResult := buildSearchResult(result, dag)
+
+			Expect(searchResult.Hash).To(Equal(node3.Hash))
+			Expect(searchResult.Turns).To(Equal(3))
+			Expect(searchResult.Role).To(Equal("user"))
+			Expect(searchResult.Preview).To(Equal("How are you?"))
+
+			// Dag branch should be in chronological order (root to leaves)
+			Expect(searchResult.Branch).To(HaveLen(3))
+			Expect(searchResult.Branch[0].Text).To(Equal("Hello"))
+			Expect(searchResult.Branch[1].Text).To(Equal("Hi there"))
+			Expect(searchResult.Branch[2].Text).To(Equal("How are you?"))
+			Expect(searchResult.Branch[2].Matched).To(BeTrue())
+			Expect(searchResult.Branch[0].Matched).To(BeFalse())
+			Expect(searchResult.Branch[1].Matched).To(BeFalse())
+		})
+
+		It("handles empty DAG gracefully", func() {
+			result := vector.QueryResult{
+				Document: vector.Document{
+					ID:   "empty-hash",
+					Hash: "empty-hash",
+				},
+				Score: 0.5,
+			}
+
+			dag := merkle.NewDag()
+			searchResult := buildSearchResult(result, dag)
+
+			Expect(searchResult.Hash).To(Equal("empty-hash"))
+			Expect(searchResult.Turns).To(Equal(0))
+			Expect(searchResult.Role).To(BeEmpty())
+			Expect(searchResult.Preview).To(BeEmpty())
+			Expect(searchResult.Branch).To(BeEmpty())
+		})
+	})
+})

--- a/pkg/utils/test/bucket.go
+++ b/pkg/utils/test/bucket.go
@@ -1,0 +1,17 @@
+package testutils
+
+import (
+	"github.com/papercomputeco/tapes/pkg/llm"
+	"github.com/papercomputeco/tapes/pkg/merkle"
+)
+
+// NewTestBucket creates a simple bucket for testing
+func NewTestBucket(role, text string) merkle.Bucket {
+	return merkle.Bucket{
+		Type:     "message",
+		Role:     role,
+		Content:  []llm.ContentBlock{{Type: "text", Text: text}},
+		Model:    "test-model",
+		Provider: "test-provider",
+	}
+}

--- a/pkg/utils/test/embedder.go
+++ b/pkg/utils/test/embedder.go
@@ -1,0 +1,26 @@
+package testutils
+
+import "context"
+
+// MockEmbedder is a test embedder that returns predictable embeddings
+type MockEmbedder struct {
+	embeddings map[string][]float32
+}
+
+func NewMockEmbedder() *MockEmbedder {
+	return &MockEmbedder{
+		embeddings: make(map[string][]float32),
+	}
+}
+
+func (m *MockEmbedder) Embed(_ context.Context, text string) ([]float32, error) {
+	if emb, ok := m.embeddings[text]; ok {
+		return emb, nil
+	}
+	// Return a default embedding for any text
+	return []float32{0.1, 0.2, 0.3}, nil
+}
+
+func (m *MockEmbedder) Close() error {
+	return nil
+}

--- a/pkg/utils/test/vector.go
+++ b/pkg/utils/test/vector.go
@@ -1,0 +1,44 @@
+package testutils
+
+import (
+	"context"
+
+	"github.com/papercomputeco/tapes/pkg/vector"
+)
+
+// MockVectorDriver is a test vector driver
+type MockVectorDriver struct {
+	documents []vector.Document
+	results   []vector.QueryResult
+}
+
+func NewMockVectorDriver() *MockVectorDriver {
+	return &MockVectorDriver{
+		documents: make([]vector.Document, 0),
+		results:   make([]vector.QueryResult, 0),
+	}
+}
+
+func (m *MockVectorDriver) Add(_ context.Context, docs []vector.Document) error {
+	m.documents = append(m.documents, docs...)
+	return nil
+}
+
+func (m *MockVectorDriver) Query(_ context.Context, _ []float32, topK int) ([]vector.QueryResult, error) {
+	if len(m.results) < topK {
+		return m.results, nil
+	}
+	return m.results[:topK], nil
+}
+
+func (m *MockVectorDriver) Get(_ context.Context, _ []string) ([]vector.Document, error) {
+	return m.documents, nil
+}
+
+func (m *MockVectorDriver) Delete(_ context.Context, _ []string) error {
+	return nil
+}
+
+func (m *MockVectorDriver) Close() error {
+	return nil
+}

--- a/pkg/vector/chroma/chroma.go
+++ b/pkg/vector/chroma/chroma.go
@@ -20,7 +20,7 @@ const (
 	DefaultCollectionName = "tapes"
 )
 
-// ChromaDriver implements vector.VectorDriver using Chroma's REST API.
+// ChromaDriver implements vector.Driver using Chroma's REST API.
 type ChromaDriver struct {
 	baseURL        string
 	collectionName string

--- a/pkg/vector/chroma/chroma_test.go
+++ b/pkg/vector/chroma/chroma_test.go
@@ -31,9 +31,9 @@ var _ = Describe("ChromaDriver", func() {
 	})
 
 	Describe("Interface compliance", func() {
-		It("should implement vector.VectorDriver interface", func() {
-			// Compile-time check that ChromaDriver implements VectorDriver
-			var _ vector.VectorDriver = (*chroma.ChromaDriver)(nil)
+		It("should implement vector.Driver interface", func() {
+			// Compile-time check that ChromaDriver implements vector.Driver
+			var _ vector.Driver = (*chroma.ChromaDriver)(nil)
 		})
 	})
 })

--- a/pkg/vector/driver.go
+++ b/pkg/vector/driver.go
@@ -23,8 +23,8 @@ type QueryResult struct {
 	Score float32
 }
 
-// VectorDriver handles storage and retrieval of vector embeddings.
-type VectorDriver interface {
+// Driver handles storage and retrieval of vector embeddings.
+type Driver interface {
 	// Add stores documents with their embeddings.
 	// If a document with the same ID already exists, implementers should update
 	// the document.

--- a/pkg/vector/utils/new.go
+++ b/pkg/vector/utils/new.go
@@ -15,7 +15,7 @@ type NewVectorDriverOpts struct {
 	Logger       *zap.Logger
 }
 
-func NewVectorDriver(o *NewVectorDriverOpts) (vector.VectorDriver, error) {
+func NewVectorDriver(o *NewVectorDriverOpts) (vector.Driver, error) {
 	switch o.ProviderType {
 	case "chroma":
 		return chroma.NewChromaDriver(chroma.Config{

--- a/proxy/config.go
+++ b/proxy/config.go
@@ -19,7 +19,7 @@ type Config struct {
 
 	// VectorDriver is an optional vector store for storing embeddings.
 	// If nil, vector storage is disabled.
-	VectorDriver vector.VectorDriver
+	VectorDriver vector.Driver
 
 	// Embedder is an optional embedder for generating embeddings.
 	// Required if VectorDriver is set.

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -433,8 +433,6 @@ func (p *Proxy) storeConversationTurn(ctx context.Context, providerName string, 
 	nodesToEmbed = append(nodesToEmbed, responseNode)
 
 	// Store embeddings if vector driver is configured
-	println(p.config.VectorDriver)
-	println(p.config.Embedder)
 	if p.config.VectorDriver != nil && p.config.Embedder != nil {
 		p.logger.Debug("storing in vector store with embedder")
 		p.storeEmbeddings(ctx, nodesToEmbed)


### PR DESCRIPTION
* 🧹 Renames `vector.VectorDriver` to `vector.Driver`
* 🧹 Also includes some MCP test refactoring, abstracting a few things into a test utils package
* 🧹 Removes a few rouge `println`

Closes: PCC-63