### PR TITLE
docs: expand contributing quickstart

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,56 @@
 # Contributing
 
-## Nix flake and `direnv`
+## Quick start (Nix)
 
 We encourage contributors to utilize the Nix flake which carries all development dependencies
 and has automatic `direnv` support:
 to enter the nix development shell, run `nix develop`.
 Allow automatic environment loading with `direnv` via `direnv allow`.
+
+## Quick start (manual)
+
+```bash
+make build-local
+./build/tapes deck --demo
+```
+
+## Prerequisites checklist
+
+- Go 1.25+
+- CGO enabled and SQLite dev libraries (e.g., `libsqlite3`)
+- Docker (required for `make format`, `make check`, `make unit-test` via Dagger)
+- Optional: Ollama for embeddings when running `tapes serve`
+
+## Common issues
+
+- SQLite errors when building or running
+  - Ensure SQLite dev libraries are installed and `CGO_ENABLED=1`
+- Merkle hashing requires `GOEXPERIMENT=jsonv2`
+  - `make build-local` sets this automatically
+- `make format`/`make check`/`make unit-test` require Docker for Dagger
+- Demo seeding docs
+  - Use `tapes deck --demo` to seed demo sessions
+  - Demo DB path defaults to `./tapes.demo.sqlite`
+  - Reseed with `tapes deck --demo --overwrite`
+
+## Example commands
+
+```bash
+# Build local binaries
+make build-local
+
+# Run the deck UI with demo data
+./build/tapes deck --demo
+
+# Reseed demo data
+./build/tapes deck --demo --overwrite
+
+# Run tests
+make unit-test
+
+# Format code
+make format
+
+# Run deck against a specific database
+TAPES_SQLITE=./tapes.sqlite ./build/tapes deck
+```


### PR DESCRIPTION
## Summary
- add quickstart steps for local builds and demo deck usage
- document prerequisites and common setup issues
- provide example commands for tests, formatting, and deck workflows

## Testing
- not run (docs only)

## References
- Closes #64