### PR TITLE
🧹 chore: Login to ECR public during release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,9 +29,11 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: us-east-1
 
-      - name: Login to ECR
-        id: login-ecr
+      - name: Login to ECR Public
+        id: login-ecr-public
         uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
 
       - name: Push tapes image
         run: |


### PR DESCRIPTION
Related to last failure in: https://github.com/papercomputeco/tapes/actions/runs/24996827635/job/73195890182