### PR TITLE
fix: ignore .humanlayer dotfiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@
 
 # JetBrains IDEs
 .idea/
+
+# HumanLayer
+.humanlayer/

--- a/.humanlayer/tasks/sqlite-tests
+++ b/.humanlayer/tasks/sqlite-tests
@@ -1,1 +1,0 @@
-/Users/briandouglas/.humanlayer/riptide/artifacts/019c5900-e629-7510-b3af-87222bd16e37


### PR DESCRIPTION
## Summary

- Removes `.humanlayer/` directory from git tracking
- Adds `.humanlayer/` to `.gitignore`

Closes #116

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ✅ 3 no changes — [View all](https://hub.continue.dev/inbox/pr/papercomputeco/tapes/117?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->