### PR TITLE
feat: proxy/header package for setting client/upstream headers

### DIFF
--- a/proxy/header/header.go
+++ b/proxy/header/header.go
@@ -1,0 +1,88 @@
+// Package header provides header filtering for the tapes proxy.
+//
+// This proxy sits between a client and an upstream LLM provider like so:
+//
+//	Client <--> Proxy <--> Upstream LLM Provider
+//
+// and headers are handled accordingly as each leg negotiates compression, hops,
+// encoding, etc. independently.
+package header
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+// Handler manages headers between proxy connections.
+type Handler struct{}
+
+// NewHandler creates a new header Handler.
+func NewHandler() *Handler {
+	return &Handler{}
+}
+
+// skipRequest is the set of request headers (client --> proxy --> upstream)
+// that are not forwarded to the upstream LLM provider.
+var skipRequest = map[string]struct{}{
+	// Hop-by-hop headers: only meaningful for a single transport-level connection.
+	"Connection": {},
+
+	// The Host header is rewritten by Go's http.Transport to match the
+	// upstream URL. Forwarding the client's Host would confuse virtual-hosted
+	// upstreams.
+	"Host": {},
+
+	// Accept-Encoding is stripped so that Go's http.Transport adds its own
+	// "Accept-Encoding: gzip" and transparently decompresses the upstream
+	// response.
+	"Accept-Encoding": {},
+}
+
+// skipResponse is the set of upstream response headers (client <-- proxy <-- upstream)
+// that are not copied back to the downstream client.
+var skipResponse = map[string]struct{}{
+	// Hop-by-hop headers: only meaningful for a single transport-level connection.
+	"Connection": {},
+
+	// Hop-by-hop headers: fasthttp manages chunked transfer encoding for the
+	// client-facing response independently.
+	"Transfer-Encoding": {},
+
+	// The proxy always reads a decompressed body (Go's http.Transport strips
+	// Content-Encoding after auto-decompression). Forwarding a stale
+	// Content-Encoding would claim an encoding the body no longer has.
+	// Fiber's compress middleware sets the correct Content-Encoding when it
+	// re-compresses the response back down to the client.
+	"Content-Encoding": {},
+
+	// The upstream Content-Length reflects the (possibly compressed) upstream
+	// body size. After decompression the length changes, and Fiber's compress
+	// middleware may re-compress to a different size. Letting Fiber compute
+	// the final Content-Length avoids sending an incorrect value.
+	"Content-Length": {},
+}
+
+// SetUpstreamRequestHeaders copies request headers from the Fiber context to
+// the outgoing http.Request, filtering headers that the proxy should not forward
+// to the upstream API.
+func (h *Handler) SetUpstreamRequestHeaders(c *fiber.Ctx, req *http.Request) {
+	c.Request().Header.VisitAll(func(key, value []byte) {
+		k := string(key)
+		if _, skip := skipRequest[k]; !skip {
+			req.Header.Set(k, string(value))
+		}
+	})
+}
+
+// SetClientResponseHeaders copies response headers from the upstream API
+// http.Response to the Fiber context, filtering headers that the proxy should
+// not forward back down to the client.
+func (h *Handler) SetClientResponseHeaders(c *fiber.Ctx, resp *http.Response) {
+	for k, v := range resp.Header {
+		if _, skip := skipResponse[k]; !skip {
+			c.Set(k, strings.Join(v, ", "))
+		}
+	}
+}

--- a/proxy/header/header_suite_test.go
+++ b/proxy/header/header_suite_test.go
@@ -1,0 +1,13 @@
+package header
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestHeader(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Header Suite")
+}

--- a/proxy/header/header_test.go
+++ b/proxy/header/header_test.go
@@ -1,0 +1,255 @@
+package header
+
+import (
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/gofiber/fiber/v2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("SetUpstreamRequestHeaders", func() {
+	var (
+		app *fiber.App
+		hh  *Handler
+	)
+
+	BeforeEach(func() {
+		app = fiber.New()
+		hh = NewHandler()
+	})
+
+	AfterEach(func() {
+		app.Shutdown()
+	})
+
+	It("forwards standard headers to the upstream request", func() {
+		var got http.Header
+
+		app.Post("/test", func(c *fiber.Ctx) error {
+			req, _ := http.NewRequest("POST", "http://upstream/test", nil)
+			hh.SetUpstreamRequestHeaders(c, req)
+			got = req.Header
+			return c.SendStatus(fiber.StatusOK)
+		})
+
+		req := httptest.NewRequest("POST", "/test", nil)
+		req.Header.Set("Authorization", "Bearer token123")
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("X-Api-Key", "secret")
+
+		resp, err := app.Test(req)
+		Expect(err).NotTo(HaveOccurred())
+		resp.Body.Close()
+
+		Expect(got.Get("Authorization")).To(Equal("Bearer token123"))
+		Expect(got.Get("Content-Type")).To(Equal("application/json"))
+		Expect(got.Get("X-Api-Key")).To(Equal("secret"))
+	})
+
+	It("strips the Connection header", func() {
+		var got http.Header
+
+		app.Post("/test", func(c *fiber.Ctx) error {
+			req, _ := http.NewRequest("POST", "http://upstream/test", nil)
+			hh.SetUpstreamRequestHeaders(c, req)
+			got = req.Header
+			return c.SendStatus(fiber.StatusOK)
+		})
+
+		req := httptest.NewRequest("POST", "/test", nil)
+		req.Header.Set("Connection", "keep-alive")
+
+		resp, err := app.Test(req)
+		Expect(err).NotTo(HaveOccurred())
+		resp.Body.Close()
+
+		Expect(got.Get("Connection")).To(BeEmpty())
+	})
+
+	It("strips the Host header", func() {
+		var got http.Header
+
+		app.Post("/test", func(c *fiber.Ctx) error {
+			req, _ := http.NewRequest("POST", "http://upstream/test", nil)
+			hh.SetUpstreamRequestHeaders(c, req)
+			got = req.Header
+			return c.SendStatus(fiber.StatusOK)
+		})
+
+		req := httptest.NewRequest("POST", "/test", nil)
+		req.Header.Set("Host", "client.example.com")
+
+		resp, err := app.Test(req)
+		Expect(err).NotTo(HaveOccurred())
+		resp.Body.Close()
+
+		Expect(got.Get("Host")).To(BeEmpty())
+	})
+
+	It("strips Accept-Encoding so Go's http.Transport negotiates its own", func() {
+		var got http.Header
+
+		app.Post("/test", func(c *fiber.Ctx) error {
+			req, _ := http.NewRequest("POST", "http://upstream/test", nil)
+			hh.SetUpstreamRequestHeaders(c, req)
+			got = req.Header
+			return c.SendStatus(fiber.StatusOK)
+		})
+
+		req := httptest.NewRequest("POST", "/test", nil)
+		req.Header.Set("Accept-Encoding", "gzip, deflate, br")
+		req.Header.Set("Authorization", "Bearer token123")
+
+		resp, err := app.Test(req)
+		Expect(err).NotTo(HaveOccurred())
+		resp.Body.Close()
+
+		Expect(got.Get("Accept-Encoding")).To(BeEmpty())
+		// Other headers still forwarded
+		Expect(got.Get("Authorization")).To(Equal("Bearer token123"))
+	})
+})
+
+var _ = Describe("SetClientResponseHeaders", func() {
+	var (
+		app *fiber.App
+		hh  *Handler
+	)
+
+	BeforeEach(func() {
+		app = fiber.New()
+		hh = NewHandler()
+	})
+
+	AfterEach(func() {
+		app.Shutdown()
+	})
+
+	It("forwards standard upstream response headers to the client", func() {
+		app.Get("/test", func(c *fiber.Ctx) error {
+			resp := &http.Response{
+				Header: http.Header{
+					"Content-Type":   {"application/json"},
+					"X-Request-Id":   {"abc-123"},
+					"X-Custom-Value": {"hello"},
+				},
+			}
+			hh.SetClientResponseHeaders(c, resp)
+			return c.SendStatus(fiber.StatusOK)
+		})
+
+		req := httptest.NewRequest("GET", "/test", nil)
+		resp, err := app.Test(req)
+		Expect(err).NotTo(HaveOccurred())
+		resp.Body.Close()
+
+		Expect(resp.Header.Get("Content-Type")).To(Equal("application/json"))
+		Expect(resp.Header.Get("X-Request-Id")).To(Equal("abc-123"))
+		Expect(resp.Header.Get("X-Custom-Value")).To(Equal("hello"))
+	})
+
+	It("strips the Connection header", func() {
+		app.Get("/test", func(c *fiber.Ctx) error {
+			resp := &http.Response{
+				Header: http.Header{
+					"Connection": {"keep-alive"},
+				},
+			}
+			hh.SetClientResponseHeaders(c, resp)
+			return c.SendStatus(fiber.StatusOK)
+		})
+
+		req := httptest.NewRequest("GET", "/test", nil)
+		resp, err := app.Test(req)
+		Expect(err).NotTo(HaveOccurred())
+		resp.Body.Close()
+
+		Expect(resp.Header.Get("Connection")).To(BeEmpty())
+	})
+
+	It("strips the Transfer-Encoding header", func() {
+		app.Get("/test", func(c *fiber.Ctx) error {
+			resp := &http.Response{
+				Header: http.Header{
+					"Transfer-Encoding": {"chunked"},
+				},
+			}
+			hh.SetClientResponseHeaders(c, resp)
+			return c.SendStatus(fiber.StatusOK)
+		})
+
+		req := httptest.NewRequest("GET", "/test", nil)
+		resp, err := app.Test(req)
+		Expect(err).NotTo(HaveOccurred())
+		resp.Body.Close()
+
+		Expect(resp.Header.Get("Transfer-Encoding")).To(BeEmpty())
+	})
+
+	It("strips Content-Encoding since the proxy body is always decompressed", func() {
+		app.Get("/test", func(c *fiber.Ctx) error {
+			resp := &http.Response{
+				Header: http.Header{
+					"Content-Encoding": {"gzip"},
+					"X-Request-Id":     {"abc-123"},
+				},
+			}
+			hh.SetClientResponseHeaders(c, resp)
+			return c.SendStatus(fiber.StatusOK)
+		})
+
+		req := httptest.NewRequest("GET", "/test", nil)
+		resp, err := app.Test(req)
+		Expect(err).NotTo(HaveOccurred())
+		resp.Body.Close()
+
+		Expect(resp.Header.Get("Content-Encoding")).To(BeEmpty())
+		// Other headers still forwarded
+		Expect(resp.Header.Get("X-Request-Id")).To(Equal("abc-123"))
+	})
+
+	It("strips Content-Length since Fiber recomputes it after compression", func() {
+		app.Get("/test", func(c *fiber.Ctx) error {
+			resp := &http.Response{
+				Header: http.Header{
+					"Content-Length": {"1234"},
+					"X-Request-Id":   {"abc-123"},
+				},
+			}
+			hh.SetClientResponseHeaders(c, resp)
+			return c.SendStatus(fiber.StatusOK)
+		})
+
+		req := httptest.NewRequest("GET", "/test", nil)
+		resp, err := app.Test(req)
+		Expect(err).NotTo(HaveOccurred())
+		resp.Body.Close()
+
+		// Content-Length should not carry the upstream value.
+		// Fiber sets its own based on the actual response body.
+		Expect(resp.Header.Get("Content-Length")).NotTo(Equal("1234"))
+		// Other headers still forwarded
+		Expect(resp.Header.Get("X-Request-Id")).To(Equal("abc-123"))
+	})
+
+	It("joins multi-value response headers with commas", func() {
+		app.Get("/test", func(c *fiber.Ctx) error {
+			resp := &http.Response{
+				Header: http.Header{
+					"X-Multi": {"value1", "value2"},
+				},
+			}
+			hh.SetClientResponseHeaders(c, resp)
+			return c.SendStatus(fiber.StatusOK)
+		})
+
+		req := httptest.NewRequest("GET", "/test", nil)
+		resp, err := app.Test(req)
+		Expect(err).NotTo(HaveOccurred())
+		resp.Body.Close()
+
+		Expect(resp.Header.Get("X-Multi")).To(Equal("value1, value2"))
+	})
+})


### PR DESCRIPTION
* ✨ followup to: #45 - new `proxy/header` package for setting req/res headers in the `client <--> proxy <--> upstream` flow