### PR TITLE
chore: Don't mark nightly as the latest

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -101,7 +101,7 @@ jobs:
           prerelease: true
           allowUpdates: true
           removeArtifacts: true
-          makeLatest: true
+          makeLatest: false
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload artifacts to release


### PR DESCRIPTION
* 🧹 This is mostly for when cutting releases on GitHub and the release notes get generated- now nightly shouldn't be marked as the latest release and doesn't get used in the notes like `nightly...v0.0.1`