### PR TITLE
feat: CI/CD - Go mod tidy checker

### DIFF
--- a/.dagger/tidy.go
+++ b/.dagger/tidy.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"dagger/tapes/internal/dagger"
+)
+
+// CheckGoModTidy runs "go mod tidy" and fails if it produces any changes to
+// go.mod or go.sum, indicating that the caller forgot to tidy before committing.
+func (t *Tapes) CheckGoModTidy(ctx context.Context) (string, error) {
+	out, err := t.goContainer().
+		WithExec([]string{"cp", "go.mod", "go.mod.HEAD"}).
+		WithExec([]string{"cp", "go.sum", "go.sum.HEAD"}).
+		WithExec([]string{"go", "mod", "tidy"}).
+		WithExec([]string{
+			"sh", "-c",
+			"diff -u go.mod.HEAD go.mod && diff -u go.sum.HEAD go.sum",
+		}).
+		Stdout(ctx)
+
+	var e *dagger.ExecError
+	if errors.As(err, &e) {
+		return "", fmt.Errorf(
+			"go.mod or go.sum are not tidy: run 'go mod tidy' and commit the changes\n\n%s",
+			e.Stdout,
+		)
+	} else if err != nil {
+		return "", fmt.Errorf("unexpected error: %w", err)
+	}
+
+	return fmt.Sprintf("go.mod and go.sum are tidy: %s", out), nil
+}

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/onsi/gomega v1.39.0
 	github.com/spf13/cobra v1.10.2
 	go.uber.org/zap v1.27.1
+	golang.org/x/term v0.40.0
 )
 
 require (
@@ -67,7 +68,6 @@ require (
 	golang.org/x/oauth2 v0.30.0 // indirect
 	golang.org/x/sync v0.17.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect
-	golang.org/x/term v0.40.0 // indirect
 	golang.org/x/text v0.30.0 // indirect
 	golang.org/x/tools v0.38.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -117,8 +117,6 @@ github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
-github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onsi/ginkgo/v2 v2.27.4 h1:fcEcQW/A++6aZAZQNUmNjvA9PSOzefMJBerHJ4t8v8Y=
 github.com/onsi/ginkgo/v2 v2.27.4/go.mod h1:ArE1D/XhNXBXCBkKOLkbsb2c81dQHCRcF5zwn/ykDRo=
 github.com/onsi/gomega v1.39.0 h1:y2ROC3hKFmQZJNFeGAMeHZKkjBL65mIZcvrLQBF9k6Q=
@@ -181,8 +179,6 @@ golang.org/x/sync v0.17.0 h1:l60nONMj9l5drqw6jlhIELNv9I0A4OFgRsG9k2oT9Ug=
 golang.org/x/sync v0.17.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.37.0 h1:fdNQudmxPjkdUTPnLn5mdQv7Zwvbvpaxqs831goi9kQ=
-golang.org/x/sys v0.37.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=
 golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/term v0.40.0 h1:36e4zGLqU4yhjlmxEaagx2KuYbJq3EwY8K943ZsHcvg=

--- a/makefile
+++ b/makefile
@@ -15,6 +15,11 @@ check: ## Runs golangci-lint check. Auto-fixes are not automatically applied.
 	$(call print-target)
 	dagger call check-lint
 
+.PHONY: tidy-check
+tidy-check: ## Checks that go.mod and go.sum are tidy. Fails if "go mod tidy" would produce changes.
+	$(call print-target)
+	dagger call check-go-mod-tidy
+
 .PHONY: format
 format: ## Runs golangci-lint linters and formatters with auto-fixes applied.
 	$(call print-target)


### PR DESCRIPTION
* 🧹 A dagger check for Go mod tidy-ness: checks that `go.mod` and `go.sum` don't drift

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ✅ 3 no changes — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fpapercomputeco%2Ftapes%2Fpull%2F100&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->