### PR TITLE
fix: capture stop_reason from Anthropic streaming responses

### DIFF
--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -652,7 +652,7 @@ var _ = Describe("reconstructStreamedResponse", func() {
 			[]byte(`{"model":"test-model","message":{"role":"assistant","content":""},"done":true,"done_reason":"stop","prompt_eval_count":10,"eval_count":5}`),
 		}
 
-		resp := p.reconstructStreamedResponse(chunks, "Hello", &llm.Usage{}, p.defaultProv)
+		resp := p.reconstructStreamedResponse(chunks, "Hello", &llm.Usage{}, &streamMeta{}, p.defaultProv)
 		Expect(resp).NotTo(BeNil())
 		Expect(resp.Message.GetText()).To(Equal("Hello"))
 		Expect(resp.Done).To(BeTrue())
@@ -665,7 +665,7 @@ var _ = Describe("reconstructStreamedResponse", func() {
 			[]byte(`{"model":"test-model","message":{"role":"assistant","content":""},"done":true,"done_reason":"stop"}`),
 		}
 
-		resp := p.reconstructStreamedResponse(chunks, "partial content here", &llm.Usage{}, p.defaultProv)
+		resp := p.reconstructStreamedResponse(chunks, "partial content here", &llm.Usage{}, &streamMeta{}, p.defaultProv)
 		Expect(resp).NotTo(BeNil())
 		Expect(resp.Message.GetText()).To(Equal("partial content here"))
 	})
@@ -676,7 +676,7 @@ var _ = Describe("reconstructStreamedResponse", func() {
 			[]byte(`also-not-json`),
 		}
 
-		resp := p.reconstructStreamedResponse(chunks, "fallback content", &llm.Usage{}, p.defaultProv)
+		resp := p.reconstructStreamedResponse(chunks, "fallback content", &llm.Usage{}, &streamMeta{}, p.defaultProv)
 		Expect(resp).NotTo(BeNil())
 		Expect(resp.Message.GetText()).To(Equal("fallback content"))
 		Expect(resp.Done).To(BeTrue())
@@ -684,7 +684,7 @@ var _ = Describe("reconstructStreamedResponse", func() {
 	})
 
 	It("returns nil when there are no chunks and no content", func() {
-		resp := p.reconstructStreamedResponse(nil, "", &llm.Usage{}, p.defaultProv)
+		resp := p.reconstructStreamedResponse(nil, "", &llm.Usage{}, &streamMeta{}, p.defaultProv)
 		Expect(resp).To(BeNil())
 	})
 
@@ -692,7 +692,7 @@ var _ = Describe("reconstructStreamedResponse", func() {
 		chunks := [][]byte{
 			[]byte(`not-json`),
 		}
-		resp := p.reconstructStreamedResponse(chunks, "", &llm.Usage{}, p.defaultProv)
+		resp := p.reconstructStreamedResponse(chunks, "", &llm.Usage{}, &streamMeta{}, p.defaultProv)
 		Expect(resp).To(BeNil())
 	})
 })


### PR DESCRIPTION
## Summary

Fixes `stop_reason` and token usage always being empty/NULL for Anthropic streaming responses. Anthropic sends these values across separate SSE events (`message_start` for input tokens, `message_delta` for output tokens and stop reason) rather than in the final chunk, so they were never captured.

## Changes

- Adds `streamMeta` struct to accumulate metadata (stop reason) from SSE events alongside existing `llm.Usage` accumulation
- Extracts `delta.stop_reason` from Anthropic `message_delta` events in `extractUsageFromSSE`
- Passes accumulated stop reason through `enqueueStreamedResponse` → `reconstructStreamedResponse` to the final stored response
- Applies to both SSE and NDJSON stream paths for consistency

## Verified

Confirmed working against live Anthropic streaming session — database now shows `stop_reason` (`end_turn`, `tool_use`), `prompt_tokens`, `completion_tokens`, and cache token counts populated on response nodes.

## Note

The `$0.00` cost display is a separate issue from token capture. Token data is now in the database; cost calculation is a presentation-layer concern.

## Test Plan

- [x] Existing unit tests updated and passing
- [x] New test for `stop_reason` extraction from `message_delta`
- [x] Verified against live session in local database

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ✅ 3 no changes — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fpapercomputeco%2Ftapes%2Fpull%2F111&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->