### PR TITLE
♻️ refactor: embed DagLoader directly in storage driver

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -9,7 +9,6 @@ import (
 	"github.com/gofiber/fiber/v2"
 
 	"github.com/papercomputeco/tapes/api/mcp"
-	"github.com/papercomputeco/tapes/pkg/merkle"
 	"github.com/papercomputeco/tapes/pkg/storage"
 )
 
@@ -17,7 +16,6 @@ import (
 type Server struct {
 	config    Config
 	driver    storage.Driver
-	dagLoader merkle.DagLoader
 	logger    *slog.Logger
 	app       *fiber.App
 	mcpServer *mcp.Server
@@ -26,18 +24,17 @@ type Server struct {
 // NewServer creates a new API server.
 // The storer is injected to allow sharing with other components
 // (e.g., the proxy when not run as a singleton).
-func NewServer(config Config, driver storage.Driver, dagLoader merkle.DagLoader, log *slog.Logger) (*Server, error) {
+func NewServer(config Config, driver storage.Driver, log *slog.Logger) (*Server, error) {
 	var err error
 	app := fiber.New(fiber.Config{
 		DisableStartupMessage: true,
 	})
 
 	s := &Server{
-		config:    config,
-		driver:    driver,
-		dagLoader: dagLoader,
-		logger:    log,
-		app:       app,
+		config: config,
+		driver: driver,
+		logger: log,
+		app:    app,
 	}
 
 	app.Get("/ping", s.handlePing)
@@ -52,7 +49,7 @@ func NewServer(config Config, driver storage.Driver, dagLoader merkle.DagLoader,
 	if config.VectorDriver != nil && config.Embedder != nil {
 		s.logger.Debug("creating mcp server")
 		mcpServer, err = mcp.NewServer(mcp.Config{
-			DagLoader:    dagLoader,
+			DagLoader:    driver,
 			VectorDriver: config.VectorDriver,
 			Embedder:     config.Embedder,
 			Logger:       log,

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -26,19 +26,16 @@ func apiTestBucket(role, text string) merkle.Bucket {
 
 var _ = Describe("buildHistory", func() {
 	var (
-		server    *Server
-		driver    storage.Driver
-		dagLoader merkle.DagLoader
-		ctx       context.Context
+		server *Server
+		driver storage.Driver
+		ctx    context.Context
 	)
 
 	BeforeEach(func() {
 		var err error
 		logger := tapeslogger.NewNoop()
-		inMem := inmemory.NewDriver()
-		driver = inMem
-		dagLoader = inMem
-		server, err = NewServer(Config{ListenAddr: ":0"}, driver, dagLoader, logger)
+		driver = inmemory.NewDriver()
+		server, err = NewServer(Config{ListenAddr: ":0"}, driver, logger)
 		Expect(err).ToNot(HaveOccurred())
 		ctx = context.Background()
 	})
@@ -152,7 +149,7 @@ var _ = Describe("buildHistory", func() {
 				Model:    "gpt-4",
 				Provider: "openai",
 			}
-			node = merkle.NewNode(bucket, nil, merkle.NodeMeta{
+			node = merkle.NewNode(bucket, nil, merkle.NodeOptions{
 				StopReason: "stop",
 				Usage: &llm.Usage{
 					PromptTokens:     100,

--- a/api/search_handler.go
+++ b/api/search_handler.go
@@ -43,7 +43,7 @@ func (s *Server) handleSearchEndpoint(c *fiber.Ctx) error {
 		c.Context(),
 		s.config.Embedder,
 		s.config.VectorDriver,
-		s.dagLoader,
+		s.driver,
 		s.logger,
 	)
 	output, err := searcher.Search(query, topK)

--- a/api/search_handler_test.go
+++ b/api/search_handler_test.go
@@ -42,7 +42,6 @@ var _ = Describe("handleSearchEndpoint", func() {
 				Embedder:     embedder,
 			},
 			inMem,
-			inMem,
 			logger,
 		)
 		Expect(err).NotTo(HaveOccurred())
@@ -53,7 +52,6 @@ var _ = Describe("handleSearchEndpoint", func() {
 			logger := tapeslogger.NewNoop()
 			noSearchServer, err := NewServer(
 				Config{ListenAddr: ":0"},
-				inMem,
 				inMem,
 				logger,
 			)

--- a/cmd/tapes/serve/api/api.go
+++ b/cmd/tapes/serve/api/api.go
@@ -3,7 +3,6 @@ package apicmder
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 
@@ -12,7 +11,6 @@ import (
 	"github.com/papercomputeco/tapes/api"
 	"github.com/papercomputeco/tapes/pkg/config"
 	"github.com/papercomputeco/tapes/pkg/logger"
-	"github.com/papercomputeco/tapes/pkg/merkle"
 	"github.com/papercomputeco/tapes/pkg/storage"
 	"github.com/papercomputeco/tapes/pkg/storage/inmemory"
 	"github.com/papercomputeco/tapes/pkg/storage/postgres"
@@ -101,17 +99,11 @@ func (c *apiCommander) run() error {
 		return fmt.Errorf("running migrations: %w", err)
 	}
 
-	// cast the driver as a DagLoader
-	dagLoader, ok := driver.(merkle.DagLoader)
-	if !ok {
-		return errors.New("storage driver does not implement merkle.DagLoader")
-	}
-
 	config := api.Config{
 		ListenAddr: c.listen,
 	}
 
-	server, err := api.NewServer(config, driver, dagLoader, c.logger)
+	server, err := api.NewServer(config, driver, c.logger)
 	if err != nil {
 		return fmt.Errorf("could not build new api server: %w", err)
 	}

--- a/cmd/tapes/serve/serve.go
+++ b/cmd/tapes/serve/serve.go
@@ -3,7 +3,6 @@ package servecmder
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -23,7 +22,6 @@ import (
 	embeddingutils "github.com/papercomputeco/tapes/pkg/embeddings/utils"
 	"github.com/papercomputeco/tapes/pkg/git"
 	"github.com/papercomputeco/tapes/pkg/logger"
-	"github.com/papercomputeco/tapes/pkg/merkle"
 	"github.com/papercomputeco/tapes/pkg/storage"
 	"github.com/papercomputeco/tapes/pkg/storage/inmemory"
 	"github.com/papercomputeco/tapes/pkg/storage/postgres"
@@ -204,7 +202,7 @@ func NewServeCmd() *cobra.Command {
 func (c *ServeCommander) run() error {
 	c.logger = logger.New(logger.WithDebug(c.debug), logger.WithPretty(true))
 
-	// Create shared driver (satisfies both storage.Driver and merkle.DagLoader)
+	// Create shared driver (satisfies storage.Driver, which embeds merkle.DagLoader)
 	driver, err := c.newStorageDriver()
 	if err != nil {
 		return err
@@ -213,12 +211,6 @@ func (c *ServeCommander) run() error {
 
 	if err := driver.Migrate(context.Background()); err != nil {
 		return fmt.Errorf("running migrations: %w", err)
-	}
-
-	// cast Driver as a DagLoader
-	dagLoader, ok := driver.(merkle.DagLoader)
-	if !ok {
-		return errors.New("storage driver does not implement merkle.DagLoader")
 	}
 
 	proxyConfig := proxy.Config{
@@ -276,7 +268,7 @@ func (c *ServeCommander) run() error {
 		VectorDriver: proxyConfig.VectorDriver,
 		Embedder:     proxyConfig.Embedder,
 	}
-	apiServer, err := api.NewServer(apiConfig, driver, dagLoader, c.logger)
+	apiServer, err := api.NewServer(apiConfig, driver, c.logger)
 	if err != nil {
 		return fmt.Errorf("could not build new api server: %w", err)
 	}

--- a/cmd/tapes/start/start.go
+++ b/cmd/tapes/start/start.go
@@ -29,7 +29,6 @@ import (
 	embeddingutils "github.com/papercomputeco/tapes/pkg/embeddings/utils"
 	"github.com/papercomputeco/tapes/pkg/git"
 	"github.com/papercomputeco/tapes/pkg/logger"
-	"github.com/papercomputeco/tapes/pkg/merkle"
 	"github.com/papercomputeco/tapes/pkg/start"
 	"github.com/papercomputeco/tapes/pkg/storage"
 	"github.com/papercomputeco/tapes/pkg/storage/inmemory"
@@ -412,11 +411,6 @@ func (c *startCommander) runServices(ctx context.Context, manager *start.Manager
 		return fmt.Errorf("running migrations: %w", err)
 	}
 
-	dagLoader, ok := driver.(merkle.DagLoader)
-	if !ok {
-		return errors.New("storage driver does not implement merkle.DagLoader")
-	}
-
 	vectorDriver, embedder, err := c.newVectorAndEmbedder(startCfg, log)
 	if err != nil {
 		return err
@@ -460,7 +454,7 @@ func (c *startCommander) runServices(ctx context.Context, manager *start.Manager
 		VectorDriver: vectorDriver,
 		Embedder:     embedder,
 	}
-	apiServer, err := api.NewServer(apiConfig, driver, dagLoader, log)
+	apiServer, err := api.NewServer(apiConfig, driver, log)
 	if err != nil {
 		return fmt.Errorf("creating api server: %w", err)
 	}

--- a/pkg/deck/demo_seed.go
+++ b/pkg/deck/demo_seed.go
@@ -143,7 +143,7 @@ func insertSession(ctx context.Context, client *ent.Client, session seedSession)
 		}
 
 		usage := buildUsage(message)
-		node := merkle.NewNode(bucket, parent, merkle.NodeMeta{
+		node := merkle.NewNode(bucket, parent, merkle.NodeOptions{
 			StopReason: message.StopReason,
 			Usage:      usage,
 			Project:    session.Project,

--- a/pkg/merkle/dag.go
+++ b/pkg/merkle/dag.go
@@ -10,7 +10,8 @@ import (
 // This allows the Dag to be loaded from any storage implementation
 // without creating a circular dependency.
 //
-// storage.Driver implementers must also implement this interface.
+// storage.Driver embeds this interface, so any storage.Driver
+// satisfies DagLoader automatically — no runtime cast needed.
 type DagLoader interface {
 	// Get retrieves a node by its hash.
 	Get(ctx context.Context, hash string) (*Node, error)

--- a/pkg/merkle/node.go
+++ b/pkg/merkle/node.go
@@ -33,9 +33,9 @@ type Node struct {
 	Project string `json:"project,omitempty"`
 }
 
-// NodeMeta contains optional metadata for a node that is stored
-// but does not affect the content-addressable hash.
-type NodeMeta struct {
+// NodeOptions contains optional metadata for a new node that is stored
+// but does not affect the content-addressable hashing.
+type NodeOptions struct {
 	StopReason string
 	Usage      *llm.Usage
 	Project    string
@@ -44,7 +44,7 @@ type NodeMeta struct {
 // NewNode creates a new node with the computed hash for the provided bucket.
 // The optional NodeOptions parameter allows for setting metadata (StopReason, Usage, etc.)
 // outside of the content addressable Bucket
-func NewNode(bucket Bucket, parent *Node, metas ...NodeMeta) *Node {
+func NewNode(bucket Bucket, parent *Node, opts ...NodeOptions) *Node {
 	n := &Node{
 		Bucket: bucket,
 	}
@@ -54,10 +54,10 @@ func NewNode(bucket Bucket, parent *Node, metas ...NodeMeta) *Node {
 	}
 
 	// Apply optional metadata if provided
-	if len(metas) > 0 {
-		n.StopReason = metas[0].StopReason
-		n.Usage = metas[0].Usage
-		n.Project = metas[0].Project
+	if len(opts) > 0 {
+		n.StopReason = opts[0].StopReason
+		n.Usage = opts[0].Usage
+		n.Project = opts[0].Project
 	}
 
 	n.Hash = n.computeHash()

--- a/pkg/merkle/node_test.go
+++ b/pkg/merkle/node_test.go
@@ -65,7 +65,7 @@ var _ = Describe("Node", func() {
 					Provider: "openai",
 				}
 				// StopReason and Usage are now on Node via NodeOptions, not Bucket
-				node := merkle.NewNode(bucket, nil, merkle.NodeMeta{
+				node := merkle.NewNode(bucket, nil, merkle.NodeOptions{
 					StopReason: "stop",
 					Usage: &llm.Usage{
 						PromptTokens:     10,
@@ -94,7 +94,7 @@ var _ = Describe("Node", func() {
 				node1 := merkle.NewNode(bucket, nil)
 
 				// Node with metadata - should have SAME hash since metadata doesn't affect hash
-				node2 := merkle.NewNode(bucket, nil, merkle.NodeMeta{
+				node2 := merkle.NewNode(bucket, nil, merkle.NodeOptions{
 					StopReason: "stop",
 					Usage: &llm.Usage{
 						PromptTokens:     10,

--- a/pkg/storage/driver.go
+++ b/pkg/storage/driver.go
@@ -10,14 +10,19 @@ import (
 // Driver defines the interface for persisting and retrieving nodes in a storage backend.
 // The Driver is the primary interface for working with pkg/merkle - it handles
 // storage, retrieval, and traversal of nodes per the storage implementor.
+//
+// A Driver embeds merkle.DagLoader, so any storage.Driver is also a merkle.DagLoader.
+// This avoids the need for callers to cast a Driver to a DagLoader — they can pass
+// a Driver wherever a DagLoader is expected directly.
 type Driver interface {
+	// DagLoader provides read and traversal operations on the DAG.
+	// Get, GetByParent, and Ancestry come from this embedded interface.
+	merkle.DagLoader
+
 	// Put stores a node. Returns true if the node was newly inserted,
 	// false if it already exists. If the node already exists, this should be
 	// a no-op. Put provides automatic deduplication via content-addressing in the dag.
 	Put(ctx context.Context, node *merkle.Node) (bool, error)
-
-	// Get retrieves a node by its hash.
-	Get(ctx context.Context, hash string) (*merkle.Node, error)
 
 	// Has checks if a node exists by its hash.
 	Has(ctx context.Context, hash string) (bool, error)
@@ -30,9 +35,6 @@ type Driver interface {
 
 	// Leaves returns all leaf nodes (nodes with no children).
 	Leaves(ctx context.Context) ([]*merkle.Node, error)
-
-	// Ancestry returns the path from a node back to its root (node first, root last).
-	Ancestry(ctx context.Context, hash string) ([]*merkle.Node, error)
 
 	// Depth returns the depth of a node (0 for roots).
 	Depth(ctx context.Context, hash string) (int, error)

--- a/pkg/storage/postgres/postgres_test.go
+++ b/pkg/storage/postgres/postgres_test.go
@@ -392,7 +392,7 @@ var _ = Describe("Driver", func() {
 				Model:    "gpt-4",
 				Provider: "openai",
 			}
-			node := merkle.NewNode(bucket, nil, merkle.NodeMeta{
+			node := merkle.NewNode(bucket, nil, merkle.NodeOptions{
 				StopReason: "stop",
 				Usage: &llm.Usage{
 					PromptTokens:     10,

--- a/pkg/storage/sqlite/sqlite_test.go
+++ b/pkg/storage/sqlite/sqlite_test.go
@@ -425,7 +425,7 @@ var _ = Describe("Driver", func() {
 				Provider: "openai",
 			}
 			// StopReason and Usage are now on Node, not Bucket
-			node := merkle.NewNode(bucket, nil, merkle.NodeMeta{
+			node := merkle.NewNode(bucket, nil, merkle.NodeOptions{
 				StopReason: "stop",
 				Usage: &llm.Usage{
 					PromptTokens:     10,

--- a/proxy/worker/pool.go
+++ b/proxy/worker/pool.go
@@ -242,7 +242,7 @@ func (p *Pool) storeConversationTurn(ctx context.Context, job Job) (string, []*m
 			AgentName: job.AgentName,
 		}
 
-		node := merkle.NewNode(bucket, parent, merkle.NodeMeta{Project: p.config.Project})
+		node := merkle.NewNode(bucket, parent, merkle.NodeOptions{Project: p.config.Project})
 
 		isNew, err := p.config.Driver.Put(ctx, node)
 		if err != nil {
@@ -274,7 +274,7 @@ func (p *Pool) storeConversationTurn(ctx context.Context, job Job) (string, []*m
 	responseNode := merkle.NewNode(
 		responseBucket,
 		parent,
-		merkle.NodeMeta{
+		merkle.NodeOptions{
 			StopReason: job.Resp.StopReason,
 			Usage:      job.Resp.Usage,
 			Project:    p.config.Project,


### PR DESCRIPTION
The `pkg/merkle/DagLoader` interface was required by various "readers" (like the API) which inadvertently do a cast on the `pkg/storage/Driver` to ensure whatever driver is used implements _both_ interfaces.

Not great.

Originally this was done because `pkg/storage/Driver` needed to import `merkle.Node` which creates a circular dependency with `merkle` package.

This patch restructures the `Driver` interface to directly embed the `DagLoader` so we can centralize on the  storage `Driver` being the one interface that handles _both_ (not expect implementers to satisfy a runtime type cast).

---

Also changes `NodeMetadata` to `NewNodeOptions` which makes alot more sense.

---

Closes PCC-328