### PR TITLE
feat: Implements `chat`, `checkout`, `init`, and `status` commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Tapes development
+/.tapes/
+
 /.direnv/
 /build/
 .DS_Store

--- a/cmd/tapes/chat/chat.go
+++ b/cmd/tapes/chat/chat.go
@@ -1,0 +1,269 @@
+// Package chatcmder provides the chat command for interactive LLM chat
+// through the tapes proxy.
+package chatcmder
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+
+	"github.com/papercomputeco/tapes/pkg/dotdir"
+	"github.com/papercomputeco/tapes/pkg/logger"
+	"github.com/papercomputeco/tapes/pkg/utils"
+)
+
+type chatCommander struct {
+	proxy string
+	api   string
+	model string
+	debug bool
+
+	logger *zap.Logger
+}
+
+// @jpmcb: TODO - we should adopt other providers with a -p --provider
+// flag and utilize the native pkg/llm/provider/ packages
+// vs. these hard coded Ollama request / responses.
+
+// ollamaRequest is the Ollama-native request format.
+// The chat command acts as a transparent Ollama client, sending requests
+// through the tapes proxy.
+type ollamaRequest struct {
+	Model    string          `json:"model"`
+	Messages []ollamaMessage `json:"messages"`
+	Stream   bool            `json:"stream"`
+}
+
+// ollamaMessage is an Ollama-native message.
+type ollamaMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+// ollamaStreamChunk represents a single streaming response chunk from Ollama.
+type ollamaStreamChunk struct {
+	Model     string        `json:"model"`
+	CreatedAt time.Time     `json:"created_at"`
+	Message   ollamaMessage `json:"message"`
+	Done      bool          `json:"done"`
+}
+
+const chatLongDesc string = `Experimental: Start an interactive chat session through the tapes proxy.
+
+The chat command sends messages to an LLM through the configured tapes proxy,
+which transparently records the conversation in the Merkle DAG.
+Supported providers: Ollama.
+
+If a checkout state exists (from "tapes checkout"), the conversation
+resumes from that point. Re-running "tapes chat" always starts from the
+same checked-out hash - it does not advance the checkout state.
+
+Use "tapes checkout <hash>" to checkout a specific conversation point,
+or "tapes checkout" (no hash provided) to clear the checkout and start fresh.
+
+Examples:
+  tapes chat --model llama3.2
+  tapes chat --model llama3.2 --proxy http://localhost:8080`
+
+const chatShortDesc string = "Experimental: Interactive LLM chat through the tapes proxy"
+
+func NewChatCmd() *cobra.Command {
+	cmder := &chatCommander{}
+
+	cmd := &cobra.Command{
+		Use:   "chat",
+		Short: chatShortDesc,
+		Long:  chatLongDesc,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			var err error
+			cmder.debug, err = cmd.Flags().GetBool("debug")
+			if err != nil {
+				return fmt.Errorf("could not get debug flag: %v", err)
+			}
+
+			return cmder.run()
+		},
+	}
+
+	cmd.PersistentFlags().StringVarP(&cmder.api, "api", "a", "http://localhost:8081", "Tapes API server address")
+
+	cmd.Flags().StringVarP(&cmder.proxy, "proxy", "p", "http://localhost:8080", "Tapes proxy address")
+	cmd.Flags().StringVarP(&cmder.model, "model", "m", "", "Model name (e.g., llama3.2)")
+	cmd.MarkFlagRequired("model")
+
+	return cmd
+}
+
+func (c *chatCommander) run() error {
+	c.logger = logger.NewLogger(c.debug)
+	defer c.logger.Sync()
+
+	// Load checkout state
+	dotdirManager := dotdir.NewManager()
+	checkout, err := dotdirManager.LoadCheckoutState("")
+	if err != nil {
+		return fmt.Errorf("loading checkout state: %w", err)
+	}
+
+	// Build initial message history from checkout
+	var messages []ollamaMessage
+	if checkout != nil {
+		fmt.Printf("Resuming from checkout %s (%d messages)\n",
+			utils.Truncate(checkout.Hash, 16), len(checkout.Messages))
+		for _, msg := range checkout.Messages {
+			messages = append(messages, ollamaMessage{
+				Role:    msg.Role,
+				Content: msg.Content,
+			})
+		}
+		fmt.Println()
+	} else {
+		fmt.Println("Starting new conversation (no checkout)")
+		fmt.Println()
+	}
+
+	fmt.Println("Type your message and press Enter. Type /exit or Ctrl+D to quit.")
+	fmt.Println()
+
+	scanner := bufio.NewScanner(os.Stdin)
+
+	for {
+		fmt.Print("you> ")
+		if !scanner.Scan() {
+			// EOF or error
+			break
+		}
+
+		input := strings.TrimSpace(scanner.Text())
+		if input == "" {
+			continue
+		}
+		if input == "/exit" {
+			break
+		}
+
+		// Append user message
+		messages = append(messages, ollamaMessage{
+			Role:    "user",
+			Content: input,
+		})
+
+		// Send to proxy and stream response
+		assistantContent, err := c.sendAndStream(messages)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			// Remove the failed user message so we can retry
+			messages = messages[:len(messages)-1]
+			continue
+		}
+
+		// Append assistant response to history
+		messages = append(messages, ollamaMessage{
+			Role:    "assistant",
+			Content: assistantContent,
+		})
+
+		fmt.Println()
+		fmt.Println()
+	}
+
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("reading input: %w", err)
+	}
+
+	fmt.Println()
+	return nil
+}
+
+// sendAndStream sends a chat request to the proxy and streams the response to stdout.
+// Returns the full assistant response text.
+func (c *chatCommander) sendAndStream(messages []ollamaMessage) (string, error) {
+	reqBody := ollamaRequest{
+		Model:    c.model,
+		Messages: messages,
+		Stream:   true,
+	}
+
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return "", fmt.Errorf("marshaling request: %w", err)
+	}
+
+	c.logger.Debug("sending chat request",
+		zap.String("proxy", c.proxy),
+		zap.String("model", c.model),
+		zap.Int("message_count", len(messages)),
+	)
+
+	// POST to the proxy's Ollama-compatible chat endpoint
+	url := c.proxy + "/api/chat"
+	httpReq, err := http.NewRequest("POST", url, bytes.NewReader(body))
+	if err != nil {
+		return "", fmt.Errorf("creating request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{
+		// LLM responses can be slow
+		Timeout: 5 * time.Minute,
+	}
+
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		return "", fmt.Errorf("sending request to proxy: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("proxy returned status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	// Stream the response
+	fmt.Print("assistant> ")
+
+	var fullContent strings.Builder
+	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+
+		var chunk ollamaStreamChunk
+		if err := json.Unmarshal(line, &chunk); err != nil {
+			c.logger.Debug("failed to parse stream chunk",
+				zap.Error(err),
+				zap.String("line", string(line)),
+			)
+			continue
+		}
+
+		// Print the content token to stdout
+		if chunk.Message.Content != "" {
+			fmt.Print(chunk.Message.Content)
+			fullContent.WriteString(chunk.Message.Content)
+		}
+
+		if chunk.Done {
+			break
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return fullContent.String(), fmt.Errorf("reading stream: %w", err)
+	}
+
+	return fullContent.String(), nil
+}

--- a/cmd/tapes/chat/chat_suite_test.go
+++ b/cmd/tapes/chat/chat_suite_test.go
@@ -1,0 +1,13 @@
+package chatcmder_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestChat(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Chat Command Suite")
+}

--- a/cmd/tapes/chat/chat_test.go
+++ b/cmd/tapes/chat/chat_test.go
@@ -1,0 +1,225 @@
+package chatcmder_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	chatcmder "github.com/papercomputeco/tapes/cmd/tapes/chat"
+)
+
+var _ = Describe("NewChatCmd", func() {
+	It("creates a command with the correct use string", func() {
+		cmd := chatcmder.NewChatCmd()
+		Expect(cmd.Use).To(Equal("chat"))
+	})
+
+	It("has required --model flag", func() {
+		cmd := chatcmder.NewChatCmd()
+		flag := cmd.Flags().Lookup("model")
+		Expect(flag).NotTo(BeNil())
+		Expect(flag.Shorthand).To(Equal("m"))
+	})
+
+	It("has --proxy flag with default value", func() {
+		cmd := chatcmder.NewChatCmd()
+		flag := cmd.Flags().Lookup("proxy")
+		Expect(flag).NotTo(BeNil())
+		Expect(flag.DefValue).To(Equal("http://localhost:8080"))
+	})
+
+	It("has persistent --api flag with default value", func() {
+		cmd := chatcmder.NewChatCmd()
+		flag := cmd.PersistentFlags().Lookup("api")
+		Expect(flag).NotTo(BeNil())
+		Expect(flag.DefValue).To(Equal("http://localhost:8081"))
+	})
+})
+
+var _ = Describe("Ollama request format", func() {
+	// These tests validate that the Ollama request/response JSON format
+	// used by the chat command is correct.
+
+	Describe("request serialization", func() {
+		type ollamaRequest struct {
+			Model    string `json:"model"`
+			Messages []struct {
+				Role    string `json:"role"`
+				Content string `json:"content"`
+			} `json:"messages"`
+			Stream bool `json:"stream"`
+		}
+
+		It("serializes a basic request correctly", func() {
+			req := ollamaRequest{
+				Model: "llama3.2",
+				Messages: []struct {
+					Role    string `json:"role"`
+					Content string `json:"content"`
+				}{
+					{Role: "user", Content: "Hello!"},
+				},
+				Stream: true,
+			}
+
+			data, err := json.Marshal(req)
+			Expect(err).NotTo(HaveOccurred())
+
+			var parsed map[string]any
+			err = json.Unmarshal(data, &parsed)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(parsed["model"]).To(Equal("llama3.2"))
+			Expect(parsed["stream"]).To(BeTrue())
+
+			messages := parsed["messages"].([]any)
+			Expect(messages).To(HaveLen(1))
+			msg := messages[0].(map[string]any)
+			Expect(msg["role"]).To(Equal("user"))
+			Expect(msg["content"]).To(Equal("Hello!"))
+		})
+
+		It("serializes a multi-turn conversation correctly", func() {
+			req := ollamaRequest{
+				Model: "llama3.2",
+				Messages: []struct {
+					Role    string `json:"role"`
+					Content string `json:"content"`
+				}{
+					{Role: "user", Content: "What is Go?"},
+					{Role: "assistant", Content: "Go is a programming language."},
+					{Role: "user", Content: "Tell me more."},
+				},
+				Stream: true,
+			}
+
+			data, err := json.Marshal(req)
+			Expect(err).NotTo(HaveOccurred())
+
+			var parsed map[string]any
+			err = json.Unmarshal(data, &parsed)
+			Expect(err).NotTo(HaveOccurred())
+
+			messages := parsed["messages"].([]any)
+			Expect(messages).To(HaveLen(3))
+		})
+	})
+
+	Describe("stream chunk parsing", func() {
+		type ollamaStreamChunk struct {
+			Model     string    `json:"model"`
+			CreatedAt time.Time `json:"created_at"`
+			Message   struct {
+				Role    string `json:"role"`
+				Content string `json:"content"`
+			} `json:"message"`
+			Done bool `json:"done"`
+		}
+
+		It("parses a content chunk", func() {
+			raw := `{"model":"llama3.2","created_at":"2024-01-01T00:00:00Z","message":{"role":"assistant","content":"Hello"},"done":false}`
+
+			var chunk ollamaStreamChunk
+			err := json.Unmarshal([]byte(raw), &chunk)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(chunk.Model).To(Equal("llama3.2"))
+			Expect(chunk.Message.Role).To(Equal("assistant"))
+			Expect(chunk.Message.Content).To(Equal("Hello"))
+			Expect(chunk.Done).To(BeFalse())
+		})
+
+		It("parses a final done chunk", func() {
+			raw := `{"model":"llama3.2","created_at":"2024-01-01T00:00:00Z","message":{"role":"assistant","content":""},"done":true}`
+
+			var chunk ollamaStreamChunk
+			err := json.Unmarshal([]byte(raw), &chunk)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(chunk.Done).To(BeTrue())
+			Expect(chunk.Message.Content).To(BeEmpty())
+		})
+
+		It("reconstructs full content from multiple chunks", func() {
+			chunks := []string{
+				`{"model":"llama3.2","message":{"role":"assistant","content":"Hello"},"done":false}`,
+				`{"model":"llama3.2","message":{"role":"assistant","content":" world"},"done":false}`,
+				`{"model":"llama3.2","message":{"role":"assistant","content":"!"},"done":false}`,
+				`{"model":"llama3.2","message":{"role":"assistant","content":""},"done":true}`,
+			}
+
+			var fullContent strings.Builder
+			for _, raw := range chunks {
+				var chunk ollamaStreamChunk
+				err := json.Unmarshal([]byte(raw), &chunk)
+				Expect(err).NotTo(HaveOccurred())
+				fullContent.WriteString(chunk.Message.Content)
+			}
+
+			Expect(fullContent.String()).To(Equal("Hello world!"))
+		})
+	})
+})
+
+var _ = Describe("Streaming proxy interaction", func() {
+	It("handles a streaming response from a mock Ollama server", func() {
+		// Create a mock server that returns streaming Ollama responses
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Expect(r.URL.Path).To(Equal("/api/chat"))
+			Expect(r.Method).To(Equal("POST"))
+
+			w.Header().Set("Content-Type", "application/x-ndjson")
+			w.WriteHeader(http.StatusOK)
+
+			chunks := []string{
+				`{"model":"llama3.2","message":{"role":"assistant","content":"Hi"},"done":false}`,
+				`{"model":"llama3.2","message":{"role":"assistant","content":" there!"},"done":false}`,
+				`{"model":"llama3.2","message":{"role":"assistant","content":""},"done":true}`,
+			}
+
+			for _, chunk := range chunks {
+				fmt.Fprintln(w, chunk)
+			}
+		}))
+		defer server.Close()
+
+		// Verify the request format by sending a request
+		reqBody := map[string]any{
+			"model": "llama3.2",
+			"messages": []map[string]string{
+				{"role": "user", "content": "hello"},
+			},
+			"stream": true,
+		}
+		data, err := json.Marshal(reqBody)
+		Expect(err).NotTo(HaveOccurred())
+
+		resp, err := http.Post(server.URL+"/api/chat", "application/json", strings.NewReader(string(data)))
+		Expect(err).NotTo(HaveOccurred())
+		defer resp.Body.Close()
+
+		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+		// Parse streaming response
+		type streamChunk struct {
+			Message struct {
+				Content string `json:"content"`
+			} `json:"message"`
+			Done bool `json:"done"`
+		}
+
+		var fullContent strings.Builder
+		decoder := json.NewDecoder(resp.Body)
+		for decoder.More() {
+			var chunk streamChunk
+			err := decoder.Decode(&chunk)
+			Expect(err).NotTo(HaveOccurred())
+			fullContent.WriteString(chunk.Message.Content)
+		}
+
+		Expect(fullContent.String()).To(Equal("Hi there!"))
+	})
+})

--- a/cmd/tapes/checkout/checkout.go
+++ b/cmd/tapes/checkout/checkout.go
@@ -1,0 +1,186 @@
+// Package checkoutcmder provides the checkout subcommand for checking out
+// a point in the conversation DAG.
+package checkoutcmder
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+
+	"github.com/papercomputeco/tapes/pkg/dotdir"
+	"github.com/papercomputeco/tapes/pkg/llm"
+	"github.com/papercomputeco/tapes/pkg/logger"
+	"github.com/papercomputeco/tapes/pkg/utils"
+)
+
+type checkoutCommander struct {
+	hash  string
+	api   string
+	debug bool
+
+	logger *zap.Logger
+}
+
+// historyResponse mirrors the API's HistoryResponse type for JSON deserialization.
+type historyResponse struct {
+	Messages []historyMessage `json:"messages"`
+	HeadHash string           `json:"head_hash"`
+	Depth    int              `json:"depth"`
+}
+
+// historyMessage mirrors the API's HistoryMessage type.
+type historyMessage struct {
+	Hash       string             `json:"hash"`
+	ParentHash *string            `json:"parent_hash,omitempty"`
+	Role       string             `json:"role"`
+	Content    []llm.ContentBlock `json:"content"`
+	Model      string             `json:"model,omitempty"`
+	Provider   string             `json:"provider,omitempty"`
+	StopReason string             `json:"stop_reason,omitempty"`
+	Usage      *llm.Usage         `json:"usage,omitempty"`
+}
+
+const checkoutLongDesc string = `Experimental: Checkout a point in the conversation for replay.
+
+Fetches the conversation history up to the given hash from the API server
+and saves the state as the starting point for a "tapes chat" session.
+
+If no hash is provided, clears the checkout state so the next chat session
+starts a new root conversation.
+
+Examples:
+  tapes checkout abc123def456   Checkout a specific conversation point
+  tapes checkout                Clear checkout state, start fresh`
+
+const checkoutShortDesc string = "Checkout a conversation point"
+
+func NewCheckoutCmd() *cobra.Command {
+	cmder := &checkoutCommander{}
+
+	cmd := &cobra.Command{
+		Use:   "checkout [hash]",
+		Short: checkoutShortDesc,
+		Long:  checkoutLongDesc,
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				cmder.hash = args[0]
+			}
+
+			var err error
+			cmder.debug, err = cmd.Flags().GetBool("debug")
+			if err != nil {
+				return fmt.Errorf("could not get debug flag: %v", err)
+			}
+
+			cmder.api, err = cmd.Flags().GetString("api")
+			if err != nil {
+				return fmt.Errorf("could not get api flag: %v", err)
+			}
+
+			return cmder.run()
+		},
+	}
+
+	cmd.PersistentFlags().StringVarP(&cmder.api, "api", "a", "http://localhost:8081", "Tapes API server address")
+
+	return cmd
+}
+
+func (c *checkoutCommander) run() error {
+	dotdirManager := dotdir.NewManager()
+	c.logger = logger.NewLogger(c.debug)
+	defer c.logger.Sync()
+
+	// If no hash provided, clear checkout state
+	if c.hash == "" {
+		if err := dotdirManager.ClearCheckout(""); err != nil {
+			return fmt.Errorf("clearing checkout: %w", err)
+		}
+		fmt.Println("Checkout cleared. Next chat will start a new conversation.")
+		return nil
+	}
+
+	c.logger.Debug("checking out conversation",
+		zap.String("hash", c.hash),
+		zap.String("api", c.api),
+	)
+
+	// Fetch the conversation history from the API
+	history, err := c.fetchHistory(c.hash)
+	if err != nil {
+		return fmt.Errorf("fetching history: %w", err)
+	}
+
+	// Convert API messages to checkout messages
+	messages := make([]dotdir.CheckoutMessage, 0, len(history.Messages))
+	for _, msg := range history.Messages {
+		text := extractText(msg.Content)
+		messages = append(messages, dotdir.CheckoutMessage{
+			Role:    msg.Role,
+			Content: text,
+		})
+	}
+
+	// Save the checkout state
+	state := &dotdir.CheckoutState{
+		Hash:     history.HeadHash,
+		Messages: messages,
+	}
+	if err := dotdirManager.SaveCheckout(state, ""); err != nil {
+		return fmt.Errorf("saving checkout: %w", err)
+	}
+
+	fmt.Printf("Checked out %s (%d messages)\n", utils.Truncate(history.HeadHash, 16), len(messages))
+	for _, msg := range messages {
+		preview := utils.Truncate(msg.Content, 60)
+		fmt.Printf("  [%s] %s\n", msg.Role, preview)
+	}
+
+	return nil
+}
+
+// fetchHistory calls the API to get the conversation history for a given hash.
+func (c *checkoutCommander) fetchHistory(hash string) (*historyResponse, error) {
+	url := fmt.Sprintf("%s/dag/history/%s", c.api, hash)
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("requesting history from API: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("API returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading API response: %w", err)
+	}
+
+	var history historyResponse
+	if err := json.Unmarshal(body, &history); err != nil {
+		return nil, fmt.Errorf("parsing API response: %w", err)
+	}
+
+	return &history, nil
+}
+
+// extractText concatenates all text content blocks from a message.
+func extractText(content []llm.ContentBlock) string {
+	var text string
+	for _, block := range content {
+		if block.Type == "text" {
+			text += block.Text
+		}
+	}
+	return text
+}

--- a/cmd/tapes/checkout/checkout_suite_test.go
+++ b/cmd/tapes/checkout/checkout_suite_test.go
@@ -1,0 +1,13 @@
+package checkoutcmder_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCheckout(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Checkout Command Suite")
+}

--- a/cmd/tapes/checkout/checkout_test.go
+++ b/cmd/tapes/checkout/checkout_test.go
@@ -1,0 +1,173 @@
+package checkoutcmder_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	checkoutcmder "github.com/papercomputeco/tapes/cmd/tapes/checkout"
+	"github.com/papercomputeco/tapes/pkg/llm"
+)
+
+var _ = Describe("NewCheckoutCmd", func() {
+	It("creates a command with the correct use string", func() {
+		cmd := checkoutcmder.NewCheckoutCmd()
+		Expect(cmd.Use).To(Equal("checkout [hash]"))
+	})
+
+	It("accepts zero arguments for clearing checkout", func() {
+		cmd := checkoutcmder.NewCheckoutCmd()
+		err := cmd.Args(cmd, []string{})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("accepts one argument for a hash", func() {
+		cmd := checkoutcmder.NewCheckoutCmd()
+		err := cmd.Args(cmd, []string{"abc123"})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("rejects more than one argument", func() {
+		cmd := checkoutcmder.NewCheckoutCmd()
+		err := cmd.Args(cmd, []string{"abc123", "def456"})
+		Expect(err).To(HaveOccurred())
+	})
+})
+
+var _ = Describe("History API response parsing", func() {
+	// This tests that the checkout command can correctly parse the
+	// API response format used by GET /dag/history/:hash
+
+	type historyMessage struct {
+		Hash       string             `json:"hash"`
+		ParentHash *string            `json:"parent_hash,omitempty"`
+		Role       string             `json:"role"`
+		Content    []llm.ContentBlock `json:"content"`
+		Model      string             `json:"model,omitempty"`
+		Provider   string             `json:"provider,omitempty"`
+		StopReason string             `json:"stop_reason,omitempty"`
+	}
+
+	type historyResponse struct {
+		Messages []historyMessage `json:"messages"`
+		HeadHash string           `json:"head_hash"`
+		Depth    int              `json:"depth"`
+	}
+
+	It("parses a valid API history response", func() {
+		parentHash := "hash1"
+		resp := historyResponse{
+			Messages: []historyMessage{
+				{
+					Hash: "hash1",
+					Role: "user",
+					Content: []llm.ContentBlock{
+						{Type: "text", Text: "Hello!"},
+					},
+					Model:    "llama3.2",
+					Provider: "ollama",
+				},
+				{
+					Hash:       "hash2",
+					ParentHash: &parentHash,
+					Role:       "assistant",
+					Content: []llm.ContentBlock{
+						{Type: "text", Text: "Hi there!"},
+					},
+					Model:      "llama3.2",
+					Provider:   "ollama",
+					StopReason: "stop",
+				},
+			},
+			HeadHash: "hash2",
+			Depth:    2,
+		}
+
+		data, err := json.Marshal(resp)
+		Expect(err).NotTo(HaveOccurred())
+
+		var parsed historyResponse
+		err = json.Unmarshal(data, &parsed)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(parsed.HeadHash).To(Equal("hash2"))
+		Expect(parsed.Depth).To(Equal(2))
+		Expect(parsed.Messages).To(HaveLen(2))
+		Expect(parsed.Messages[0].Role).To(Equal("user"))
+		Expect(parsed.Messages[1].Role).To(Equal("assistant"))
+
+		// Extract text from content blocks
+		var text string
+		for _, block := range parsed.Messages[1].Content {
+			if block.Type == "text" {
+				text += block.Text
+			}
+		}
+		Expect(text).To(Equal("Hi there!"))
+	})
+
+	It("correctly handles a mock API server returning history", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Expect(r.URL.Path).To(Equal("/dag/history/abc123"))
+			Expect(r.Method).To(Equal("GET"))
+
+			resp := historyResponse{
+				Messages: []historyMessage{
+					{
+						Hash: "root",
+						Role: "user",
+						Content: []llm.ContentBlock{
+							{Type: "text", Text: "What is Go?"},
+						},
+					},
+					{
+						Hash: "abc123",
+						Role: "assistant",
+						Content: []llm.ContentBlock{
+							{Type: "text", Text: "Go is a programming language."},
+						},
+					},
+				},
+				HeadHash: "abc123",
+				Depth:    2,
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(resp)
+		}))
+		defer server.Close()
+
+		// Fetch from mock server
+		url := fmt.Sprintf("%s/dag/history/abc123", server.URL)
+		resp, err := http.Get(url)
+		Expect(err).NotTo(HaveOccurred())
+		defer resp.Body.Close()
+
+		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+		var history historyResponse
+		err = json.NewDecoder(resp.Body).Decode(&history)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(history.HeadHash).To(Equal("abc123"))
+		Expect(history.Messages).To(HaveLen(2))
+	})
+
+	It("handles API returning 404 for unknown hash", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			json.NewEncoder(w).Encode(map[string]string{
+				"error": "node not found",
+			})
+		}))
+		defer server.Close()
+
+		resp, err := http.Get(fmt.Sprintf("%s/dag/history/unknown", server.URL))
+		Expect(err).NotTo(HaveOccurred())
+		defer resp.Body.Close()
+
+		Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+	})
+})

--- a/cmd/tapes/init/init.go
+++ b/cmd/tapes/init/init.go
@@ -1,0 +1,64 @@
+// Package initcmder provides the init command for initializing a local .tapes
+// directory in the current working directory.
+package initcmder
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	dirName = ".tapes"
+)
+
+const initLongDesc string = `Initialize a new .tapes/ directory in the current working directory.
+
+Creates a local .tapes/ directory that takes precedence over the default
+~/.tapes/ directory for checkout state, storage, configuration,
+and other tapes operations.
+
+This is useful for maintaining separate tapes state per project or directory.
+
+Examples:
+  tapes init`
+
+const initShortDesc string = "Initialize a local .tapes/ directory"
+
+func NewInitCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "init",
+		Short: initShortDesc,
+		Long:  initLongDesc,
+		Args:  cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return runInit()
+		},
+	}
+
+	return cmd
+}
+
+func runInit() error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("getting current directory: %w", err)
+	}
+
+	dir := filepath.Join(cwd, dirName)
+
+	info, err := os.Stat(dir)
+	if err == nil && info.IsDir() {
+		fmt.Printf("Already initialized: %s\n", dir)
+		return nil
+	}
+
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("creating .tapes directory: %w", err)
+	}
+
+	fmt.Printf("Initialized .tapes directory: %s\n", dir)
+	return nil
+}

--- a/cmd/tapes/init/init_suite_test.go
+++ b/cmd/tapes/init/init_suite_test.go
@@ -1,0 +1,13 @@
+package initcmder_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestInit(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Init Command Suite")
+}

--- a/cmd/tapes/init/init_test.go
+++ b/cmd/tapes/init/init_test.go
@@ -1,0 +1,101 @@
+package initcmder_test
+
+import (
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	initcmder "github.com/papercomputeco/tapes/cmd/tapes/init"
+)
+
+var _ = Describe("NewInitCmd", func() {
+	It("creates a command with the correct use string", func() {
+		cmd := initcmder.NewInitCmd()
+		Expect(cmd.Use).To(Equal("init"))
+	})
+
+	It("accepts zero arguments", func() {
+		cmd := initcmder.NewInitCmd()
+		err := cmd.Args(cmd, []string{})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("rejects any arguments", func() {
+		cmd := initcmder.NewInitCmd()
+		err := cmd.Args(cmd, []string{"extra"})
+		Expect(err).To(HaveOccurred())
+	})
+})
+
+var _ = Describe("Init command execution", func() {
+	var (
+		tmpDir  string
+		origDir string
+	)
+
+	BeforeEach(func() {
+		var err error
+		tmpDir, err = os.MkdirTemp("", "tapes-init-test-*")
+		Expect(err).NotTo(HaveOccurred())
+
+		origDir, err = os.Getwd()
+		Expect(err).NotTo(HaveOccurred())
+
+		err = os.Chdir(tmpDir)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		err := os.Chdir(origDir)
+		Expect(err).NotTo(HaveOccurred())
+		os.RemoveAll(tmpDir)
+	})
+
+	It("creates a .tapes directory in the current directory", func() {
+		cmd := initcmder.NewInitCmd()
+		cmd.SetArgs([]string{})
+		err := cmd.Execute()
+		Expect(err).NotTo(HaveOccurred())
+
+		info, err := os.Stat(filepath.Join(tmpDir, ".tapes"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(info.IsDir()).To(BeTrue())
+	})
+
+	It("succeeds when .tapes directory already exists", func() {
+		err := os.MkdirAll(filepath.Join(tmpDir, ".tapes"), 0o755)
+		Expect(err).NotTo(HaveOccurred())
+
+		cmd := initcmder.NewInitCmd()
+		cmd.SetArgs([]string{})
+		err = cmd.Execute()
+		Expect(err).NotTo(HaveOccurred())
+
+		info, err := os.Stat(filepath.Join(tmpDir, ".tapes"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(info.IsDir()).To(BeTrue())
+	})
+
+	It("does not overwrite existing contents when already initialized", func() {
+		tapesDir := filepath.Join(tmpDir, ".tapes")
+		err := os.MkdirAll(tapesDir, 0o755)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Write a file into the existing .tapes dir
+		testFile := filepath.Join(tapesDir, "checkout.json")
+		err = os.WriteFile(testFile, []byte(`{"hash":"abc"}`), 0o644)
+		Expect(err).NotTo(HaveOccurred())
+
+		cmd := initcmder.NewInitCmd()
+		cmd.SetArgs([]string{})
+		err = cmd.Execute()
+		Expect(err).NotTo(HaveOccurred())
+
+		// Verify the existing file is still there
+		data, err := os.ReadFile(testFile)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(data)).To(Equal(`{"hash":"abc"}`))
+	})
+})

--- a/cmd/tapes/status/status.go
+++ b/cmd/tapes/status/status.go
@@ -1,0 +1,64 @@
+// Package statuscmder provides the status command for displaying the current
+// checkout state of the local .tapes directory.
+package statuscmder
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/papercomputeco/tapes/pkg/dotdir"
+	"github.com/papercomputeco/tapes/pkg/utils"
+)
+
+const statusLongDesc string = `Show the current tapes checkout state.
+
+Reads the local .tapes/ directory (or ~/.tapes/) to display the checked-out
+conversation point, including the hash and message history.
+
+If no checkout state exists, indicates that the next chat session will start
+a new conversation.
+
+Examples:
+  tapes status`
+
+const statusShortDesc string = "Show current checkout state"
+
+func NewStatusCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "status",
+		Short: statusShortDesc,
+		Long:  statusLongDesc,
+		Args:  cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return runStatus()
+		},
+	}
+
+	return cmd
+}
+
+func runStatus() error {
+	manager := dotdir.NewManager()
+
+	state, err := manager.LoadCheckoutState("")
+	if err != nil {
+		return fmt.Errorf("loading checkout state: %w", err)
+	}
+
+	if state == nil {
+		fmt.Println("No checkout state. Next chat will start a new conversation.")
+		return nil
+	}
+
+	fmt.Printf("Checked out: %s\n", state.Hash)
+	fmt.Printf("Messages:    %d\n", len(state.Messages))
+	fmt.Println()
+
+	for i, msg := range state.Messages {
+		preview := utils.Truncate(msg.Content, 72)
+		fmt.Printf("  %d. [%s] %s\n", i+1, msg.Role, preview)
+	}
+
+	return nil
+}

--- a/cmd/tapes/status/status_suite_test.go
+++ b/cmd/tapes/status/status_suite_test.go
@@ -1,0 +1,13 @@
+package statuscmder_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestStatus(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Status Command Suite")
+}

--- a/cmd/tapes/status/status_test.go
+++ b/cmd/tapes/status/status_test.go
@@ -1,0 +1,92 @@
+package statuscmder_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	statuscmder "github.com/papercomputeco/tapes/cmd/tapes/status"
+	"github.com/papercomputeco/tapes/pkg/dotdir"
+)
+
+var _ = Describe("NewStatusCmd", func() {
+	It("creates a command with the correct use string", func() {
+		cmd := statuscmder.NewStatusCmd()
+		Expect(cmd.Use).To(Equal("status"))
+	})
+
+	It("accepts zero arguments", func() {
+		cmd := statuscmder.NewStatusCmd()
+		err := cmd.Args(cmd, []string{})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("rejects any arguments", func() {
+		cmd := statuscmder.NewStatusCmd()
+		err := cmd.Args(cmd, []string{"extra"})
+		Expect(err).To(HaveOccurred())
+	})
+})
+
+var _ = Describe("Status command execution", func() {
+	var (
+		tmpDir  string
+		origDir string
+	)
+
+	BeforeEach(func() {
+		var err error
+		tmpDir, err = os.MkdirTemp("", "tapes-status-test-*")
+		Expect(err).NotTo(HaveOccurred())
+
+		origDir, err = os.Getwd()
+		Expect(err).NotTo(HaveOccurred())
+
+		err = os.Chdir(tmpDir)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		err := os.Chdir(origDir)
+		Expect(err).NotTo(HaveOccurred())
+		os.RemoveAll(tmpDir)
+	})
+
+	It("runs without error when no checkout state exists", func() {
+		// Create a local .tapes dir so the manager picks it up
+		err := os.MkdirAll(filepath.Join(tmpDir, ".tapes"), 0o755)
+		Expect(err).NotTo(HaveOccurred())
+
+		cmd := statuscmder.NewStatusCmd()
+		cmd.SetArgs([]string{})
+		err = cmd.Execute()
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("runs without error when checkout state exists", func() {
+		tapesDir := filepath.Join(tmpDir, ".tapes")
+		err := os.MkdirAll(tapesDir, 0o755)
+		Expect(err).NotTo(HaveOccurred())
+
+		state := &dotdir.CheckoutState{
+			Hash: "abc123def456",
+			Messages: []dotdir.CheckoutMessage{
+				{Role: "user", Content: "Hello!"},
+				{Role: "assistant", Content: "Hi there!"},
+			},
+		}
+
+		data, err := json.MarshalIndent(state, "", "  ")
+		Expect(err).NotTo(HaveOccurred())
+		err = os.WriteFile(filepath.Join(tapesDir, "checkout.json"), data, 0o644)
+		Expect(err).NotTo(HaveOccurred())
+
+		cmd := statuscmder.NewStatusCmd()
+		cmd.SetArgs([]string{})
+		err = cmd.Execute()
+		Expect(err).NotTo(HaveOccurred())
+	})
+})

--- a/cmd/tapes/tapes.go
+++ b/cmd/tapes/tapes.go
@@ -4,8 +4,12 @@ package tapescmder
 import (
 	"github.com/spf13/cobra"
 
+	chatcmder "github.com/papercomputeco/tapes/cmd/tapes/chat"
+	checkoutcmder "github.com/papercomputeco/tapes/cmd/tapes/checkout"
+	initcmder "github.com/papercomputeco/tapes/cmd/tapes/init"
 	searchcmder "github.com/papercomputeco/tapes/cmd/tapes/search"
 	servecmder "github.com/papercomputeco/tapes/cmd/tapes/serve"
+	statuscmder "github.com/papercomputeco/tapes/cmd/tapes/status"
 	versioncmder "github.com/papercomputeco/tapes/cmd/version"
 )
 
@@ -15,6 +19,13 @@ Run services using:
   tapes serve api      Run the API server
   tapes serve proxy    Run the proxy server
   tapes serve          Run both servers together
+
+Experimental: Chat through the proxy:
+  tapes chat               Start an interactive chat session
+  tapes checkout <hash>    Checkout a conversation point
+  tapes checkout           Clear checkout state, start fresh
+  tapes status             Show current checkout state
+  tapes init               Initialize a local .tapes directory
 
 Search sessions:
   tapes search         Search sessions using semantic similarity`
@@ -32,8 +43,12 @@ func NewTapesCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolP("debug", "d", false, "Enable debug logging")
 
 	// Add subcommands
-	cmd.AddCommand(servecmder.NewServeCmd())
+	cmd.AddCommand(chatcmder.NewChatCmd())
+	cmd.AddCommand(checkoutcmder.NewCheckoutCmd())
+	cmd.AddCommand(initcmder.NewInitCmd())
 	cmd.AddCommand(searchcmder.NewSearchCmd())
+	cmd.AddCommand(servecmder.NewServeCmd())
+	cmd.AddCommand(statuscmder.NewStatusCmd())
 	cmd.AddCommand(versioncmder.NewVersionCmd())
 
 	return cmd

--- a/pkg/dotdir/checkout.go
+++ b/pkg/dotdir/checkout.go
@@ -1,0 +1,102 @@
+package dotdir
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const (
+	checkoutFile = "checkout.json"
+)
+
+// CheckoutState represents the persisted checkout state.
+// It contains the hash of the checked-out node and the conversation messages
+// leading up to (and including) that node.
+type CheckoutState struct {
+	// Hash is the hash of the checked-out node.
+	Hash string `json:"hash"`
+
+	// Messages is the conversation history in chronological order
+	// (oldest first), up to and including the checked-out node.
+	Messages []CheckoutMessage `json:"messages"`
+}
+
+// CheckoutMessage represents a single message in the checked-out conversation.
+type CheckoutMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+// LoadCheckoutState loads the checkout state from a target .tapes/checkout.json.
+// Returns nil, nil if no checkout state exists (empty/new conversation state).
+// If overrideDir is non-empty, it is used instead of the default ~/.tapes/ location.
+func (m *Manager) LoadCheckoutState(overrideDir string) (*CheckoutState, error) {
+	dir, err := m.Target(overrideDir)
+	if err != nil {
+		return nil, err
+	}
+
+	path := filepath.Join(dir, checkoutFile)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("reading checkout state: %w", err)
+	}
+
+	state := &CheckoutState{}
+	if err := json.Unmarshal(data, &state); err != nil {
+		return nil, fmt.Errorf("parsing checkout state: %w", err)
+	}
+
+	return state, nil
+}
+
+// SaveCheckout persists the checkout state to a target .tapes/checkout.json.
+func (m *Manager) SaveCheckout(state *CheckoutState, overrideDir string) error {
+	if state == nil {
+		return fmt.Errorf("cannot save nil checkout state")
+	}
+
+	dir, err := m.Target(overrideDir)
+	if err != nil {
+		return err
+	}
+
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling checkout state: %w", err)
+	}
+
+	path := filepath.Join(dir, checkoutFile)
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("writing checkout state: %w", err)
+	}
+
+	return nil
+}
+
+// ClearCheckout removes the checkout state file.
+// This resets the state so the next chat session starts a new root conversation.
+// If overrideDir is non-empty, it is used instead of the default ~/.tapes/ location.
+// Returns nil if the file doesn't exist (already cleared).
+func (m *Manager) ClearCheckout(overrideDir string) error {
+	dir, err := m.Target(overrideDir)
+	if err != nil {
+		return err
+	}
+
+	path := filepath.Join(dir, checkoutFile)
+	if err := os.Remove(path); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("removing checkout state: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/dotdir/checkout_test.go
+++ b/pkg/dotdir/checkout_test.go
@@ -1,0 +1,157 @@
+package dotdir_test
+
+import (
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/papercomputeco/tapes/pkg/dotdir"
+)
+
+var _ = Describe("dotdir.Manager checkout", func() {
+	var tmpDir string
+	var m *dotdir.Manager
+
+	BeforeEach(func() {
+		var err error
+		tmpDir, err = os.MkdirTemp("", "dotdir-test-*")
+		Expect(err).NotTo(HaveOccurred())
+		m = dotdir.NewManager()
+	})
+
+	AfterEach(func() {
+		os.RemoveAll(tmpDir)
+	})
+
+	Describe("LoadCheckout", func() {
+		It("returns nil when no checkout file exists", func() {
+			state, err := m.LoadCheckoutState(tmpDir)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(state).To(BeNil())
+		})
+
+		It("loads a valid checkout state", func() {
+			// Write a checkout file manually
+			data := `{"hash":"abc123","messages":[{"role":"user","content":"hello"},{"role":"assistant","content":"hi there"}]}`
+			err := os.WriteFile(filepath.Join(tmpDir, "checkout.json"), []byte(data), 0o644)
+			Expect(err).NotTo(HaveOccurred())
+
+			state, err := m.LoadCheckoutState(tmpDir)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(state).NotTo(BeNil())
+			Expect(state.Hash).To(Equal("abc123"))
+			Expect(state.Messages).To(HaveLen(2))
+			Expect(state.Messages[0].Role).To(Equal("user"))
+			Expect(state.Messages[0].Content).To(Equal("hello"))
+			Expect(state.Messages[1].Role).To(Equal("assistant"))
+			Expect(state.Messages[1].Content).To(Equal("hi there"))
+		})
+
+		It("returns error for invalid JSON", func() {
+			err := os.WriteFile(filepath.Join(tmpDir, "checkout.json"), []byte("not json"), 0o644)
+			Expect(err).NotTo(HaveOccurred())
+
+			state, err := m.LoadCheckoutState(tmpDir)
+			Expect(err).To(HaveOccurred())
+			Expect(state).To(BeNil())
+		})
+	})
+
+	Describe("SaveCheckout", func() {
+		It("persists checkout state to disk", func() {
+			state := &dotdir.CheckoutState{
+				Hash: "def456",
+				Messages: []dotdir.CheckoutMessage{
+					{Role: "user", Content: "what is Go?"},
+					{Role: "assistant", Content: "Go is a programming language."},
+				},
+			}
+
+			err := m.SaveCheckout(state, tmpDir)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify the file exists
+			_, err = os.Stat(filepath.Join(tmpDir, "checkout.json"))
+			Expect(err).NotTo(HaveOccurred())
+
+			// Load it back and verify
+			loaded, err := m.LoadCheckoutState(tmpDir)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(loaded.Hash).To(Equal("def456"))
+			Expect(loaded.Messages).To(HaveLen(2))
+		})
+
+		It("returns error for nil state", func() {
+			err := m.SaveCheckout(nil, tmpDir)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("overwrites existing checkout state", func() {
+			first := &dotdir.CheckoutState{
+				Hash:     "first",
+				Messages: []dotdir.CheckoutMessage{{Role: "user", Content: "first message"}},
+			}
+			second := &dotdir.CheckoutState{
+				Hash:     "second",
+				Messages: []dotdir.CheckoutMessage{{Role: "user", Content: "second message"}},
+			}
+
+			err := m.SaveCheckout(first, tmpDir)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = m.SaveCheckout(second, tmpDir)
+			Expect(err).NotTo(HaveOccurred())
+
+			loaded, err := m.LoadCheckoutState(tmpDir)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(loaded.Hash).To(Equal("second"))
+		})
+	})
+
+	Describe("ClearCheckout", func() {
+		It("removes the checkout file", func() {
+			// First save a checkout
+			state := &dotdir.CheckoutState{Hash: "to-clear", Messages: []dotdir.CheckoutMessage{}}
+			err := m.SaveCheckout(state, tmpDir)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Clear it
+			err = m.ClearCheckout(tmpDir)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify it's gone
+			loaded, err := m.LoadCheckoutState(tmpDir)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(loaded).To(BeNil())
+		})
+
+		It("succeeds when no checkout file exists", func() {
+			err := m.ClearCheckout(tmpDir)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Describe("round-trip", func() {
+		It("saves and loads checkout state correctly", func() {
+			state := &dotdir.CheckoutState{
+				Hash: "abc123def456",
+				Messages: []dotdir.CheckoutMessage{
+					{Role: "system", Content: "You are a helpful assistant."},
+					{Role: "user", Content: "Hello!"},
+					{Role: "assistant", Content: "Hi! How can I help?"},
+					{Role: "user", Content: "Tell me about Go."},
+					{Role: "assistant", Content: "Go is a statically typed, compiled language."},
+				},
+			}
+
+			err := m.SaveCheckout(state, tmpDir)
+			Expect(err).NotTo(HaveOccurred())
+
+			loaded, err := m.LoadCheckoutState(tmpDir)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(loaded).To(Equal(state))
+		})
+	})
+})

--- a/pkg/dotdir/dotdir_suite_test.go
+++ b/pkg/dotdir/dotdir_suite_test.go
@@ -1,0 +1,13 @@
+package dotdir_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestDotdir(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Dotdir Suite")
+}

--- a/pkg/dotdir/manager.go
+++ b/pkg/dotdir/manager.go
@@ -1,0 +1,70 @@
+// Package dotdir manages the .tapes/ and ~/.tapes directories.
+//
+// The checkout state represents a point in a conversation DAG that the user has
+// "checked out" for resuming chat sessions. The state is persisted as a JSON file
+// in the ~/.tapes/ directory.
+package dotdir
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const (
+	// dirName is the name of the tapes directory.
+	dirName = ".tapes"
+)
+
+type Manager struct{}
+
+func NewManager() *Manager {
+	return &Manager{}
+}
+
+// Target returns the target absolute path to a .tapes/ directory.
+// Order of precedence is as follows:
+//  1. Provided override
+//  2. Local ./.tapes/ dir
+//  3. Home ~/.tapes/ dir
+//  4. If none found, attempt to create ~/.tapes/ dir
+func (m *Manager) Target(overrideDir string) (string, error) {
+	var dir string
+
+	switch {
+	case overrideDir != "":
+		dir = overrideDir
+
+	case m.localDirExists():
+		cwd, err := os.Getwd()
+		if err != nil {
+			return "", fmt.Errorf("getting current directory: %w", err)
+		}
+		dir = filepath.Join(cwd, dirName)
+
+	default:
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("getting home directory: %w", err)
+		}
+		dir = filepath.Join(home, dirName)
+	}
+
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("creating tapes directory %s: %w", dir, err)
+	}
+
+	return filepath.Abs(dir)
+}
+
+// localDirExists checks whether a .tapes/ directory exists in the current
+// working directory.
+func (m *Manager) localDirExists() bool {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return false
+	}
+
+	info, err := os.Stat(filepath.Join(cwd, dirName))
+	return err == nil && info.IsDir()
+}

--- a/pkg/dotdir/manager_test.go
+++ b/pkg/dotdir/manager_test.go
@@ -1,0 +1,109 @@
+package dotdir_test
+
+import (
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/papercomputeco/tapes/pkg/dotdir"
+)
+
+var _ = Describe("dotdir", func() {
+	var tmpDir string
+	var m *dotdir.Manager
+
+	BeforeEach(func() {
+		var err error
+		tmpDir, err = os.MkdirTemp("", "dotdir-test-*")
+		Expect(err).NotTo(HaveOccurred())
+
+		// Resolve symlinks so paths match filepath.Abs results
+		// (e.g. on macOS /var -> /private/var).
+		tmpDir, err = filepath.EvalSymlinks(tmpDir)
+		Expect(err).NotTo(HaveOccurred())
+
+		m = dotdir.NewManager()
+	})
+
+	AfterEach(func() {
+		os.RemoveAll(tmpDir)
+	})
+
+	Describe("NewManager", func() {
+		It("creates a new manager", func() {
+			Expect(m).ToNot(BeNil())
+		})
+	})
+
+	Describe("Target", func() {
+		It("creates the directory if it doesn't exist", func() {
+			dir := filepath.Join(tmpDir, "newdir")
+			result, err := m.Target(dir)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(dir))
+
+			info, err := os.Stat(dir)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(info.IsDir()).To(BeTrue())
+		})
+
+		It("returns existing directory without error", func() {
+			result, err := m.Target(tmpDir)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(tmpDir))
+		})
+
+		It("returns the override dir even when a local .tapes dir exists", func() {
+			// Create a local .tapes dir in the tmpDir
+			localTapes := filepath.Join(tmpDir, ".tapes")
+			Expect(os.Mkdir(localTapes, 0o755)).To(Succeed())
+
+			// Change to tmpDir so the local dir is discoverable
+			origDir, err := os.Getwd()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(os.Chdir(tmpDir)).To(Succeed())
+			DeferCleanup(func() { os.Chdir(origDir) })
+
+			overrideDir := filepath.Join(tmpDir, "override")
+			result, err := m.Target(overrideDir)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(overrideDir))
+		})
+
+		It("returns the local .tapes dir when it exists and no override is provided", func() {
+			// Create a local .tapes dir in the tmpDir
+			localTapes := filepath.Join(tmpDir, ".tapes")
+			Expect(os.Mkdir(localTapes, 0o755)).To(Succeed())
+
+			// Change to tmpDir so the local dir is discoverable
+			origDir, err := os.Getwd()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(os.Chdir(tmpDir)).To(Succeed())
+			DeferCleanup(func() { os.Chdir(origDir) })
+
+			result, err := m.Target("")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(localTapes))
+		})
+
+		It("falls back to the home dir when no local .tapes dir exists and no override is provided", func() {
+			// Ensure we're in a directory without a .tapes subdir
+			emptyDir := filepath.Join(tmpDir, "empty")
+			Expect(os.Mkdir(emptyDir, 0o755)).To(Succeed())
+
+			origDir, err := os.Getwd()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(os.Chdir(emptyDir)).To(Succeed())
+			DeferCleanup(func() { os.Chdir(origDir) })
+
+			home, err := os.UserHomeDir()
+			Expect(err).NotTo(HaveOccurred())
+
+			result, err := m.Target("")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(filepath.Join(home, ".tapes")))
+		})
+	})
+})

--- a/pkg/utils/string.go
+++ b/pkg/utils/string.go
@@ -1,0 +1,9 @@
+package utils
+
+// Truncate is a simple string truncate
+func Truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "..."
+}

--- a/pkg/utils/string_test.go
+++ b/pkg/utils/string_test.go
@@ -1,0 +1,21 @@
+package utils
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("truncate", func() {
+	It("returns the string unchanged when within the limit", func() {
+		Expect(Truncate("short", 10)).To(Equal("short"))
+	})
+
+	It("returns the string unchanged when exactly at the limit", func() {
+		Expect(Truncate("12345", 5)).To(Equal("12345"))
+	})
+
+	It("truncates with ellipsis when over the limit", func() {
+		result := Truncate("this is a long string", 10)
+		Expect(result).To(Equal("this is a ..."))
+	})
+})

--- a/pkg/utils/utils_suite_test.go
+++ b/pkg/utils/utils_suite_test.go
@@ -1,0 +1,13 @@
+package utils
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestUtils(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Utils Suite")
+}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -364,7 +364,7 @@ func (p *Proxy) handleHTTPRespToPipeWriter(httpResp *http.Response, pw *io.PipeW
 	// After streaming completes, enqueue for async storage
 	if parsedReq != nil && len(allChunks) > 0 {
 		p.logger.Debug("streaming complete",
-			zap.String("content_preview", truncate(fullContent.String(), 200)),
+			zap.String("content_preview", fullContent.String()),
 			zap.Int("chunk_count", len(allChunks)),
 			zap.Duration("duration", time.Since(startTime)),
 		)
@@ -407,12 +407,4 @@ func (p *Proxy) reconstructStreamedResponse(chunks [][]byte, fullContent string)
 	}
 
 	return nil
-}
-
-func truncate(s string, maxLen int) string {
-	s = strings.ReplaceAll(s, "\n", " ")
-	if len(s) <= maxLen {
-		return s
-	}
-	return s[:maxLen] + "..."
 }

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -655,31 +655,6 @@ var _ = Describe("reconstructStreamedResponse", func() {
 	})
 })
 
-var _ = Describe("truncate", func() {
-	It("returns the string unchanged when within the limit", func() {
-		Expect(truncate("short", 10)).To(Equal("short"))
-	})
-
-	It("returns the string unchanged when exactly at the limit", func() {
-		Expect(truncate("12345", 5)).To(Equal("12345"))
-	})
-
-	It("truncates with ellipsis when over the limit", func() {
-		result := truncate("this is a long string", 10)
-		Expect(result).To(Equal("this is a ..."))
-	})
-
-	It("replaces newlines with spaces", func() {
-		result := truncate("line1\nline2\nline3", 100)
-		Expect(result).To(Equal("line1 line2 line3"))
-	})
-
-	It("replaces newlines before truncating", func() {
-		result := truncate("ab\ncd\nef", 5)
-		Expect(result).To(Equal("ab cd..."))
-	})
-})
-
 var _ = Describe("New", func() {
 	It("returns an error for unrecognized provider type", func() {
 		logger, _ := zap.NewDevelopment()


### PR DESCRIPTION
This PR introduces a few experimental commands:

* ✨ Introduces the `dotdir` package in `pkg/dotdir/`, primarily API is the `Manager`: this manages the checkout state in a `.tapes/` dir (override first, then local, then in ~/.tapes` last), their configuration, etc.
* ✨ Introduces `tapes checkout` for checking out a point in a conversation and sets the state for future `tapes chat` sessions. This essentially enables people to directly interface with the data structures and iterative nature of branching trees in the merkle dag. Check uses the 
* ✨ Introduces `tapes init` for initializing a `.tapes/` dir locally. Local dirs take precedence over `~/.tapes` and are useful for storing local state per project.
* ✨ Introduces `tapes chat`, a simple experimental chat client for Ollama that uses the checkout state (if non exists, starts a new conversation turn).
* 🔧 Removes `truncate` from the `proxy` package: put it in the `utils` package with some tests.

Closes: PCC-66