### PR TITLE
feat: add tabbed analytics and AI insights extraction

### DIFF
--- a/cmd/tapes/deck/deck.go
+++ b/cmd/tapes/deck/deck.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/papercomputeco/tapes/cmd/tapes/sqlitepath"
+	"github.com/papercomputeco/tapes/pkg/credentials"
 	"github.com/papercomputeco/tapes/pkg/deck"
 )
 
@@ -32,28 +33,34 @@ Examples:
   tapes deck --demo --overwrite
   tapes deck -m
   tapes deck -m -f
+  tapes deck --web --insights
+  tapes deck --web --insights --insights-provider anthropic
 `
 	deckShortDesc = "Deck - ROI dashboard for agent sessions"
 	sortDirDesc   = "desc"
 )
 
 type deckCommander struct {
-	sqlitePath  string
-	pricingPath string
-	since       string
-	from        string
-	to          string
-	sort        string
-	sortDir     string
-	model       string
-	status      string
-	project     string
-	session     string
-	refresh     uint
-	web         bool
-	port        int
-	demo        bool
-	overwrite   bool
+	sqlitePath       string
+	pricingPath      string
+	since            string
+	from             string
+	to               string
+	sort             string
+	sortDir          string
+	model            string
+	status           string
+	project          string
+	session          string
+	refresh          uint
+	web              bool
+	port             int
+	demo             bool
+	overwrite        bool
+	insights         bool
+	insightsModel    string
+	insightsProvider string
+	insightsKey      string
 }
 
 func NewDeckCmd() *cobra.Command {
@@ -85,6 +92,10 @@ func NewDeckCmd() *cobra.Command {
 	cmd.Flags().IntVar(&cmder.port, "port", 8888, "Web server port")
 	cmd.Flags().BoolVarP(&cmder.demo, "demo", "m", false, "Seed demo data and open the deck UI")
 	cmd.Flags().BoolVarP(&cmder.overwrite, "overwrite", "f", false, "Overwrite demo database before seeding (default for demo db)")
+	cmd.Flags().BoolVar(&cmder.insights, "insights", false, "Enable AI insights via LLM facet extraction")
+	cmd.Flags().StringVar(&cmder.insightsModel, "insights-model", "gpt-4o-mini", "Model for AI insights extraction")
+	cmd.Flags().StringVar(&cmder.insightsProvider, "insights-provider", "openai", "Provider for AI insights (openai|anthropic|ollama)")
+	cmd.Flags().StringVar(&cmder.insightsKey, "insights-key", "", "API key for AI insights provider")
 
 	return cmd
 }
@@ -129,8 +140,15 @@ func (c *deckCommander) run(ctx context.Context, cmd *cobra.Command) error {
 		return err
 	}
 
+	// Build facet deps — auto-enable when credentials are available
+	var facets *facetDeps
+	var facetWorker *deck.FacetWorker
+	var facetAnalyticsFunc func(context.Context) (*deck.FacetAnalytics, error)
+
+	facets, facetWorker, facetAnalyticsFunc = c.buildFacetDeps(cmd, query)
+
 	if c.web {
-		return runDeckWeb(ctx, query, filters, c.port)
+		return runDeckWeb(ctx, query, filters, c.port, facets)
 	}
 
 	refreshDuration, err := refreshDuration(c.refresh)
@@ -138,7 +156,51 @@ func (c *deckCommander) run(ctx context.Context, cmd *cobra.Command) error {
 		return err
 	}
 
-	return RunDeckTUI(ctx, query, filters, refreshDuration)
+	return RunDeckTUI(ctx, query, filters, refreshDuration, facetWorker, facetAnalyticsFunc)
+}
+
+// buildFacetDeps auto-detects API credentials and creates facet extraction
+// dependencies. Returns nil values if no credentials are available and
+// --insights was not explicitly set.
+func (c *deckCommander) buildFacetDeps(cmd *cobra.Command, query *deck.Query) (*facetDeps, *deck.FacetWorker, func(context.Context) (*deck.FacetAnalytics, error)) {
+	credMgr, err := credentials.NewManager("")
+	if err != nil {
+		credMgr = nil
+	}
+
+	cfg := deck.LLMCallerConfig{
+		Provider: c.insightsProvider,
+		Model:    c.insightsModel,
+		APIKey:   c.insightsKey,
+		CredMgr:  credMgr,
+	}
+
+	// If not explicitly enabled, check whether any API key can be resolved.
+	// Skip auto-enable if nothing is available — don't fall back to ollama silently.
+	if !c.insights {
+		if !deck.HasLLMCredentials(cfg) {
+			return nil, nil, nil
+		}
+	}
+
+	llmCaller, err := deck.NewLLMCaller(cfg)
+	if err != nil {
+		return nil, nil, nil
+	}
+
+	store := deck.NewEntFacetStore(query.EntClient())
+	extractor := deck.NewFacetExtractor(query, llmCaller, store)
+	worker := deck.NewFacetWorker(extractor, store, query)
+
+	fmt.Fprintf(cmd.OutOrStdout(), "AI insights enabled (%s/%s)\n", c.insightsProvider, c.insightsModel)
+
+	return &facetDeps{
+			extractor: extractor,
+			worker:    worker,
+			store:     store,
+		},
+		worker,
+		extractor.AggregateFacets
 }
 
 func refreshDuration(refresh uint) (time.Duration, error) {

--- a/pkg/deck/facets_llm.go
+++ b/pkg/deck/facets_llm.go
@@ -1,0 +1,383 @@
+package deck
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/papercomputeco/tapes/pkg/credentials"
+)
+
+const providerOllama = "ollama"
+
+// LLMCallerConfig holds configuration for creating an LLM caller.
+type LLMCallerConfig struct {
+	Provider string               // "openai", "anthropic", or "ollama"
+	Model    string               // e.g. "gpt-4o-mini", "claude-haiku-4-5-20251001"
+	APIKey   string               // explicit API key (highest priority)
+	BaseURL  string               // override base URL
+	CredMgr  *credentials.Manager // credentials from tapes auth
+}
+
+// HasLLMCredentials checks whether an API key can be resolved from the config
+// without creating a caller. Used for auto-enabling insights.
+func HasLLMCredentials(cfg LLMCallerConfig) bool {
+	if cfg.APIKey != "" {
+		return true
+	}
+	provider := strings.ToLower(cfg.Provider)
+	if provider == providerOllama {
+		return true
+	}
+	if cfg.CredMgr != nil {
+		if key := resolveAPIKeyFromCreds(cfg.CredMgr, provider); key != "" {
+			return true
+		}
+	}
+	if key := resolveAPIKeyFromEnv(provider); key != "" {
+		return true
+	}
+	return false
+}
+
+// NewLLMCaller creates a LLMCallFunc based on the provided configuration.
+// Resolution order for API key:
+//  1. Explicit APIKey in config
+//  2. credentials.Manager (from tapes auth)
+//  3. Environment variables (OPENAI_API_KEY / ANTHROPIC_API_KEY)
+//  4. Fall back to Ollama at localhost:11434
+func NewLLMCaller(cfg LLMCallerConfig) (LLMCallFunc, error) {
+	provider := strings.ToLower(cfg.Provider)
+	model := cfg.Model
+
+	// Resolve API key: explicit > tapes auth > env vars
+	apiKey := cfg.APIKey
+	if apiKey == "" && cfg.CredMgr != nil {
+		apiKey = resolveAPIKeyFromCreds(cfg.CredMgr, provider)
+	}
+	if apiKey == "" {
+		apiKey = resolveAPIKeyFromEnv(provider)
+	}
+
+	// If no key found and provider is not explicitly ollama, fall back to ollama
+	if apiKey == "" && provider != providerOllama {
+		log.Printf("facets: no API key found for %s, falling back to ollama", provider)
+		provider = providerOllama
+	}
+
+	switch provider {
+	case providerOpenAI, "":
+		if model == "" {
+			model = "gpt-4o-mini"
+		}
+		baseURL := cfg.BaseURL
+		if baseURL == "" {
+			baseURL = "https://api.openai.com"
+		}
+		return newOpenAICaller(apiKey, model, baseURL), nil
+
+	case providerAnthropic:
+		if model == "" {
+			model = "claude-haiku-4-5-20251001"
+		}
+		baseURL := cfg.BaseURL
+		if baseURL == "" {
+			baseURL = "https://api.anthropic.com"
+		}
+		return newAnthropicCaller(apiKey, model, baseURL), nil
+
+	case providerOllama:
+		if model == "" {
+			model = "llama3.2"
+		}
+		baseURL := cfg.BaseURL
+		if baseURL == "" {
+			baseURL = "http://localhost:11434"
+		}
+		return newOllamaCaller(model, baseURL), nil
+
+	default:
+		return nil, fmt.Errorf("unsupported provider: %s", provider)
+	}
+}
+
+func resolveAPIKeyFromCreds(mgr *credentials.Manager, provider string) string {
+	if mgr == nil {
+		return ""
+	}
+	key, err := mgr.GetKey(provider)
+	if err != nil || key != "" {
+		return key
+	}
+	// If provider-specific key not found, try others
+	if provider == providerOpenAI || provider == "" {
+		if key, err = mgr.GetKey(providerAnthropic); err == nil && key != "" {
+			return key
+		}
+	}
+	if provider == providerAnthropic {
+		if key, err = mgr.GetKey(providerOpenAI); err == nil && key != "" {
+			return key
+		}
+	}
+	return ""
+}
+
+func resolveAPIKeyFromEnv(provider string) string {
+	switch provider {
+	case providerAnthropic:
+		return os.Getenv("ANTHROPIC_API_KEY")
+	case providerOpenAI, "":
+		return os.Getenv("OPENAI_API_KEY")
+	default:
+		// Try both
+		if key := os.Getenv("OPENAI_API_KEY"); key != "" {
+			return key
+		}
+		return os.Getenv("ANTHROPIC_API_KEY")
+	}
+}
+
+// --- OpenAI caller ---
+
+type openAIRequest struct {
+	Model          string            `json:"model"`
+	Messages       []openAIMessage   `json:"messages"`
+	ResponseFormat *openAIRespFormat `json:"response_format,omitempty"`
+}
+
+type openAIMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type openAIRespFormat struct {
+	Type string `json:"type"`
+}
+
+type openAIResponse struct {
+	Choices []struct {
+		Message struct {
+			Content string `json:"content"`
+		} `json:"message"`
+	} `json:"choices"`
+	Error *struct {
+		Message string `json:"message"`
+	} `json:"error,omitempty"`
+}
+
+func newOpenAICaller(apiKey, model, baseURL string) LLMCallFunc {
+	return func(ctx context.Context, prompt string) (string, error) {
+		reqBody := openAIRequest{
+			Model: model,
+			Messages: []openAIMessage{
+				{Role: "user", Content: prompt},
+			},
+			ResponseFormat: &openAIRespFormat{Type: "json_object"},
+		}
+
+		data, err := json.Marshal(reqBody)
+		if err != nil {
+			return "", fmt.Errorf("marshal request: %w", err)
+		}
+
+		ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+"/v1/chat/completions", bytes.NewReader(data))
+		if err != nil {
+			return "", fmt.Errorf("create request: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return "", fmt.Errorf("openai request: %w", err)
+		}
+		defer resp.Body.Close()
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return "", fmt.Errorf("read response: %w", err)
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			return "", fmt.Errorf("openai API error (status %d): %s", resp.StatusCode, string(body))
+		}
+
+		var result openAIResponse
+		if err := json.Unmarshal(body, &result); err != nil {
+			return "", fmt.Errorf("unmarshal response: %w", err)
+		}
+
+		if result.Error != nil {
+			return "", fmt.Errorf("openai error: %s", result.Error.Message)
+		}
+
+		if len(result.Choices) == 0 {
+			return "", errors.New("openai returned no choices")
+		}
+
+		return result.Choices[0].Message.Content, nil
+	}
+}
+
+// --- Anthropic caller ---
+
+type anthropicRequest struct {
+	Model     string             `json:"model"`
+	MaxTokens int                `json:"max_tokens"`
+	Messages  []anthropicMessage `json:"messages"`
+}
+
+type anthropicMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type anthropicResponse struct {
+	Content []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	} `json:"content"`
+	Error *struct {
+		Message string `json:"message"`
+	} `json:"error,omitempty"`
+}
+
+func newAnthropicCaller(apiKey, model, baseURL string) LLMCallFunc {
+	return func(ctx context.Context, prompt string) (string, error) {
+		reqBody := anthropicRequest{
+			Model:     model,
+			MaxTokens: 1024,
+			Messages: []anthropicMessage{
+				{Role: "user", Content: prompt + "\n\nReturn ONLY valid JSON, no markdown or extra text."},
+			},
+		}
+
+		data, err := json.Marshal(reqBody)
+		if err != nil {
+			return "", fmt.Errorf("marshal request: %w", err)
+		}
+
+		ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+"/v1/messages", bytes.NewReader(data))
+		if err != nil {
+			return "", fmt.Errorf("create request: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("x-api-key", apiKey)
+		req.Header.Set("anthropic-version", "2023-06-01")
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return "", fmt.Errorf("anthropic request: %w", err)
+		}
+		defer resp.Body.Close()
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return "", fmt.Errorf("read response: %w", err)
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			return "", fmt.Errorf("anthropic API error (status %d): %s", resp.StatusCode, string(body))
+		}
+
+		var result anthropicResponse
+		if err := json.Unmarshal(body, &result); err != nil {
+			return "", fmt.Errorf("unmarshal response: %w", err)
+		}
+
+		if result.Error != nil {
+			return "", fmt.Errorf("anthropic error: %s", result.Error.Message)
+		}
+
+		if len(result.Content) == 0 {
+			return "", errors.New("anthropic returned no content")
+		}
+
+		return result.Content[0].Text, nil
+	}
+}
+
+// --- Ollama caller ---
+
+type ollamaChatRequest struct {
+	Model    string              `json:"model"`
+	Messages []ollamaChatMessage `json:"messages"`
+	Stream   bool                `json:"stream"`
+	Format   string              `json:"format"`
+}
+
+type ollamaChatMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type ollamaChatResponse struct {
+	Message struct {
+		Content string `json:"content"`
+	} `json:"message"`
+	Done bool `json:"done"`
+}
+
+func newOllamaCaller(model, baseURL string) LLMCallFunc {
+	return func(ctx context.Context, prompt string) (string, error) {
+		reqBody := ollamaChatRequest{
+			Model: model,
+			Messages: []ollamaChatMessage{
+				{Role: "user", Content: prompt},
+			},
+			Stream: false,
+			Format: "json",
+		}
+
+		data, err := json.Marshal(reqBody)
+		if err != nil {
+			return "", fmt.Errorf("marshal request: %w", err)
+		}
+
+		ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+"/api/chat", bytes.NewReader(data))
+		if err != nil {
+			return "", fmt.Errorf("create request: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return "", fmt.Errorf("ollama request: %w", err)
+		}
+		defer resp.Body.Close()
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return "", fmt.Errorf("read response: %w", err)
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			return "", fmt.Errorf("ollama API error (status %d): %s", resp.StatusCode, string(body))
+		}
+
+		var result ollamaChatResponse
+		if err := json.Unmarshal(body, &result); err != nil {
+			return "", fmt.Errorf("unmarshal response: %w", err)
+		}
+
+		return result.Message.Content, nil
+	}
+}

--- a/pkg/deck/facets_llm_test.go
+++ b/pkg/deck/facets_llm_test.go
@@ -1,0 +1,168 @@
+package deck
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("NewLLMCaller", func() {
+	It("returns an ollama caller when no key is available", func() {
+		cfg := LLMCallerConfig{
+			Provider: "openai",
+			Model:    "gpt-4o-mini",
+			APIKey:   "", // no key
+		}
+		caller, err := NewLLMCaller(cfg)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(caller).NotTo(BeNil())
+	})
+
+	It("returns an error for unsupported provider", func() {
+		cfg := LLMCallerConfig{
+			Provider: "unsupported",
+			APIKey:   "key",
+		}
+		_, err := NewLLMCaller(cfg)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("unsupported provider"))
+	})
+
+	It("creates an openai caller with explicit key", func() {
+		cfg := LLMCallerConfig{
+			Provider: "openai",
+			Model:    "gpt-4o-mini",
+			APIKey:   "test-key",
+		}
+		caller, err := NewLLMCaller(cfg)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(caller).NotTo(BeNil())
+	})
+
+	It("creates an anthropic caller with explicit key", func() {
+		cfg := LLMCallerConfig{
+			Provider: "anthropic",
+			Model:    "claude-haiku-4-5-20251001",
+			APIKey:   "test-key",
+		}
+		caller, err := NewLLMCaller(cfg)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(caller).NotTo(BeNil())
+	})
+
+	It("creates an ollama caller explicitly", func() {
+		cfg := LLMCallerConfig{
+			Provider: "ollama",
+			Model:    "llama3.2",
+		}
+		caller, err := NewLLMCaller(cfg)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(caller).NotTo(BeNil())
+	})
+})
+
+var _ = Describe("OpenAI caller", func() {
+	It("calls the OpenAI API and returns response content", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Expect(r.URL.Path).To(Equal("/v1/chat/completions"))
+			Expect(r.Header.Get("Authorization")).To(Equal("Bearer test-key"))
+			Expect(r.Header.Get("Content-Type")).To(Equal("application/json"))
+
+			var req openAIRequest
+			err := json.NewDecoder(r.Body).Decode(&req)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(req.Model).To(Equal("gpt-4o-mini"))
+			Expect(req.ResponseFormat).NotTo(BeNil())
+			Expect(req.ResponseFormat.Type).To(Equal("json_object"))
+
+			resp := openAIResponse{
+				Choices: []struct {
+					Message struct {
+						Content string `json:"content"`
+					} `json:"message"`
+				}{
+					{Message: struct {
+						Content string `json:"content"`
+					}{Content: `{"goal_category":"fix_bug"}`}},
+				},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(resp)
+		}))
+		defer server.Close()
+
+		caller := newOpenAICaller("test-key", "gpt-4o-mini", server.URL)
+		result, err := caller(context.Background(), "test prompt")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(ContainSubstring("fix_bug"))
+	})
+
+	It("returns error on non-200 status", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+			w.Write([]byte(`{"error":{"message":"invalid key"}}`))
+		}))
+		defer server.Close()
+
+		caller := newOpenAICaller("bad-key", "gpt-4o-mini", server.URL)
+		_, err := caller(context.Background(), "test prompt")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("status 401"))
+	})
+})
+
+var _ = Describe("Anthropic caller", func() {
+	It("calls the Anthropic API and returns response content", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Expect(r.URL.Path).To(Equal("/v1/messages"))
+			Expect(r.Header.Get("x-api-key")).To(Equal("test-key"))
+			Expect(r.Header.Get("anthropic-version")).To(Equal("2023-06-01"))
+
+			resp := anthropicResponse{
+				Content: []struct {
+					Type string `json:"type"`
+					Text string `json:"text"`
+				}{
+					{Type: "text", Text: `{"goal_category":"implement_feature"}`},
+				},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(resp)
+		}))
+		defer server.Close()
+
+		caller := newAnthropicCaller("test-key", "claude-haiku-4-5-20251001", server.URL)
+		result, err := caller(context.Background(), "test prompt")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(ContainSubstring("implement_feature"))
+	})
+})
+
+var _ = Describe("Ollama caller", func() {
+	It("calls the Ollama API and returns response content", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			Expect(r.URL.Path).To(Equal("/api/chat"))
+
+			var req ollamaChatRequest
+			err := json.NewDecoder(r.Body).Decode(&req)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(req.Stream).To(BeFalse())
+			Expect(req.Format).To(Equal("json"))
+
+			resp := ollamaChatResponse{Done: true}
+			resp.Message.Content = `{"goal_category":"refactor_code"}`
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(resp)
+		}))
+		defer server.Close()
+
+		caller := newOllamaCaller("llama3.2", server.URL)
+		result, err := caller(context.Background(), "test prompt")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(ContainSubstring("refactor_code"))
+	})
+})

--- a/pkg/deck/facets_worker.go
+++ b/pkg/deck/facets_worker.go
@@ -1,0 +1,95 @@
+package deck
+
+import (
+	"context"
+	"log"
+	"sync"
+	"sync/atomic"
+)
+
+// FacetWorker processes sessions in the background to extract facets.
+type FacetWorker struct {
+	extractor *FacetExtractor
+	store     FacetStore
+	query     Querier
+
+	done  atomic.Int64
+	total atomic.Int64
+}
+
+// NewFacetWorker creates a new FacetWorker.
+func NewFacetWorker(extractor *FacetExtractor, store FacetStore, query Querier) *FacetWorker {
+	return &FacetWorker{
+		extractor: extractor,
+		store:     store,
+		query:     query,
+	}
+}
+
+// Progress returns the number of sessions processed and total to process.
+func (w *FacetWorker) Progress() (done, total int) {
+	return int(w.done.Load()), int(w.total.Load())
+}
+
+// Run starts background facet extraction. It queries all sessions, skips those
+// with existing facets, and processes the rest with bounded concurrency.
+// It blocks until all sessions are processed or the context is cancelled.
+func (w *FacetWorker) Run(ctx context.Context) {
+	filters := Filters{Sort: "time", SortDir: "desc"}
+	overview, err := w.query.Overview(ctx, filters)
+	if err != nil {
+		log.Printf("facets worker: failed to load sessions: %v", err)
+		return
+	}
+
+	// Collect session IDs that need processing
+	var pending []string
+	for _, session := range overview.Sessions {
+		if ctx.Err() != nil {
+			return
+		}
+		_, err := w.store.GetFacet(ctx, session.ID)
+		if err == nil {
+			// Already has facets
+			continue
+		}
+		pending = append(pending, session.ID)
+	}
+
+	w.total.Store(int64(len(pending)))
+	w.done.Store(0)
+
+	if len(pending) == 0 {
+		return
+	}
+
+	// Process with bounded concurrency (2 workers to avoid rate limits)
+	const maxConcurrency = 2
+	sem := make(chan struct{}, maxConcurrency)
+	var wg sync.WaitGroup
+
+	for _, sessionID := range pending {
+		if ctx.Err() != nil {
+			break
+		}
+
+		sem <- struct{}{}
+		wg.Add(1)
+		go func(sid string) {
+			defer wg.Done()
+			defer func() { <-sem }()
+
+			if ctx.Err() != nil {
+				return
+			}
+
+			_, err := w.extractor.Extract(ctx, sid)
+			if err != nil {
+				log.Printf("facets worker: extraction failed for session %s: %v", sid, err)
+			}
+			w.done.Add(1)
+		}(sessionID)
+	}
+
+	wg.Wait()
+}

--- a/pkg/deck/facets_worker_test.go
+++ b/pkg/deck/facets_worker_test.go
@@ -1,0 +1,156 @@
+package deck
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// memoryFacetStore is an in-memory FacetStore for testing.
+type memoryFacetStore struct {
+	mu     sync.Mutex
+	facets map[string]*SessionFacet
+}
+
+func newMemoryFacetStore() *memoryFacetStore {
+	return &memoryFacetStore{facets: map[string]*SessionFacet{}}
+}
+
+func (s *memoryFacetStore) SaveFacet(_ context.Context, f *SessionFacet) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.facets[f.SessionID] = f
+	return nil
+}
+
+func (s *memoryFacetStore) GetFacet(_ context.Context, sessionID string) (*SessionFacet, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if f, ok := s.facets[sessionID]; ok {
+		return f, nil
+	}
+	return nil, errors.New("not found")
+}
+
+func (s *memoryFacetStore) ListFacets(_ context.Context) ([]*SessionFacet, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	result := make([]*SessionFacet, 0, len(s.facets))
+	for _, f := range s.facets {
+		result = append(result, f)
+	}
+	return result, nil
+}
+
+// mockQuerierWithSessions returns an overview with the given session IDs.
+type mockQuerierWithSessions struct {
+	mockQuerier
+	sessions []SessionSummary
+}
+
+func (m *mockQuerierWithSessions) Overview(_ context.Context, _ Filters) (*Overview, error) {
+	return &Overview{Sessions: m.sessions}, nil
+}
+
+var _ = Describe("FacetWorker", func() {
+	It("processes sessions that have no existing facets", func() {
+		store := newMemoryFacetStore()
+
+		sessions := []SessionSummary{
+			{ID: "s1", Label: "Fix bug"},
+			{ID: "s2", Label: "Add feature"},
+			{ID: "s3", Label: "Refactor"},
+		}
+
+		// Pre-fill one session
+		store.facets["s2"] = &SessionFacet{SessionID: "s2", GoalCategory: "implement_feature"}
+
+		detail := &SessionDetail{
+			Summary:  SessionSummary{ID: "test"},
+			Messages: []SessionMessage{{Role: "user", Text: "test"}},
+		}
+
+		mockLLM := func(_ context.Context, _ string) (string, error) {
+			return `{
+				"underlying_goal": "test goal",
+				"goal_category": "fix_bug",
+				"outcome": "fully_achieved",
+				"session_type": "single_task",
+				"friction_types": [],
+				"brief_summary": "test summary"
+			}`, nil
+		}
+
+		querier := &mockQuerierWithSessions{
+			mockQuerier: mockQuerier{detail: detail},
+			sessions:    sessions,
+		}
+
+		extractor := NewFacetExtractor(querier, mockLLM, store)
+		worker := NewFacetWorker(extractor, store, querier)
+
+		worker.Run(context.Background())
+
+		done, total := worker.Progress()
+		Expect(total).To(Equal(2)) // s1 and s3 needed processing, s2 was skipped
+		Expect(done).To(Equal(2))
+
+		// All sessions should now have facets
+		_, err := store.GetFacet(context.Background(), "s1")
+		Expect(err).NotTo(HaveOccurred())
+		_, err = store.GetFacet(context.Background(), "s2")
+		Expect(err).NotTo(HaveOccurred())
+		_, err = store.GetFacet(context.Background(), "s3")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("reports zero progress with no sessions", func() {
+		store := newMemoryFacetStore()
+		querier := &mockQuerierWithSessions{sessions: nil}
+		extractor := NewFacetExtractor(querier, nil, store)
+		worker := NewFacetWorker(extractor, store, querier)
+
+		worker.Run(context.Background())
+
+		done, total := worker.Progress()
+		Expect(total).To(Equal(0))
+		Expect(done).To(Equal(0))
+	})
+
+	It("respects context cancellation", func() {
+		store := newMemoryFacetStore()
+		sessions := make([]SessionSummary, 50)
+		for i := range sessions {
+			sessions[i] = SessionSummary{ID: fmt.Sprintf("s%d", i)}
+		}
+
+		detail := &SessionDetail{
+			Messages: []SessionMessage{{Role: "user", Text: "test"}},
+		}
+
+		// Slow LLM to ensure cancellation kicks in
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // Cancel immediately
+
+		mockLLM := func(ctx context.Context, _ string) (string, error) {
+			return `{"underlying_goal":"t","goal_category":"fix_bug","outcome":"fully_achieved","session_type":"single_task","friction_types":[],"brief_summary":"t"}`, ctx.Err()
+		}
+
+		querier := &mockQuerierWithSessions{
+			mockQuerier: mockQuerier{detail: detail},
+			sessions:    sessions,
+		}
+		extractor := NewFacetExtractor(querier, mockLLM, store)
+		worker := NewFacetWorker(extractor, store, querier)
+
+		worker.Run(ctx)
+
+		// Should have processed very few or no sessions due to immediate cancellation
+		done, _ := worker.Progress()
+		Expect(done).To(BeNumerically("<", 50))
+	})
+})

--- a/pkg/deck/query.go
+++ b/pkg/deck/query.go
@@ -38,6 +38,12 @@ type Query struct {
 // Ensure Query implements Querier
 var _ Querier = (*Query)(nil)
 
+// EntClient returns the underlying ent client for use by subsystems
+// like the facet store.
+func (q *Query) EntClient() *ent.Client {
+	return q.client
+}
+
 func NewQuery(ctx context.Context, dbPath string, pricing PricingTable) (*Query, func() error, error) {
 	driver, err := sqlite.NewDriver(ctx, dbPath)
 	if err != nil {

--- a/web/deck/deck.css
+++ b/web/deck/deck.css
@@ -926,6 +926,42 @@ body {
   overflow: auto;
 }
 
+/* ── Analytics tabs ── */
+.analytics-tabs {
+  display: flex;
+  gap: 0;
+  padding: 0 24px;
+  border-bottom: 1px solid var(--border);
+}
+
+.analytics-tab {
+  border: none;
+  border-bottom: 2px solid transparent;
+  background: transparent;
+  color: var(--muted);
+  padding: 10px 16px;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.analytics-tab:hover {
+  color: var(--text);
+}
+
+.analytics-tab--active {
+  color: var(--text-bright);
+  border-bottom-color: var(--primary);
+}
+
+.analytics-tab-panel[hidden] {
+  display: none;
+}
+
 /* ── Analytics panels ── */
 .analytics-summary {
   display: grid;
@@ -982,6 +1018,83 @@ body {
 
 @keyframes spin {
   to { transform: rotate(360deg); }
+}
+
+/* ── Skeleton loading ── */
+@keyframes shimmer {
+  0% { background-position: -200% 0; }
+  100% { background-position: 200% 0; }
+}
+
+.skeleton {
+  background: linear-gradient(90deg, var(--border) 25%, transparent 50%, var(--border) 75%);
+  background-size: 200% 100%;
+  animation: shimmer 1.5s ease-in-out infinite;
+  border-radius: 2px;
+}
+
+.skeleton-metric {
+  border: 1px solid var(--border);
+  padding: 16px;
+}
+
+.skeleton-metric__label {
+  width: 80px;
+  height: 9px;
+  margin-bottom: 12px;
+}
+
+.skeleton-metric__value {
+  width: 60%;
+  height: 22px;
+}
+
+.skeleton-row {
+  display: flex;
+  gap: 8px;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.skeleton-row__cell {
+  height: 12px;
+  flex: 1;
+}
+
+.skeleton-row__cell--sm { flex: 0.4; }
+.skeleton-row__cell--md { flex: 0.7; }
+
+.skeleton-bar {
+  margin-bottom: 12px;
+}
+
+.skeleton-bar__label {
+  width: 60%;
+  height: 10px;
+  margin-bottom: 6px;
+}
+
+.skeleton-bar__track {
+  width: 100%;
+  height: 8px;
+}
+
+.loading-spinner {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 16px 0;
+  color: var(--muted);
+  font-size: 11px;
+}
+
+.loading-spinner__dot {
+  width: 12px;
+  height: 12px;
+  border: 2px solid var(--border);
+  border-top-color: var(--green);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
 }
 
 /* ── Heatmap ── */
@@ -1320,10 +1433,19 @@ body {
 /* ── Histogram ── */
 .histogram__row {
   display: grid;
-  grid-template-columns: 90px 1fr 40px;
+  grid-template-columns: 120px 1fr 40px;
   gap: 8px;
   align-items: center;
   margin-bottom: 8px;
+}
+
+.histogram__desc {
+  grid-column: 1 / -1;
+  font-size: 9px;
+  color: var(--muted);
+  margin-top: -4px;
+  margin-bottom: 4px;
+  padding-left: 128px;
 }
 
 .histogram__label {
@@ -1348,6 +1470,17 @@ body {
 .histogram__count {
   font-size: 11px;
   font-weight: 600;
+  color: var(--text-bright);
+}
+
+.histogram__toggle {
+  font-size: 10px;
+  color: var(--muted);
+  cursor: pointer;
+  padding: 4px 0;
+  text-align: right;
+}
+.histogram__toggle:hover {
   color: var(--text-bright);
 }
 
@@ -1408,8 +1541,17 @@ body {
 
 .provider__legend-item {
   display: flex;
-  align-items: center;
+  align-items: baseline;
   gap: 6px;
+  flex-wrap: wrap;
+}
+
+.legend__desc {
+  font-size: 9px;
+  color: var(--muted);
+  width: 100%;
+  padding-left: 14px;
+  margin-top: -2px;
 }
 
 .provider__dot {
@@ -1440,6 +1582,12 @@ body {
 .friction-item__label {
   color: var(--text);
   text-transform: capitalize;
+}
+
+.friction-item__desc {
+  font-size: 9px;
+  color: var(--muted);
+  margin-left: auto;
 }
 
 /* ── Summary cards ── */
@@ -1550,6 +1698,16 @@ body {
 
   .metric__value {
     font-size: 20px;
+  }
+
+  .analytics-tabs {
+    padding: 0 16px;
+    overflow-x: auto;
+  }
+
+  .analytics-tab {
+    padding: 8px 10px;
+    font-size: 9px;
   }
 
   .charts {

--- a/web/deck/index.html
+++ b/web/deck/index.html
@@ -137,6 +137,14 @@
         <div id="analytics-content">
         <section class="analytics-summary" id="analytics-summary"></section>
 
+        <div class="analytics-tabs" id="analytics-tabs">
+          <button class="analytics-tab analytics-tab--active" data-tab="activity" type="button">activity</button>
+          <button class="analytics-tab" data-tab="distribution" type="button">distribution + models</button>
+          <button class="analytics-tab" data-tab="insights" type="button">ai insights</button>
+          <button class="analytics-tab" data-tab="summaries" type="button">summaries</button>
+        </div>
+
+        <div class="analytics-tab-panel" id="tab-activity">
         <section class="analytics-panels">
           <div class="analytics-panel">
             <div class="section-header">
@@ -167,7 +175,9 @@
             <div class="day-detail__sessions" id="day-detail-sessions"></div>
           </div>
         </section>
+        </div>
 
+        <div class="analytics-tab-panel" id="tab-distribution" hidden>
         <section class="analytics-panels">
           <div class="analytics-panel">
             <div class="section-header">
@@ -184,7 +194,6 @@
             <div class="histogram" id="analytics-cost"></div>
           </div>
         </section>
-
         <section class="analytics-panels">
           <div class="analytics-panel analytics-panel--wide">
             <div class="section-header">
@@ -201,8 +210,10 @@
             <div id="analytics-providers"></div>
           </div>
         </section>
+        </div>
 
-        <section class="analytics-insights" id="analytics-insights" hidden>
+        <div class="analytics-tab-panel" id="tab-insights" hidden>
+        <section class="analytics-insights" id="analytics-insights">
           <div class="section-header">
             <span class="section-header__label">ai insights</span>
             <div class="section-header__line"></div>
@@ -239,14 +250,19 @@
               <div id="insights-types"></div>
             </div>
           </div>
-          <div class="analytics-panel analytics-panel--full">
-            <div class="section-header">
-              <span class="section-header__label">recent summaries</span>
-              <div class="section-header__line"></div>
-            </div>
-            <div id="insights-summaries"></div>
-          </div>
         </section>
+        </div>
+
+        <div class="analytics-tab-panel" id="tab-summaries" hidden>
+        <section class="analytics-insights" id="analytics-summaries-section">
+          <div class="section-header">
+            <span class="section-header__label">recent summaries</span>
+            <div class="section-header__line"></div>
+          </div>
+          <div id="insights-summaries"></div>
+        </section>
+        </div>
+
         </div><!-- analytics-content -->
       </main>
 


### PR DESCRIPTION
## Summary

closes #94

![tapesdeck](https://github.com/user-attachments/assets/82fd398f-b8b7-4801-afcb-8e176f8a7edc)

- Adds tabbed navigation to analytics in both TUI and web dashboard (Activity, Distribution + Models, AI Insights, Summaries)
- Prevents page jumps on analytics refresh by preserving scroll position
- TUI: tab/shift+tab switching, pinned footer, scrollable summaries with cursor navigation, context-sensitive hints
- Web: matching tab UI with skeleton loading placeholders for perceived performance
- Reversed day selection so key 1 = most recent day, 9 = oldest
- Adds LLM-based facet extraction with configurable providers and background worker processing

## Test plan

- [x] Run `tapes deck` and verify tab switching with tab/shift+tab
- [x] Verify analytics refresh preserves scroll position
- [x] Test day selection 1-9 on activity tab in TUI
- [x] Test summaries tab scrolling with j/k navigation
- [ ] Run `tapes deck --web` and verify web tab UI and skeleton loading
- [ ] Verify facet extraction worker processes sessions
- [ ] Run `make test` for new facets_llm and facets_worker tests

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ✅ 3 no changes — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fpapercomputeco%2Ftapes%2Fpull%2F99&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->