### PR TITLE
feat: Canary smoke tests after builds in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,5 +47,67 @@ jobs:
           DAGGER_CLOUD_TOKEN: ${{ secrets.DAGGER_CLOUD_TOKEN }}
         with:
           verb: call
-          args: build
+          args: build export --path=./build
           version: ${{ env.DAGGER_VERSION }}
+
+      - name: Upload darwin arm64 binaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: darwin-arm64-binaries
+          path: build/darwin/arm64/
+          retention-days: 1
+
+      - name: Upload darwin amd64 binaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: darwin-amd64-binaries
+          path: build/darwin/amd64/
+          retention-days: 1
+
+      - name: Upload linux amd64 binaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-amd64-binaries
+          path: build/linux/amd64/
+          retention-days: 1
+
+      - name: Upload linux arm64 binaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-arm64-binaries
+          path: build/linux/arm64/
+          retention-days: 1
+
+  smoke:
+    name: Smoke Test (${{ matrix.os }})
+    needs: build
+    runs-on: ${{ matrix.runner }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macOS 15 (arm64)
+            runner: macos-15
+            artifact: darwin-arm64-binaries
+          - os: macOS 15 (amd64)
+            runner: macos-15-intel
+            artifact: darwin-amd64-binaries
+          - os: Linux (amd64)
+            runner: ubuntu-latest
+            artifact: linux-amd64-binaries
+          - os: Linux (arm64)
+            runner: ubuntu-22.04-arm
+            artifact: linux-arm64-binaries
+
+    steps:
+      - name: Download binaries
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: ./bin
+
+      - name: Run canary
+        run: |
+          chmod +x ./bin/tapes
+          ./bin/tapes version


### PR DESCRIPTION
* ✨ Smoke tests in CI after build to ensure builds are valid: targets MacOS 15 (darwin arm64 and linux amd64). Related to #50 