### PR TITLE
🐛 fix: clamp deck --since to the 30d rolling window

### DIFF
--- a/cmd/tapes/deck/tui.go
+++ b/cmd/tapes/deck/tui.go
@@ -166,17 +166,21 @@ func newDeckModel(query deck.Querier, filters deck.Filters, overview *deck.Overv
 		}
 	}
 
-	// Determine initial time period from filters
-	period := period30d
-	if filters.Since > 0 {
-		switch {
-		case filters.Since >= 30*24*time.Hour:
-			period = period30d
-		case filters.Since >= 7*24*time.Hour:
-			period = period7d
-		default:
-			period = period24h
-		}
+	// tapes deck shows at most a rolling 30-day window. Missing --since (0)
+	// or a value larger than 30d both clamp to 30d so the label, the cutoff,
+	// and the data all agree.
+	if filters.Since <= 0 || filters.Since > maxSinceDuration {
+		filters.Since = maxSinceDuration
+	}
+
+	var period timePeriod
+	switch {
+	case filters.Since >= 30*24*time.Hour:
+		period = period30d
+	case filters.Since >= 7*24*time.Hour:
+		period = period7d
+	default:
+		period = period24h
 	}
 
 	s := spinner.New()

--- a/cmd/tapes/deck/tui_test.go
+++ b/cmd/tapes/deck/tui_test.go
@@ -209,4 +209,45 @@ var _ = Describe("Deck TUI helpers", func() {
 			Expect(countWrappedLines("a\n\nb", 10)).To(Equal(3))
 		})
 	})
+
+	Describe("newDeckModel initial time period", func() {
+		It("clamps a zero --since to the 30d window", func() {
+			m := newDeckModel(nil, deck.Filters{}, nil, 0)
+			Expect(m.filters.Since).To(Equal(maxSinceDuration))
+			Expect(m.timePeriod).To(Equal(period30d))
+		})
+
+		It("clamps a negative --since to the 30d window", func() {
+			m := newDeckModel(nil, deck.Filters{Since: -1 * time.Hour}, nil, 0)
+			Expect(m.filters.Since).To(Equal(maxSinceDuration))
+			Expect(m.timePeriod).To(Equal(period30d))
+		})
+
+		It("clamps an over-sized --since down to 30d", func() {
+			m := newDeckModel(nil, deck.Filters{Since: 90 * 24 * time.Hour}, nil, 0)
+			Expect(m.filters.Since).To(Equal(maxSinceDuration))
+			Expect(m.timePeriod).To(Equal(period30d))
+		})
+
+		It("keeps a 7d --since and picks the 7d period", func() {
+			since := 7 * 24 * time.Hour
+			m := newDeckModel(nil, deck.Filters{Since: since}, nil, 0)
+			Expect(m.filters.Since).To(Equal(since))
+			Expect(m.timePeriod).To(Equal(period7d))
+		})
+
+		It("keeps a 24h --since and picks the 24h period", func() {
+			since := 24 * time.Hour
+			m := newDeckModel(nil, deck.Filters{Since: since}, nil, 0)
+			Expect(m.filters.Since).To(Equal(since))
+			Expect(m.timePeriod).To(Equal(period24h))
+		})
+
+		It("treats sub-7d values as the 24h period", func() {
+			since := 3 * 24 * time.Hour
+			m := newDeckModel(nil, deck.Filters{Since: since}, nil, 0)
+			Expect(m.filters.Since).To(Equal(since))
+			Expect(m.timePeriod).To(Equal(period24h))
+		})
+	})
 })


### PR DESCRIPTION
## Summary

- `newDeckModel` previously trusted `filters.Since` as-is when positive, so a missing `--since` (0) or a value larger than 30d could leave the period label, cutoff, and displayed data disagreeing.
- Clamp `filters.Since` into `(0, maxSinceDuration]` before choosing the initial `timePeriod`, keeping the TUI on a coherent rolling 30-day window.
- Added Ginkgo specs covering zero, negative, over-sized, 7d, 24h, and sub-7d `--since` values.

## Test plan

- [x] `go test ./cmd/tapes/deck/ -run TestDeckCommander`