### PR TITLE
✨ feat: add Claude Opus 4.7 pricing and normalization

### DIFF
--- a/pkg/sessions/pricing.go
+++ b/pkg/sessions/pricing.go
@@ -10,7 +10,7 @@ import (
 
 // DefaultPricing returns hardcoded pricing per million tokens for supported models.
 //
-// Last verified: 2026-03-08
+// Last verified: 2026-04-16
 // Sources:
 //   - Anthropic: https://platform.claude.com/docs/en/about-claude/pricing
 //   - OpenAI:    https://platform.openai.com/docs/pricing
@@ -23,6 +23,7 @@ import (
 func DefaultPricing() PricingTable {
 	return PricingTable{
 		// Anthropic
+		"claude-opus-4.7":   {Input: 5.00, Output: 25.00, CacheRead: 0.50, CacheWrite: 6.25},
 		"claude-opus-4.6":   {Input: 5.00, Output: 25.00, CacheRead: 0.50, CacheWrite: 6.25},
 		"claude-opus-4.5":   {Input: 5.00, Output: 25.00, CacheRead: 0.50, CacheWrite: 6.25},
 		"claude-opus-4.1":   {Input: 15.00, Output: 75.00, CacheRead: 1.50, CacheWrite: 18.75},
@@ -145,6 +146,7 @@ func NormalizeModel(model string) string {
 	normalized = strings.ReplaceAll(normalized, "-5-3", "-5.3")
 	normalized = strings.ReplaceAll(normalized, "-5-2", "-5.2")
 	normalized = strings.ReplaceAll(normalized, "-5-1", "-5.1")
+	normalized = strings.ReplaceAll(normalized, "-4-7", "-4.7")
 	normalized = strings.ReplaceAll(normalized, "-4-6", "-4.6")
 	normalized = strings.ReplaceAll(normalized, "-4-5", "-4.5")
 	normalized = strings.ReplaceAll(normalized, "-4-1", "-4.1")

--- a/pkg/sessions/summary_test.go
+++ b/pkg/sessions/summary_test.go
@@ -211,6 +211,7 @@ var _ = Describe("NormalizeModel", func() {
 	})
 	It("rewrites hyphenated version markers", func() {
 		Expect(sessions.NormalizeModel("claude-opus-4-6")).To(Equal("claude-opus-4.6"))
+		Expect(sessions.NormalizeModel("claude-opus-4-7")).To(Equal("claude-opus-4.7"))
 	})
 	It("returns empty for empty input", func() {
 		Expect(sessions.NormalizeModel("")).To(Equal(""))


### PR DESCRIPTION
## Summary
- Add `claude-opus-4.7` to `DefaultPricing` at the shared 4.5/4.6 tier ($5 input, $25 output, $0.50 cache read, $6.25 cache write) — verified against Anthropic's pricing page.
- Add `-4-7` → `-4.7` rewrite in `NormalizeModel` so Anthropic-style model IDs like `claude-opus-4-7-20260401` normalize correctly.
- Bump "Last verified" comment to 2026-04-16.

## Test plan
- [x] `go test ./pkg/sessions/...` passes
- [x] `go test ./proxy/... ./api/... ./pkg/storage/... ./pkg/deck/... ./cmd/tapes/start/...` passes
- [x] `NormalizeModel("claude-opus-4-7") == "claude-opus-4.7"` assertion added to `summary_test.go`