### PR TITLE
fix: use lld linker for macOS builds to support Sequoia (15.x)

### DIFF
--- a/.dagger/build.go
+++ b/.dagger/build.go
@@ -113,7 +113,9 @@ func (t *Tapes) buildLinux(outputs *dagger.Directory, ldflags string) *dagger.Di
 // cross-compilers inside a Linux container.
 func (t *Tapes) buildDarwin(outputs *dagger.Directory, ldflags string) *dagger.Directory {
 	cgoFlags := "-I/opt/sqlite"
-	cgoLdFlags := ""
+	// Use lld instead of osxcross's ld64 to properly set SG_READ_ONLY flag on __DATA_CONST
+	// segment, which is required by macOS 15 (Sequoia) and later.
+	cgoLdFlags := "-fuse-ld=lld"
 
 	targets := []buildTarget{
 		{"darwin", "amd64", "o64-clang", "o64-clang++", cgoFlags, cgoLdFlags},


### PR DESCRIPTION
## Summary

- Fixes darwin binaries crashing on macOS 15 (Sequoia) with `dyld: __DATA_CONST segment missing SG_READ_ONLY flag`
- Switches from osxcross's ld64 to LLVM's lld linker for darwin cross-compilation

## Problem

macOS 15 (Sequoia) enforces that `__DATA_CONST` segments have the `SG_READ_ONLY` flag (0x10) set. The osxcross ld64 linker (from cctools-port) doesn't set this flag, causing all darwin binaries to fail immediately on launch:

```
dyld[74978]: __DATA_CONST segment missing SG_READ_ONLY flag in /usr/local/bin/tapes
dyld[74978]: __DATA_CONST segment missing SG_READ_ONLY flag
Abort trap: 6
```

## Fix

Use `-fuse-ld=lld` in CGO_LDFLAGS to invoke LLVM's lld linker (already installed in the build container) instead of osxcross's ld64. LLD properly sets the `SG_READ_ONLY` flag on `__DATA_CONST` segments.

## Compatibility

| macOS Version | Before | After |
|---------------|--------|-------|
| 10.13 - 14.x  | ✅     | ✅    |
| 15.x (Sequoia)| ❌     | ✅    |

The minimum deployment target remains **macOS 10.13** (verified via `otool -l`).

## Verification

Built with Dagger and verified segment flags with `otool`:

```bash
# Before (broken)
otool -l tapes | grep -A10 "__DATA_CONST"
#   flags 0x0  ❌

# After (fixed)  
otool -l tapes | grep -A10 "__DATA_CONST"
#   flags 0x10 ✅ (SG_READ_ONLY)
```

Tested binary runs successfully on macOS 15.2:
```
$ tapes version
Version: dev
Sha: HEAD
Built at: dev
```

## Test locally

```bash
dagger call build --ldflags="-s -w" export --path ./test-build
./test-build/darwin/amd64/tapes version
```