### PR TITLE
fix(dagger): register `goModTidy` as a dagger check

### DIFF
--- a/.dagger/tidy.go
+++ b/.dagger/tidy.go
@@ -10,6 +10,8 @@ import (
 
 // CheckGoModTidy runs "go mod tidy" and fails if it produces any changes to
 // go.mod or go.sum, indicating that the caller forgot to tidy before committing.
+//
+// +check
 func (t *Tapes) CheckGoModTidy(ctx context.Context) (string, error) {
 	out, err := t.goContainer().
 		WithExec([]string{"cp", "go.mod", "go.mod.HEAD"}).


### PR DESCRIPTION
In order for that Dagger function to be recognized as a Check, a [`+check` pragma was missing](https://docs.dagger.io/core-concepts/checks/#creating-checks).

Let's see if this is the proper fix (should be). How to test: `dagger check -l`, and the function should appear.

This will also allow the GitHub app to catch it and run it

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ✅ 3 no changes — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fpapercomputeco%2Ftapes%2Fpull%2F101&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->