### PR TITLE
fix: correct streaming model loss and backfill token calculation

### DIFF
--- a/pkg/backfill/backfill.go
+++ b/pkg/backfill/backfill.go
@@ -161,10 +161,16 @@ func (b *Backfiller) matchAndUpdate(ctx context.Context, entries []TranscriptEnt
 		}
 
 		matched[bestMatch.ID] = true
+		// PromptTokens follows the proxy convention: total input tokens including
+		// base input, cache creation, and cache read. The Anthropic API reports
+		// input_tokens as only the non-cached portion, so we must sum all three.
+		totalInput := entry.Message.Usage.InputTokens +
+			entry.Message.Usage.CacheCreationInputTokens +
+			entry.Message.Usage.CacheReadInputTokens
 		usage := &llm.Usage{
-			PromptTokens:             entry.Message.Usage.InputTokens,
+			PromptTokens:             totalInput,
 			CompletionTokens:         entry.Message.Usage.OutputTokens,
-			TotalTokens:              entry.Message.Usage.InputTokens + entry.Message.Usage.OutputTokens,
+			TotalTokens:              totalInput + entry.Message.Usage.OutputTokens,
 			CacheCreationInputTokens: entry.Message.Usage.CacheCreationInputTokens,
 			CacheReadInputTokens:     entry.Message.Usage.CacheReadInputTokens,
 		}


### PR DESCRIPTION
## Summary

Fixes two bugs affecting cost accuracy in the deck (PCC-152):

- **Streaming model loss**: Anthropic's model name only appears in the `message_start` SSE event, but we only parsed the final chunk (`message_stop`) which has no model. Nodes stored with `model=""` were skipped by `costForNode()`, showing $0 cost. Now extracts model into `streamMeta` and applies it in `reconstructStreamedResponse`.

- **Backfill PromptTokens mismatch**: Backfill set `PromptTokens = input_tokens` (non-cached base only), but the proxy convention is `PromptTokens = input_tokens + cache_creation + cache_read`. This caused `CostForTokensWithCache` to compute `baseInput = 0` for cached turns, under-counting costs.

Both bugs cause **under-counting**, not the 10x over-counting reported. The $300+ session cost is likely legitimate given token accumulation across conversation turns.

## Test plan

- [x] Proxy SSE tests: model extraction from `message_start`, model propagation through `reconstructStreamedResponse`, last-chunk model preserved when available
- [x] Backfill integration tests: `PromptTokens` = sum of all input token types with cache, correct when no cache tokens present
- [x] All existing proxy, backfill, and deck tests pass

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 not started · ✅ 1 no changes — [View all](https://hub.continue.dev/inbox/pr/papercomputeco/tapes/127?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->