### PR TITLE
fix: make deck demo overwrite default

### DIFF
--- a/cmd/tapes/deck/deck.go
+++ b/cmd/tapes/deck/deck.go
@@ -82,7 +82,7 @@ func NewDeckCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&cmder.web, "web", false, "Serve the web dashboard locally")
 	cmd.Flags().IntVar(&cmder.port, "port", 8888, "Web server port")
 	cmd.Flags().BoolVarP(&cmder.demo, "demo", "m", false, "Seed demo data and open the deck UI")
-	cmd.Flags().BoolVarP(&cmder.overwrite, "overwrite", "f", false, "Overwrite demo database before seeding")
+	cmd.Flags().BoolVarP(&cmder.overwrite, "overwrite", "f", false, "Overwrite demo database before seeding (default for demo db)")
 
 	return cmd
 }
@@ -98,6 +98,9 @@ func (c *deckCommander) run(ctx context.Context, cmd *cobra.Command) error {
 	}
 	if c.demo && strings.TrimSpace(c.sqlitePath) == "" {
 		c.sqlitePath = deck.DemoSQLitePath
+		if !c.overwrite {
+			c.overwrite = true
+		}
 	}
 
 	sqlitePath, err := sqlitepath.ResolveSQLitePath(c.sqlitePath)


### PR DESCRIPTION
## Summary
- Default demo runs now overwrite the demo SQLite DB when `--sqlite` is not provided
- Update help text to clarify the demo DB overwrite behavior

## Why
The `-f/--overwrite` requirement for `tapes deck --demo` was a mistake; it adds unnecessary friction and breaks the expectation that demo mode should just work. This makes it easier for users to spin up demos with less friction by allowing repeated runs without extra flags.

## Testing
- `make format`