### PR TITLE
✨ feat: Serve Scalar API reference from the API server

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -48,6 +48,10 @@ func NewServer(config Config, driver storage.Driver, log *slog.Logger) (*Server,
 	app.Get("/v1/sessions/:hash", s.handleGetSession)
 	app.Get("/v1/search", s.handleSearchEndpoint)
 
+	// API reference UI. Always mounted — the viewer JS comes from a CDN
+	// at view time, so the binary cost is negligible.
+	s.mountSwagger(app)
+
 	// Register MCP server if vector driver and embedder are configured
 	var mcpServer *mcp.Server
 	if config.VectorDriver != nil && config.Embedder != nil {

--- a/api/swagger_middleware.go
+++ b/api/swagger_middleware.go
@@ -1,0 +1,41 @@
+package api
+
+import (
+	"github.com/gofiber/fiber/v2"
+	"github.com/swaggo/swag"
+
+	// Register the generated OpenAPI spec with swag.ReadDoc.
+	_ "github.com/papercomputeco/tapes/docs"
+)
+
+// scalarHTML loads the Scalar API reference viewer from a CDN. Keeping the
+// viewer JS out of our binary saves ~12 MB compared to embedding swagger-ui.
+const scalarHTML = `<!doctype html>
+<html>
+  <head>
+    <title>Tapes API</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+  </head>
+  <body>
+    <script id="api-reference" data-url="/swagger/doc.json"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference@1.52.1"></script>
+  </body>
+</html>`
+
+// mountSwagger registers the API reference routes. The viewer JS is fetched
+// from a CDN at view time, so the only binary cost is this file plus the
+// generated docs package.
+func (s *Server) mountSwagger(app *fiber.App) {
+	app.Get("/swagger/doc.json", func(c *fiber.Ctx) error {
+		doc, err := swag.ReadDoc()
+		if err != nil {
+			return c.Status(fiber.StatusInternalServerError).SendString(err.Error())
+		}
+		return c.Type("json").SendString(doc)
+	})
+
+	app.Get("/swagger", func(c *fiber.Ctx) error {
+		return c.Type("html").SendString(scalarHTML)
+	})
+}


### PR DESCRIPTION
### Summary
PR #183 wired up swaggo annotations and generated the OpenAPI spec. This adds a drop-in runtime viewer: /swagger renders Scalar via CDN, so no viewer assets are embedded and the binary only grows by ~1 MB. Spec is served at /swagger/doc.json via swag.ReadDoc.

### Testing
- [X] run locally and confirm UI comes up at localhost:8081/swagger