### PR TITLE
Update .gitignore to exclude generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 /build/
 /tmp/
 /tapes
+/config.toml
+/tapes.db
+/tapes.db~
 .DS_Store
 
 # JetBrains IDEs


### PR DESCRIPTION
## Summary
Add additional generated files to .gitignore to prevent them from being accidentally committed to the repository.

## Changes
- Added `/config.toml` to ignore project configuration files
- Added `/tapes.db` and `/tapes.db~` to ignore database files and their backups

These files are generated during local development and should not be tracked in version control.