### PR TITLE
fix: wire project resolution into tapes start command

### DIFF
--- a/cmd/tapes/serve/proxy/proxy.go
+++ b/cmd/tapes/serve/proxy/proxy.go
@@ -99,7 +99,7 @@ func NewProxyCmd() *cobra.Command {
 				cmder.project = cfg.Proxy.Project
 			}
 			if cmder.project == "" {
-				cmder.project = git.RepoName()
+				cmder.project = git.RepoName(cmd.Context())
 			}
 			return nil
 		},

--- a/cmd/tapes/serve/serve.go
+++ b/cmd/tapes/serve/serve.go
@@ -133,7 +133,7 @@ func NewServeCmd() *cobra.Command {
 				cmder.project = cfg.Proxy.Project
 			}
 			if cmder.project == "" {
-				cmder.project = git.RepoName()
+				cmder.project = git.RepoName(cmd.Context())
 			}
 			return nil
 		},

--- a/pkg/git/detect.go
+++ b/pkg/git/detect.go
@@ -13,8 +13,8 @@ import (
 // RepoName returns the name of the current git repository.
 // It runs "git rev-parse --show-toplevel" and returns the base directory name.
 // If not inside a git repo, it falls back to the base name of the working directory.
-func RepoName() string {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+func RepoName(ctx context.Context) string {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
 	out, err := exec.CommandContext(ctx, "git", "rev-parse", "--show-toplevel").Output()

--- a/pkg/git/detect_test.go
+++ b/pkg/git/detect_test.go
@@ -1,6 +1,8 @@
 package git_test
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -9,7 +11,7 @@ import (
 
 var _ = Describe("RepoName", func() {
 	It("returns a non-empty name when inside a git repo", func() {
-		name := git.RepoName()
+		name := git.RepoName(context.Background())
 		Expect(name).ToNot(BeEmpty())
 	})
 })


### PR DESCRIPTION
## Summary
- The `tapes start` command never set the `Project` field on the proxy config, causing all sessions created via `tapes start claude` to have an empty project
- Added `--project` flag and config file resolution (`proxy.project`) to the start command, with `git.RepoName()` as the final fallback
- Updated `git.RepoName()` to accept a `context.Context` parameter for proper context propagation across all callers

Fixes #120

## Test Plan
- Added 4 Ginkgo tests for project resolution in `loadConfig`: flag priority, config file fallback, flag-over-config precedence, and empty when unset
- All existing tests pass, linter clean via `make format`

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ✅ 3 no changes — [View all](https://hub.continue.dev/inbox/pr/papercomputeco/tapes/121?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->