### PR TITLE
fix: add newline to root command failure message

### DIFF
--- a/cli/tapes/main.go
+++ b/cli/tapes/main.go
@@ -11,7 +11,7 @@ func main() {
 	cmd := tapescmder.NewTapesCmd()
 	err := cmd.Execute()
 	if err != nil {
-		fmt.Printf("Error executing root command: %v", err)
+		fmt.Printf("Error executing root command: %v\n", err)
 		os.Exit(1)
 	}
 }

--- a/cli/tapesapi/main.go
+++ b/cli/tapesapi/main.go
@@ -16,7 +16,7 @@ func main() {
 
 	err := cmd.Execute()
 	if err != nil {
-		fmt.Printf("Error executing root command: %v", err)
+		fmt.Printf("Error executing root command: %v\n", err)
 		os.Exit(1)
 	}
 }

--- a/cli/tapesprox/main.go
+++ b/cli/tapesprox/main.go
@@ -16,7 +16,7 @@ func main() {
 
 	err := cmd.Execute()
 	if err != nil {
-		fmt.Printf("Error executing root command: %v", err)
+		fmt.Printf("Error executing root command: %v\n", err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
This may be a subjective style preference, but the last line of output doesn't include a newline.

Before fix:
```
m4air:tapes glenn$ ./build/tapes start codex
Error: no OpenAI API key found — run 'tapes auth openai' with a service account key first
Usage:
  tapes start [agent] [flags]

<truncated>

Error executing root command: no OpenAI API key found — run 'tapes auth openai' with a service account key firstm4air:tapes glenn$
```

After fix:
```
m4air:tapes glenn$ ./build/tapes start codex
Error: no OpenAI API key found — run 'tapes auth openai' with a service account key first
Usage:
  tapes start [agent] [flags]

<truncated>

Error executing root command: no OpenAI API key found — run 'tapes auth openai' with a service account key first
m4air:tapes glenn$
```

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ✅ 2 no changes — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fpapercomputeco%2Ftapes%2Fpull%2F107&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->