### PR TITLE
✨ feat: Pull embedding gemma for user during "tapes local up"

### DIFF
--- a/cmd/tapes/local/local.go
+++ b/cmd/tapes/local/local.go
@@ -19,16 +19,18 @@ import (
 )
 
 const (
-	defaultPostgresImage = "public.ecr.aws/g4e5l3z3/papercomputeco/postgres"
-	defaultOllamaImage   = "ollama/ollama:latest"
-	localNetworkName     = "tapes-local"
-	postgresContainer    = "tapes-local-postgres"
-	ollamaContainer      = "tapes-local-ollama"
-	postgresDirName      = "postgres"
-	postgresDataPath     = "/tapes-postgres/data"
-	postgresUser         = "tapes"
-	postgresPass         = "tapes"
-	postgresDB           = "tapes"
+	defaultPostgresImage  = "public.ecr.aws/g4e5l3z3/papercomputeco/postgres"
+	defaultOllamaImage    = "ollama/ollama:latest"
+	defaultEmbeddingModel = "embeddinggemma"
+	ollamaEmbeddingModel  = defaultEmbeddingModel + ":latest"
+	localNetworkName      = "tapes-local"
+	postgresContainer     = "tapes-local-postgres"
+	ollamaContainer       = "tapes-local-ollama"
+	postgresDirName       = "postgres"
+	postgresDataPath      = "/tapes-postgres/data"
+	postgresUser          = "tapes"
+	postgresPass          = "tapes"
+	postgresDB            = "tapes"
 )
 
 type localCommander struct {
@@ -148,6 +150,12 @@ func (c *localCommander) runUp() error {
 	if err := cliui.Step(os.Stdout, "Waiting for Postgres", waitForPostgresReady); err != nil {
 		return err
 	}
+	if err := cliui.Step(os.Stdout, "Waiting for Ollama", waitForOllamaReady); err != nil {
+		return err
+	}
+	if err := ensureOllamaModel(ollamaEmbeddingModel); err != nil {
+		return err
+	}
 
 	dsn := fmt.Sprintf("postgres://%s:%s@localhost:%d/%s?sslmode=disable", postgresUser, postgresPass, c.postgresPort, postgresDB)
 
@@ -162,10 +170,10 @@ func (c *localCommander) runUp() error {
 	fmt.Printf("  tapes config set proxy.upstream %q\n", fmt.Sprintf("http://localhost:%d", c.ollamaPort))
 	fmt.Printf("  tapes config set embedding.provider %q\n", "ollama")
 	fmt.Printf("  tapes config set embedding.target %q\n", fmt.Sprintf("http://localhost:%d", c.ollamaPort))
-	fmt.Printf("  tapes config set embedding.model %q\n\n", "nomic-embed-text")
+	fmt.Printf("  tapes config set embedding.model %q\n\n", defaultEmbeddingModel)
 	fmt.Printf("Next steps:\n")
 	fmt.Printf("  1. Run: tapes serve --postgres %q\n", dsn)
-	fmt.Printf("  2. Optionally pull models with: docker exec -it %s ollama pull qwen3-coder:30b\n\n", ollamaContainer)
+	fmt.Printf("  2. Optionally pull chat/completion models with: docker exec -it %s ollama pull qwen3-coder:30b\n\n", ollamaContainer)
 	return nil
 }
 
@@ -319,6 +327,22 @@ func waitForPostgresReady() error {
 		time.Sleep(1 * time.Second)
 	}
 	return fmt.Errorf("postgres container %q did not become ready within 30s", postgresContainer)
+}
+
+func waitForOllamaReady() error {
+	deadline := time.Now().Add(60 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := dockerOutput("exec", ollamaContainer, "ollama", "list"); err == nil {
+			return nil
+		}
+		time.Sleep(1 * time.Second)
+	}
+	return fmt.Errorf("ollama container %q did not become ready within 60s", ollamaContainer)
+}
+
+func ensureOllamaModel(model string) error {
+	fmt.Printf("  %s %s\n", cliui.WarnStyle.Render("↓"), cliui.StepStyle.Render("Pulling Ollama model "+model))
+	return runDocker("exec", ollamaContainer, "ollama", "pull", model)
 }
 
 func resolveLocalTapesDir(configDir string) (string, error) {

--- a/pkg/embeddings/ollama/ollama.go
+++ b/pkg/embeddings/ollama/ollama.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	// DefaultEmbeddingModel is the default model used for embeddings.
-	DefaultEmbeddingModel = "nomic-embed-text"
+	DefaultEmbeddingModel = "embeddinggemma"
 
 	// DefaultBaseURL is the default Ollama API URL.
 	DefaultBaseURL = "http://localhost:11434"
@@ -35,7 +35,7 @@ type EmbedderConfig struct {
 	// Defaults to DefaultBaseURL if empty.
 	BaseURL string
 
-	// Model is the embedding model to use (e.g., "nomic-embed-text", "all-minilm").
+	// Model is the embedding model to use (e.g., "embeddinggemma", "all-minilm").
 	// Defaults to DefaultEmbeddingModel if empty.
 	Model string
 }


### PR DESCRIPTION
Now pulls the model for the user via a docker exec `ollama pull`:

<img width="1213" height="1032" alt="image" src="https://github.com/user-attachments/assets/611a3fa8-1900-4f91-9cda-6afeb2c23ffb" />

This also sets the default model in the ollama embedding provider to `embeddinggemma` which is small but performant.