### PR TITLE
feat: Adds `pkg/sse/` for server sent events handling

### DIFF
--- a/pkg/sse/event.go
+++ b/pkg/sse/event.go
@@ -1,0 +1,27 @@
+// Package sse provides a minimal, purpose-built SSE (Server-Sent Events)
+// tee-reader for use in the tapes proxy. It is designed to parse SSE events from
+// an upstream LLM provider while simultaneously forwarding the raw bytes
+// verbatim to a downstream client in a tee pipe fashion.
+//
+// This package intentionally does NOT provide SSE writer or server
+// capabilities.
+//
+// See the SSE specification:
+// https://html.spec.whatwg.org/multipage/server-sent-events.html
+package sse
+
+// Event represents a single parsed SSE event, delimited by a blank line
+// in the upstream byte stream.
+type Event struct {
+	// Type is the SSE event type from the "event:" field.
+	// An empty string means the default "message" type per the SSE spec.
+	Type string
+
+	// Data is the concatenated contents of all "data:" lines for this event,
+	// joined with "\n" (per the SSE spec, multiple data fields are joined
+	// with a single newline).
+	Data string
+
+	// ID is the last event ID from the "id:" field, if present.
+	ID string
+}

--- a/pkg/sse/reader.go
+++ b/pkg/sse/reader.go
@@ -1,0 +1,152 @@
+package sse
+
+import (
+	"bufio"
+	"io"
+	"strings"
+)
+
+// TeeReader reads SSE events from a source io.Reader while simultaneously
+// writing all raw bytes verbatim to a destination io.writer.
+// This effectively enables "tee" shaped reading where TeeReader.Next
+// returns the Event for consumption while writing to a separate destination.
+//
+// ┌──────────────────┐
+// │ source io.Reader │
+// └──────────────────┘
+// │
+// ▼
+// ┌──────────────────┐   ┌───────────────────────┐
+// │ TeeReader.Next() │──▶│ destination io.Writer │
+// └──────────────────┘   └───────────────────────┘
+// │
+// ▼
+// ┌──────────────────┐
+// │      Event       │
+// └──────────────────┘
+//
+// An SSE client io.Writer receives the exact copy of the
+// stream, while the caller can inspect parsed events.
+type TeeReader struct {
+	scanner *bufio.Scanner
+	dest    io.Writer
+
+	// current accumulates fields for the event being built in the current scan.
+	current *Event
+	hasData bool
+}
+
+// NewTeeReader returns a Reader that parses SSE events from the src io.Reader
+// and writes all raw bytes through to dest.
+// The dest writer typically backs an io.Pipe connected to the downstream HTTP
+// response.
+func NewTeeReader(src io.Reader, dest io.Writer) *TeeReader {
+	scanner := bufio.NewScanner(src)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+
+	return &TeeReader{
+		scanner: scanner,
+		dest:    dest,
+		current: &Event{},
+	}
+}
+
+// Next returns the next parsed SSE event from the scanner. It blocks until a
+// complete event is available (terminated by a blank line in the stream).
+// Next returns nil, nil when the source is exhausted.
+//
+// Next also tees all bytes to the destination writer supplied
+// to NewTeeReader. This ensures the downstream client receivers can consume
+// SSE stream bytes verbatim.
+func (r *TeeReader) Next() (*Event, error) {
+	for r.scanner.Scan() {
+		raw := r.scanner.Text()
+
+		// Write the raw line content and newline to the destination.
+		// bufio.Scanner strips the newline from the Scan() so we reinsert it here.
+		_, err := io.WriteString(r.dest, raw+"\n")
+		if err != nil {
+			return nil, err
+		}
+
+		// A blank line signals the end of the current event.
+		if raw == "" {
+			if r.hasData {
+				currentEvent := r.current
+				r.reset()
+				return currentEvent, nil
+			}
+
+			// Blank line with no accumulated fields — skip (e.g. leading
+			// blank lines or keep-alive newlines).
+			continue
+		}
+
+		// Lines starting with ':' are comments. Skip them in Event parsing.
+		if strings.HasPrefix(raw, ":") {
+			continue
+		}
+
+		r.parseLine(raw)
+	}
+
+	if err := r.scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	// Source exhausted and no error from scanner.
+	// If there is an in-progress event (stream ended without a trailing blank
+	// line), yield it.
+	if r.hasData {
+		ev := r.current
+		r.reset()
+		return ev, nil
+	}
+
+	return nil, nil
+}
+
+// parseLine processes a single non-empty, non-comment SSE line and
+// accumulates the field into the current event.
+//
+// Per the SSE spec, a line has the form "field:value" where the first
+// space after the colon is optional and stripped if present.
+func (r *TeeReader) parseLine(line string) {
+	var field, value string
+
+	if before, after, ok := strings.Cut(line, ":"); ok {
+		field = before
+		value = after
+		// Strip a single leading space after the colon, per spec.
+		value = strings.TrimPrefix(value, " ")
+	} else {
+		// Line with no colon: the entire line is the field name with
+		// an empty value.
+		field = line
+	}
+
+	switch field {
+	case "data":
+		if r.hasData && r.current.Data != "" {
+			// Multiple data fields are joined with "\n".
+			r.current.Data += "\n"
+		}
+		r.current.Data += value
+		r.hasData = true
+	case "event":
+		r.current.Type = value
+		r.hasData = true
+	case "id":
+		r.current.ID = value
+		r.hasData = true
+	default:
+		// * "retry" is intentionally ignored — not relevant for proxy use.
+		// * Other unknown fields are ignored per the SSE spec.
+	}
+}
+
+// reset clears the accumulated event state for the next event.
+func (r *TeeReader) reset() {
+	r.current = &Event{}
+	r.hasData = false
+}

--- a/pkg/sse/reader_test.go
+++ b/pkg/sse/reader_test.go
@@ -1,0 +1,299 @@
+package sse
+
+import (
+	"bytes"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Reader", func() {
+	var dst *bytes.Buffer
+
+	BeforeEach(func() {
+		dst = &bytes.Buffer{}
+	})
+
+	Describe("Next", func() {
+		Context("with standard SSE events", func() {
+			It("parses a single event", func() {
+				src := strings.NewReader("data: hello world\n\n")
+				r := NewTeeReader(src, dst)
+
+				ev, err := r.Next()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(ev.Data).To(Equal("hello world"))
+				Expect(ev.Type).To(BeEmpty())
+				Expect(ev.ID).To(BeEmpty())
+
+				ev, err = r.Next()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(ev).To(BeNil())
+			})
+
+			It("parses multiple events", func() {
+				src := strings.NewReader("data: first\n\ndata: second\n\n")
+				r := NewTeeReader(src, dst)
+
+				ev1, err := r.Next()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(ev1.Data).To(Equal("first"))
+
+				ev2, err := r.Next()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(ev2.Data).To(Equal("second"))
+
+				ev3, err := r.Next()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(ev3).To(BeNil())
+			})
+
+			It("parses event type", func() {
+				src := strings.NewReader("event: content_block_delta\ndata: {\"type\":\"delta\"}\n\n")
+				r := NewTeeReader(src, dst)
+
+				ev, err := r.Next()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(ev.Type).To(Equal("content_block_delta"))
+				Expect(ev.Data).To(Equal("{\"type\":\"delta\"}"))
+			})
+
+			It("parses event ID", func() {
+				src := strings.NewReader("id: 42\ndata: hello\n\n")
+				r := NewTeeReader(src, dst)
+
+				ev, err := r.Next()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(ev.ID).To(Equal("42"))
+				Expect(ev.Data).To(Equal("hello"))
+			})
+
+			It("joins multiple data lines with newline", func() {
+				src := strings.NewReader("data: line one\ndata: line two\ndata: line three\n\n")
+				r := NewTeeReader(src, dst)
+
+				ev, err := r.Next()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(ev.Data).To(Equal("line one\nline two\nline three"))
+			})
+		})
+
+		Context("with OpenAI-style SSE", func() {
+			It("parses OpenAI streaming chunks", func() {
+				input := "data: {\"id\":\"chatcmpl-1\",\"choices\":[{\"delta\":{\"content\":\"Hello\"}}]}\n\n" +
+					"data: {\"id\":\"chatcmpl-1\",\"choices\":[{\"delta\":{\"content\":\" world\"}}]}\n\n" +
+					"data: [DONE]\n\n"
+				src := strings.NewReader(input)
+				r := NewTeeReader(src, dst)
+
+				ev1, err := r.Next()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(ev1.Data).To(Equal("{\"id\":\"chatcmpl-1\",\"choices\":[{\"delta\":{\"content\":\"Hello\"}}]}"))
+
+				ev2, err := r.Next()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(ev2.Data).To(Equal("{\"id\":\"chatcmpl-1\",\"choices\":[{\"delta\":{\"content\":\" world\"}}]}"))
+
+				ev3, err := r.Next()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(ev3.Data).To(Equal("[DONE]"))
+
+				ev4, err := r.Next()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(ev4).To(BeNil())
+			})
+		})
+
+		Context("with Anthropic-style SSE", func() {
+			It("parses Anthropic streaming events with event types", func() {
+				input := "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\"}}\n\n" +
+					"event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"delta\":{\"text\":\"Hello\"}}\n\n" +
+					"event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n"
+				src := strings.NewReader(input)
+				r := NewTeeReader(src, dst)
+
+				ev1, err := r.Next()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(ev1.Type).To(Equal("message_start"))
+				Expect(ev1.Data).To(ContainSubstring("message_start"))
+
+				ev2, err := r.Next()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(ev2.Type).To(Equal("content_block_delta"))
+				Expect(ev2.Data).To(ContainSubstring("Hello"))
+
+				ev3, err := r.Next()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(ev3.Type).To(Equal("message_stop"))
+
+				ev4, err := r.Next()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(ev4).To(BeNil())
+			})
+		})
+
+		Context("with SSE comments", func() {
+			It("ignores comment lines in parsed events", func() {
+				src := strings.NewReader(": this is a comment\ndata: hello\n\n")
+				r := NewTeeReader(src, dst)
+
+				ev, err := r.Next()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(ev.Data).To(Equal("hello"))
+			})
+
+			It("forwards comment lines to dst", func() {
+				src := strings.NewReader(": keep-alive\ndata: hello\n\n")
+				r := NewTeeReader(src, dst)
+
+				_, err := r.Next()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(dst.String()).To(ContainSubstring(": keep-alive\n"))
+			})
+		})
+
+		Context("with data field variations", func() {
+			It("handles data field with no space after colon", func() {
+				src := strings.NewReader("data:no-space\n\n")
+				r := NewTeeReader(src, dst)
+
+				ev, err := r.Next()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(ev.Data).To(Equal("no-space"))
+			})
+
+			It("handles empty data field", func() {
+				src := strings.NewReader("data:\n\n")
+				r := NewTeeReader(src, dst)
+
+				ev, err := r.Next()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(ev.Data).To(BeEmpty())
+			})
+
+			It("handles data field with only a space (empty value per spec)", func() {
+				src := strings.NewReader("data: \n\n")
+				r := NewTeeReader(src, dst)
+
+				ev, err := r.Next()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(ev.Data).To(BeEmpty())
+			})
+		})
+
+		Context("verbatim byte forwarding", func() {
+			It("forwards all bytes including \\n\\n delimiters to dst", func() {
+				input := "data: first\n\ndata: second\n\n"
+				src := strings.NewReader(input)
+				r := NewTeeReader(src, dst)
+
+				_, err := r.Next()
+				Expect(err).NotTo(HaveOccurred())
+				_, err = r.Next()
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(dst.String()).To(Equal(input))
+			})
+
+			It("preserves exact OpenAI SSE framing in dst", func() {
+				input := "data: {\"choices\":[{\"delta\":{\"content\":\"Hi\"}}]}\n\ndata: [DONE]\n\n"
+				src := strings.NewReader(input)
+				r := NewTeeReader(src, dst)
+
+				_, err := r.Next()
+				Expect(err).NotTo(HaveOccurred())
+				_, err = r.Next()
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(dst.String()).To(Equal(input))
+			})
+
+			It("preserves exact Anthropic SSE framing in dst", func() {
+				input := "event: content_block_delta\ndata: {\"delta\":{\"text\":\"Hi\"}}\n\nevent: message_stop\ndata: {\"type\":\"message_stop\"}\n\n"
+				src := strings.NewReader(input)
+				r := NewTeeReader(src, dst)
+
+				_, err := r.Next()
+				Expect(err).NotTo(HaveOccurred())
+				_, err = r.Next()
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(dst.String()).To(Equal(input))
+			})
+
+			It("preserves comment lines in dst output", func() {
+				input := ": comment\ndata: hello\n\n"
+				src := strings.NewReader(input)
+				r := NewTeeReader(src, dst)
+
+				_, err := r.Next()
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(dst.String()).To(Equal(input))
+			})
+		})
+
+		Context("edge cases", func() {
+			It("returns nil on empty input", func() {
+				src := strings.NewReader("")
+				r := NewTeeReader(src, dst)
+
+				ev, err := r.Next()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(ev).To(BeNil())
+			})
+
+			It("returns nil on input with only blank lines", func() {
+				src := strings.NewReader("\n\n\n")
+				r := NewTeeReader(src, dst)
+
+				ev, err := r.Next()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(ev).To(BeNil())
+			})
+
+			It("yields event when stream ends without trailing blank line", func() {
+				src := strings.NewReader("data: unterminated")
+				r := NewTeeReader(src, dst)
+
+				ev, err := r.Next()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(ev.Data).To(Equal("unterminated"))
+
+				ev, err = r.Next()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(ev).To(BeNil())
+			})
+
+			It("skips leading blank lines before first event", func() {
+				src := strings.NewReader("\n\ndata: hello\n\n")
+				r := NewTeeReader(src, dst)
+
+				ev, err := r.Next()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(ev.Data).To(Equal("hello"))
+			})
+
+			It("ignores unknown fields", func() {
+				src := strings.NewReader("retry: 3000\nfoo: bar\ndata: hello\n\n")
+				r := NewTeeReader(src, dst)
+
+				ev, err := r.Next()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(ev.Data).To(Equal("hello"))
+			})
+
+			It("handles field with no colon", func() {
+				// Per spec: if a line has no colon, the entire line is the field name
+				// with an empty value. Unknown fields are ignored.
+				src := strings.NewReader("data\n\n")
+				r := NewTeeReader(src, dst)
+
+				ev, err := r.Next()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(ev.Data).To(BeEmpty())
+			})
+		})
+	})
+})

--- a/pkg/sse/sse_suite_test.go
+++ b/pkg/sse/sse_suite_test.go
@@ -1,0 +1,13 @@
+package sse
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestSSE(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "SSE Suite")
+}

--- a/proxy/proxy_sse_test.go
+++ b/proxy/proxy_sse_test.go
@@ -1,0 +1,257 @@
+package proxy
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/zap"
+
+	"github.com/papercomputeco/tapes/pkg/storage/inmemory"
+)
+
+// openaiTestRequest is a minimal OpenAI-format request for test fixtures.
+type openaiTestRequest struct {
+	Model    string               `json:"model"`
+	Messages []openaiTestMsgEntry `json:"messages"`
+	Stream   *bool                `json:"stream,omitempty"`
+}
+
+type openaiTestMsgEntry struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+// newOpenAITestProxy creates a Proxy pointed at the given upstream URL,
+// using an in-memory storage driver and the openai provider.
+func newOpenAITestProxy(upstreamURL string) (*Proxy, *inmemory.Driver) {
+	logger, _ := zap.NewDevelopment()
+	driver := inmemory.NewDriver()
+
+	p, err := New(
+		Config{
+			ListenAddr:   ":0",
+			UpstreamURL:  upstreamURL,
+			ProviderType: "openai",
+		},
+		driver,
+		logger,
+	)
+	Expect(err).NotTo(HaveOccurred())
+	return p, driver
+}
+
+// makeOpenAIRequestBody builds a JSON-encoded OpenAI chat request.
+func makeOpenAIRequestBody(model string, messages []openaiTestMsgEntry, stream *bool) []byte {
+	body, err := json.Marshal(openaiTestRequest{
+		Model:    model,
+		Messages: messages,
+		Stream:   stream,
+	})
+	Expect(err).NotTo(HaveOccurred())
+	return body
+}
+
+var _ = Describe("SSE Streaming Proxy", func() {
+	var (
+		p        *Proxy
+		driver   *inmemory.Driver
+		upstream *httptest.Server
+	)
+
+	AfterEach(func() {
+		if p != nil {
+			p.Close()
+		}
+		if upstream != nil {
+			upstream.Close()
+		}
+	})
+
+	Context("when upstream returns an OpenAI SSE streaming response", func() {
+		BeforeEach(func() {
+			upstream = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "text/event-stream")
+				w.Header().Set("Cache-Control", "no-cache")
+				flusher, ok := w.(http.Flusher)
+				Expect(ok).To(BeTrue())
+
+				events := []string{
+					"data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"Hello\"}}]}\n\n",
+					"data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\" world\"}}]}\n\n",
+					"data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"!\"}}]}\n\n",
+					"data: [DONE]\n\n",
+				}
+
+				for _, event := range events {
+					fmt.Fprint(w, event)
+					flusher.Flush()
+				}
+			}))
+			p, driver = newOpenAITestProxy(upstream.URL)
+		})
+
+		It("preserves SSE event boundaries with \\n\\n delimiters", func() {
+			reqBody := makeOpenAIRequestBody("gpt-4", []openaiTestMsgEntry{
+				{Role: "user", Content: "Say hello"},
+			}, boolPtr(true))
+
+			resp, err := p.server.Test(httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(string(reqBody))), -1)
+			Expect(err).NotTo(HaveOccurred())
+			defer resp.Body.Close()
+
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+			body, err := io.ReadAll(resp.Body)
+			Expect(err).NotTo(HaveOccurred())
+			bodyStr := string(body)
+
+			// The critical assertion: SSE event boundaries must be preserved.
+			// Each event must end with \n\n, not just \n.
+			Expect(bodyStr).To(ContainSubstring("data: {\"id\":\"chatcmpl-1\""))
+			Expect(bodyStr).To(ContainSubstring("data: [DONE]\n\n"))
+
+			// Verify individual events are separated by \n\n
+			Expect(strings.Count(bodyStr, "\n\n")).To(BeNumerically(">=", 4))
+		})
+
+		It("streams all OpenAI chunks to the client", func() {
+			reqBody := makeOpenAIRequestBody("gpt-4", []openaiTestMsgEntry{
+				{Role: "user", Content: "Say hello"},
+			}, boolPtr(true))
+
+			resp, err := p.server.Test(httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(string(reqBody))), -1)
+			Expect(err).NotTo(HaveOccurred())
+			defer resp.Body.Close()
+
+			body, err := io.ReadAll(resp.Body)
+			Expect(err).NotTo(HaveOccurred())
+			bodyStr := string(body)
+
+			Expect(bodyStr).To(ContainSubstring(`"content":"Hello"`))
+			Expect(bodyStr).To(ContainSubstring(`"content":" world"`))
+			Expect(bodyStr).To(ContainSubstring(`"content":"!"`))
+			Expect(bodyStr).To(ContainSubstring("[DONE]"))
+		})
+
+		It("accumulates content and stores the conversation after SSE streaming", func() {
+			reqBody := makeOpenAIRequestBody("gpt-4", []openaiTestMsgEntry{
+				{Role: "user", Content: "Say hello"},
+			}, boolPtr(true))
+
+			resp, err := p.server.Test(httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(string(reqBody))), -1)
+			Expect(err).NotTo(HaveOccurred())
+			resp.Body.Close()
+
+			// Drain the worker pool to ensure async storage completes
+			p.Close()
+			p = nil
+
+			ctx := GinkgoT().Context()
+			nodes, err := driver.List(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			// 1 user message + 1 assistant response = 2 nodes
+			Expect(nodes).To(HaveLen(2))
+
+			leaves, err := driver.Leaves(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(leaves).To(HaveLen(1))
+			Expect(leaves[0].Bucket.Role).To(Equal("assistant"))
+			// The accumulated content from all SSE chunks
+			Expect(leaves[0].Bucket.ExtractText()).To(Equal("Hello world!"))
+		})
+	})
+
+	Context("when upstream returns an Anthropic-style SSE response with event types", func() {
+		BeforeEach(func() {
+			upstream = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "text/event-stream")
+				flusher, ok := w.(http.Flusher)
+				Expect(ok).To(BeTrue())
+
+				events := []string{
+					"event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"model\":\"claude-3\"}}\n\n",
+					"event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"delta\":{\"text\":\"Hi there\"}}\n\n",
+					"event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n",
+				}
+
+				for _, event := range events {
+					fmt.Fprint(w, event)
+					flusher.Flush()
+				}
+			}))
+			p, driver = newOpenAITestProxy(upstream.URL)
+		})
+
+		It("preserves event type and data fields with \\n\\n delimiters", func() {
+			reqBody := makeOpenAIRequestBody("claude-3", []openaiTestMsgEntry{
+				{Role: "user", Content: "Hi"},
+			}, boolPtr(true))
+
+			resp, err := p.server.Test(httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(string(reqBody))), -1)
+			Expect(err).NotTo(HaveOccurred())
+			defer resp.Body.Close()
+
+			body, err := io.ReadAll(resp.Body)
+			Expect(err).NotTo(HaveOccurred())
+			bodyStr := string(body)
+
+			// Event type lines must be preserved
+			Expect(bodyStr).To(ContainSubstring("event: message_start\n"))
+			Expect(bodyStr).To(ContainSubstring("event: content_block_delta\n"))
+			Expect(bodyStr).To(ContainSubstring("event: message_stop\n"))
+
+			// Data lines must be present
+			Expect(bodyStr).To(ContainSubstring("data: {\"type\":\"message_start\""))
+			Expect(bodyStr).To(ContainSubstring("data: {\"type\":\"content_block_delta\""))
+
+			// Event boundaries must use \n\n
+			Expect(strings.Count(bodyStr, "\n\n")).To(BeNumerically(">=", 3))
+		})
+	})
+
+	Context("when upstream SSE includes comment lines", func() {
+		BeforeEach(func() {
+			upstream = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "text/event-stream")
+				flusher, ok := w.(http.Flusher)
+				Expect(ok).To(BeTrue())
+
+				// Some providers send comment lines as keep-alives
+				events := []string{
+					": keep-alive\n\n",
+					"data: {\"choices\":[{\"delta\":{\"content\":\"OK\"}}]}\n\n",
+					"data: [DONE]\n\n",
+				}
+
+				for _, event := range events {
+					fmt.Fprint(w, event)
+					flusher.Flush()
+				}
+			}))
+			p, driver = newOpenAITestProxy(upstream.URL)
+		})
+
+		It("forwards comment lines verbatim to the client", func() {
+			reqBody := makeOpenAIRequestBody("gpt-4", []openaiTestMsgEntry{
+				{Role: "user", Content: "test"},
+			}, boolPtr(true))
+
+			resp, err := p.server.Test(httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(string(reqBody))), -1)
+			Expect(err).NotTo(HaveOccurred())
+			defer resp.Body.Close()
+
+			body, err := io.ReadAll(resp.Body)
+			Expect(err).NotTo(HaveOccurred())
+			bodyStr := string(body)
+
+			Expect(bodyStr).To(ContainSubstring(": keep-alive\n"))
+			Expect(bodyStr).To(ContainSubstring("data: {\"choices\""))
+		})
+	})
+})


### PR DESCRIPTION
* ✨ Implements a new `pkg/sse/` package for handling server sent event reads, primarily, focused on proxying reads to a separate `io.Writer` while returning ane `*Event`: the caller can then consume the event for telemetry (i.e., the proxy can enqueue it for the worker pool to pick up) while the downstream client (i.e., the HTTP request writer) can get the stream verbatim from the source. This effectively implements a "Tee" shaped SSE reader which takes a `io.Reader` and `io.Writer` while still returning `*Event` on each `TeeReader.Next()` call.
* ✨ Proxy now uses new `pkg/sse/` package and `NewTeeReader` and `TeeReader.Next()` for iterating server sent events.
  * Includes new tests for SSE events in the proxy.

Fixes: https://github.com/papercomputeco/tapes/issues/71

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ❌ 1 failed · ▶️ 2 not started · ✅ 1 no changes — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fpapercomputeco%2Ftapes%2Fpull%2F78&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->