### PR TITLE
✨ feat: Wire ingest queue-depth gauge and add API server /metrics

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gofiber/adaptor/v2"
 	"github.com/gofiber/fiber/v2"
+	"github.com/gofiber/fiber/v2/middleware/recover"
 
 	"github.com/papercomputeco/tapes/api/mcp"
 	"github.com/papercomputeco/tapes/pkg/storage"
@@ -18,6 +19,7 @@ type Server struct {
 	driver    storage.Driver
 	logger    *slog.Logger
 	app       *fiber.App
+	metrics   *Metrics
 	mcpServer *mcp.Server
 }
 
@@ -31,11 +33,26 @@ func NewServer(config Config, driver storage.Driver, log *slog.Logger) (*Server,
 	})
 
 	s := &Server{
-		config: config,
-		driver: driver,
-		logger: log,
-		app:    app,
+		config:  config,
+		driver:  driver,
+		logger:  log,
+		app:     app,
+		metrics: NewMetrics(),
 	}
+
+	// RED metrics is registered first so it sits as the outermost wrapper.
+	// Order matters: the request-count and duration increments run AFTER
+	// c.Next() returns, not in a defer, so a panic unwinding through them
+	// would skip those updates. Putting recover.New() inside the metrics
+	// middleware means recover catches the panic and translates it into
+	// an error returned to the metrics middleware — which then derives
+	// the right status via the err (see Middleware in metrics.go).
+	app.Use(s.metrics.Middleware())
+	app.Use(recover.New())
+
+	// /metrics is intentionally outside any auth group — Alloy scrapes
+	// in-cluster and there is no caller identity to verify.
+	app.Get("/metrics", s.metrics.Handler())
 
 	app.Get("/ping", s.handlePing)
 

--- a/api/metrics.go
+++ b/api/metrics.go
@@ -1,0 +1,163 @@
+package api
+
+import (
+	"errors"
+	"strconv"
+	"time"
+
+	"github.com/gofiber/adaptor/v2"
+	"github.com/gofiber/fiber/v2"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+// Metrics is the Prometheus surface for the Tapes API server. Each Server
+// owns its own registry so tests can scrape in isolation; the production
+// path mounts /metrics on the Fiber app via NewServer.
+type Metrics struct {
+	registry *prometheus.Registry
+
+	requests *prometheus.CounterVec
+	duration *prometheus.HistogramVec
+	inflight prometheus.Gauge
+
+	// scrapeHandler is the cached /metrics Fiber handler. promhttp.HandlerFor
+	// with a non-nil Registry calls MustRegister(...) on the registry to
+	// instrument the scrape handler itself (promhttp_metric_handler_*),
+	// so building a fresh handler twice against the same Metrics would
+	// panic on the second call. Build once at construction; Handler()
+	// just returns this field.
+	scrapeHandler fiber.Handler
+}
+
+// NewMetrics constructs the Tapes API server's RED metrics. Labels stay
+// templated (`route`) rather than per-URL so :hash path params don't blow up
+// cardinality.
+func NewMetrics() *Metrics {
+	reg := prometheus.NewRegistry()
+	m := &Metrics{
+		registry: reg,
+		requests: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "tapes_apiserver_requests_total",
+				Help: "Total HTTP requests handled by the Tapes API server, by route template, method, and status.",
+			},
+			[]string{"route", "method", "status"},
+		),
+		duration: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Name:    "tapes_apiserver_request_duration_seconds",
+				Help:    "Latency of requests handled by the Tapes API server.",
+				Buckets: prometheus.DefBuckets,
+			},
+			[]string{"route", "method"},
+		),
+		inflight: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "tapes_apiserver_inflight_requests",
+			Help: "In-flight requests currently being handled by the Tapes API server.",
+		}),
+	}
+	reg.MustRegister(m.requests, m.duration, m.inflight)
+	m.scrapeHandler = adaptor.HTTPHandler(promhttp.HandlerFor(reg, promhttp.HandlerOpts{Registry: reg}))
+	return m
+}
+
+// Registry exposes the *prometheus.Registry so tests can scrape against the
+// same registry the middleware writes to.
+func (m *Metrics) Registry() *prometheus.Registry { return m.registry }
+
+// Middleware returns a Fiber handler that records request count + duration
+// per (route template, method, status). Templates like /v1/sessions/:hash
+// stay as the label value so the :hash path param never expands cardinality.
+//
+// Register this OUTSIDE recover.New() (i.e. via app.Use before recover) —
+// see resolveStatus for why.
+func (m *Metrics) Middleware() fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		m.inflight.Inc()
+		defer m.inflight.Dec()
+
+		start := time.Now()
+		err := c.Next()
+
+		// Route().Path is the registered template (e.g. /v1/sessions/:hash);
+		// we fall back to a sentinel when Fiber's router never advanced past
+		// the middleware's own "/" entry, so unknown URLs don't each become
+		// their own series. Fiber v2 keeps c.route pointing at the last
+		// matched route — which for an unhandled request is this very
+		// middleware (path "/") — rather than nilling it, so we can't rely
+		// on an empty path. Detecting an unmatched request via the
+		// framework-emitted 404 fiber.Error is the contract that survives
+		// across Fiber versions: a real handler returning fiber.ErrNotFound
+		// is rare and harmless to bucket with router 404s here.
+		route := c.Route().Path
+		if route == "" || isRouterNotFound(err) {
+			route = "unmatched"
+		}
+
+		m.requests.WithLabelValues(route, c.Method(), strconv.Itoa(resolveStatus(c, err))).Inc()
+		m.duration.WithLabelValues(route, c.Method()).Observe(time.Since(start).Seconds())
+
+		return err
+	}
+}
+
+// resolveStatus returns the HTTP status the client will see for this
+// request. Two reasons we can't just read c.Response().StatusCode():
+//
+//  1. When a downstream middleware (recover.New, an auth check, the
+//     route handler) returns a non-nil error, Fiber routes it through
+//     the registered ErrorHandler — but only AFTER all middleware has
+//     unwound. By the time this middleware records metrics, the status
+//     is still its pre-error default (typically 200).
+//
+//  2. recover.New translates a panic into a generic error rather than
+//     calling c.Status(500), so even with the metrics middleware
+//     wrapping recover, the response status hasn't been touched yet.
+//
+// Mirror what Fiber's default ErrorHandler will do: a *fiber.Error
+// carries the code; everything else is treated as 500. If err is nil,
+// trust whatever the handler set. Use errors.As so a wrapped fiber.Error
+// (e.g. fmt.Errorf("...: %w", fiber.ErrBadRequest)) is still recognized
+// — Fiber's own ErrorHandler does the same, so the metrics row should
+// agree with what the client actually sees.
+func resolveStatus(c *fiber.Ctx, err error) int {
+	if err == nil {
+		return c.Response().StatusCode()
+	}
+	var e *fiber.Error
+	if errors.As(err, &e) {
+		return e.Code
+	}
+	return fiber.StatusInternalServerError
+}
+
+// isRouterNotFound reports whether err is the synthetic 404 the Fiber router
+// itself emits when no registered route matches the request. We use this to
+// detect "unmatched" so the cardinality of the requests counter stays bounded
+// by the number of registered routes, not by attacker-controlled URLs.
+//
+// A naive "any 404 *fiber.Error is unmatched" would silently misclassify
+// any handler that returns fiber.ErrNotFound (or wraps it) — those would
+// drop their route dimension and show up as `route="unmatched"`. Distinguish
+// the two via errors.Is: handler-returned fiber.ErrNotFound (and wraps of
+// it) match the package singleton; the router emits a freshly-allocated
+// *fiber.Error with message "Cannot METHOD /path" which does not. So we
+// treat err as router-emitted iff it's a 404 fiber.Error that does NOT
+// match the singleton — handler-emitted fiber.ErrNotFound buckets on its
+// registered route template instead of collapsing to unmatched.
+func isRouterNotFound(err error) bool {
+	var e *fiber.Error
+	if !errors.As(err, &e) || e.Code != fiber.StatusNotFound {
+		return false
+	}
+	return !errors.Is(err, fiber.ErrNotFound)
+}
+
+// Handler returns a Fiber handler that serves Prometheus text exposition
+// from this Metrics instance's registry. Mount it at /metrics with no
+// auth. The handler is built once at NewMetrics time and cached — see the
+// scrapeHandler field comment for why.
+func (m *Metrics) Handler() fiber.Handler {
+	return m.scrapeHandler
+}

--- a/api/metrics_test.go
+++ b/api/metrics_test.go
@@ -1,0 +1,386 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/gofiber/fiber/v2/middleware/recover"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+
+	tapeslogger "github.com/papercomputeco/tapes/pkg/logger"
+	"github.com/papercomputeco/tapes/pkg/storage/inmemory"
+)
+
+// newTestApp constructs a fresh *Metrics and a bare Fiber app wired with
+// the metrics middleware in the production order (metrics outside
+// recover.New). Use it for specs that exercise middleware behavior in
+// isolation — registering ad-hoc routes against the returned app — and
+// don't need the full Server's v1 routes, swagger, or MCP surface. Specs
+// that need real handlers (`/ping`, `/v1/sessions/:hash`) should keep
+// using NewServer via the suite-level BeforeEach.
+func newTestApp() (*Metrics, *fiber.App) {
+	m := NewMetrics()
+	app := fiber.New()
+	app.Use(m.Middleware())
+	app.Use(recover.New())
+	return m, app
+}
+
+// counterValue returns the value of tapes_apiserver_requests_total for the
+// given (route, method, status) labelset, or 0 if no such row exists. We
+// scrape the registry directly via Gather() rather than the HTTP exposition
+// so tests assert against typed values, not regexes over text.
+func counterValue(reg *prometheus.Registry, route, method, status string) float64 {
+	mfs, err := reg.Gather()
+	Expect(err).NotTo(HaveOccurred())
+	for _, mf := range mfs {
+		if mf.GetName() != "tapes_apiserver_requests_total" {
+			continue
+		}
+		for _, m := range mf.Metric {
+			if labelsMatch(m, map[string]string{"route": route, "method": method, "status": status}) {
+				return m.GetCounter().GetValue()
+			}
+		}
+	}
+	return 0
+}
+
+// countSeriesWithRoute returns the number of distinct counter rows whose
+// route label equals the given value. Used to verify cardinality contracts
+// (e.g. that unmatched 404s collapse to a single sentinel row).
+func countSeriesWithRoute(reg *prometheus.Registry, route string) int {
+	mfs, err := reg.Gather()
+	Expect(err).NotTo(HaveOccurred())
+	count := 0
+	for _, mf := range mfs {
+		if mf.GetName() != "tapes_apiserver_requests_total" {
+			continue
+		}
+		for _, m := range mf.Metric {
+			for _, lp := range m.Label {
+				if lp.GetName() == "route" && lp.GetValue() == route {
+					count++
+					break
+				}
+			}
+		}
+	}
+	return count
+}
+
+func labelsMatch(m *dto.Metric, want map[string]string) bool {
+	got := map[string]string{}
+	for _, lp := range m.Label {
+		got[lp.GetName()] = lp.GetValue()
+	}
+	for k, v := range want {
+		if got[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+var _ = Describe("API server Prometheus metrics", func() {
+	var server *Server
+
+	BeforeEach(func() {
+		logger := tapeslogger.NewNoop()
+		driver := inmemory.NewDriver()
+
+		var err error
+		server, err = NewServer(Config{ListenAddr: ":0"}, driver, logger)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	Describe("/metrics endpoint", func() {
+		It("is scrape-able without auth and exposes the tapes_apiserver_* surface", func() {
+			// Touch /ping first so the requests counter and duration
+			// histogram each have an observed labelset. Without an
+			// observation prometheus omits the metric family entirely
+			// (only the always-present gauge would otherwise show up),
+			// which would make an empty scrape look misleadingly bare.
+			ping, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "/ping", nil)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = server.app.Test(ping)
+			Expect(err).NotTo(HaveOccurred())
+
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "/metrics", nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			resp, err := server.app.Test(req)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+			body, err := io.ReadAll(resp.Body)
+			Expect(err).NotTo(HaveOccurred())
+			text := string(body)
+
+			// All three RED metrics should be present now that the
+			// counter and histogram each have at least one observation.
+			Expect(text).To(ContainSubstring("tapes_apiserver_requests_total"))
+			Expect(text).To(ContainSubstring("tapes_apiserver_request_duration_seconds"))
+			Expect(text).To(ContainSubstring("tapes_apiserver_inflight_requests"))
+		})
+	})
+
+	Describe("RED counter labels", func() {
+		It("uses the templated route, not the materialized URL, for parameterised paths", func() {
+			// /v1/sessions/:hash matches even though the hash slot is empty
+			// or fake — we only care that the registered template is what
+			// lands in the `route` label. We hit it twice with different
+			// :hash values and assert they collapse to a single series.
+			for _, hash := range []string{"abc123", "def456"} {
+				req, err := http.NewRequestWithContext(
+					context.Background(), http.MethodGet, "/v1/sessions/"+hash, nil)
+				Expect(err).NotTo(HaveOccurred())
+				_, err = server.app.Test(req)
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			// Both requests should hit the same templated row. The actual
+			// status the handler returns for an unknown hash is 404, but
+			// the precise code is not what this test asserts — only that
+			// the row exists and counts both hits.
+			total := 0.0
+			for _, status := range []string{"200", "404", "500"} {
+				total += counterValue(server.metrics.Registry(),
+					"/v1/sessions/:hash", http.MethodGet, status)
+			}
+			Expect(total).To(BeNumerically(">=", 2.0),
+				"both /v1/sessions/<hash> hits should land on the templated row")
+
+			// And no row should carry the materialized URL as the route.
+			Expect(countSeriesWithRoute(server.metrics.Registry(),
+				"/v1/sessions/abc123")).To(Equal(0))
+			Expect(countSeriesWithRoute(server.metrics.Registry(),
+				"/v1/sessions/def456")).To(Equal(0))
+		})
+
+		It("collapses unmatched 404s to a single 'unmatched' sentinel row", func() {
+			// Three different never-registered URLs. Without the sentinel,
+			// each materialized path would become its own series — that
+			// would let an attacker inflate cardinality with random URLs.
+			for _, path := range []string{"/nope/one", "/nope/two", "/totally/different"} {
+				req, err := http.NewRequestWithContext(
+					context.Background(), http.MethodGet, path, nil)
+				Expect(err).NotTo(HaveOccurred())
+				_, err = server.app.Test(req)
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			// Only one row should exist for the sentinel, regardless of how
+			// many distinct unmatched URLs we threw at it.
+			Expect(countSeriesWithRoute(server.metrics.Registry(),
+				"unmatched")).To(Equal(1))
+			Expect(counterValue(server.metrics.Registry(),
+				"unmatched", http.MethodGet, "404")).To(Equal(3.0))
+		})
+	})
+
+	Describe("status derivation under error conditions", func() {
+		It("counts a panic as 500 (recover.New() runs inside the metrics middleware)", func() {
+			// The metrics middleware wraps recover.New, so a panic must
+			// surface back through the metrics middleware as an error,
+			// get mapped to 500, and land in the requests_total counter.
+			// Use a bare test app so the route registration here does not
+			// pollute the suite-level Server with /_test/* paths.
+			m, app := newTestApp()
+			app.Get("/_test/panic", func(c *fiber.Ctx) error {
+				panic("boom")
+			})
+
+			req, err := http.NewRequestWithContext(
+				context.Background(), http.MethodGet, "/_test/panic", nil)
+			Expect(err).NotTo(HaveOccurred())
+			resp, err := app.Test(req)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.StatusCode).To(Equal(http.StatusInternalServerError))
+
+			Expect(counterValue(m.Registry(),
+				"/_test/panic", http.MethodGet, "500")).To(Equal(1.0))
+		})
+
+		It("counts a wrapped *fiber.Error with the wrapped status code", func() {
+			// errors.As inside resolveStatus should recover the inner
+			// fiber.Error from a fmt.Errorf("...: %w", ...) wrap, matching
+			// what Fiber's own ErrorHandler does — so the metrics row
+			// agrees with the actual response status the client sees.
+			m, app := newTestApp()
+			app.Get("/_test/wrapped", func(c *fiber.Ctx) error {
+				return fmt.Errorf("validation failed: %w", fiber.ErrBadRequest)
+			})
+
+			req, err := http.NewRequestWithContext(
+				context.Background(), http.MethodGet, "/_test/wrapped", nil)
+			Expect(err).NotTo(HaveOccurred())
+			resp, err := app.Test(req)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
+
+			Expect(counterValue(m.Registry(),
+				"/_test/wrapped", http.MethodGet, "400")).To(Equal(1.0))
+		})
+
+		It("keeps unmatched-route attribution intact even when a literal '/' route is registered", func() {
+			// Defensive contract test, intentionally fragile.
+			//
+			// Today the unmatched bucket relies on isRouterNotFound: an
+			// unmatched URL leaves c.Route().Path pointing at the
+			// metrics-middleware mount path (which is "/"), and we
+			// reassign route to "unmatched" only because the router
+			// emits a 404 *fiber.Error. If a future change either
+			//
+			//   (a) removes the isRouterNotFound branch in Middleware,
+			//       or
+			//   (b) registers a real handler at literal "/" while
+			//       leaving the unmatched detection in place,
+			//
+			// real "/" traffic and unmatched-router-fallthrough traffic
+			// could both label-encode as route="/" and the unmatched
+			// sentinel would silently disappear. This spec exercises
+			// case (b): a real "/" handler IS registered, and the
+			// assertion is that unmatched URLs still land on
+			// route="unmatched", NOT on route="/" with status="404".
+			//
+			// If this test ever fails, the contract is broken — read
+			// the comment in api/metrics.go around isRouterNotFound and
+			// decide whether to widen the unmatched detection or accept
+			// the new behavior. Don't paper over the assertion.
+			m, app := newTestApp()
+			app.Get("/", func(c *fiber.Ctx) error { return c.SendString("home") })
+
+			// Hit the real "/" handler — should land on route="/" 200.
+			homeReq, err := http.NewRequestWithContext(
+				context.Background(), http.MethodGet, "/", nil)
+			Expect(err).NotTo(HaveOccurred())
+			homeResp, err := app.Test(homeReq)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(homeResp.StatusCode).To(Equal(http.StatusOK))
+
+			// Hit a path that doesn't match anything — should land on
+			// route="unmatched" 404, NOT on route="/" 404.
+			missReq, err := http.NewRequestWithContext(
+				context.Background(), http.MethodGet, "/totally/unknown", nil)
+			Expect(err).NotTo(HaveOccurred())
+			missResp, err := app.Test(missReq)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(missResp.StatusCode).To(Equal(http.StatusNotFound))
+
+			Expect(counterValue(m.Registry(), "/", http.MethodGet, "200")).
+				To(Equal(1.0), "real / traffic must count as route=/ status=200")
+			Expect(counterValue(m.Registry(), "unmatched", http.MethodGet, "404")).
+				To(Equal(1.0), "unmatched paths must still bucket as unmatched even with a real / route registered")
+			Expect(counterValue(m.Registry(), "/", http.MethodGet, "404")).
+				To(Equal(0.0), "unmatched 404s must NOT leak into the / route bucket")
+		})
+
+		It("buckets a handler-emitted fiber.ErrNotFound on the registered route template, not unmatched", func() {
+			// isRouterNotFound must distinguish the framework's catchall
+			// 404 (fresh *fiber.Error with message "Cannot METHOD /path")
+			// from a handler returning the package singleton fiber.ErrNotFound.
+			// The first should bucket as unmatched; the second should keep
+			// its route template label so the route dimension survives.
+			m, app := newTestApp()
+			app.Get("/_test/notfound", func(c *fiber.Ctx) error {
+				return fiber.ErrNotFound
+			})
+
+			req, err := http.NewRequestWithContext(
+				context.Background(), http.MethodGet, "/_test/notfound", nil)
+			Expect(err).NotTo(HaveOccurred())
+			resp, err := app.Test(req)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+
+			Expect(counterValue(m.Registry(), "/_test/notfound", http.MethodGet, "404")).
+				To(Equal(1.0), "handler-emitted fiber.ErrNotFound must bucket on its registered route, not unmatched")
+			Expect(counterValue(m.Registry(), "unmatched", http.MethodGet, "404")).
+				To(Equal(0.0), "handler-returned fiber.ErrNotFound must not collapse into the unmatched sentinel")
+		})
+
+		It("buckets a wrapped fiber.ErrNotFound on the registered route template", func() {
+			// Same contract as the previous spec, exercised through an
+			// errors.Wrap chain. errors.Is unwraps until it finds the
+			// singleton, so wrapped not-founds are also identified as
+			// handler-emitted and keep their route dimension.
+			m, app := newTestApp()
+			app.Get("/_test/wrapped-notfound", func(c *fiber.Ctx) error {
+				return fmt.Errorf("session lookup: %w", fiber.ErrNotFound)
+			})
+
+			req, err := http.NewRequestWithContext(
+				context.Background(), http.MethodGet, "/_test/wrapped-notfound", nil)
+			Expect(err).NotTo(HaveOccurred())
+			resp, err := app.Test(req)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+
+			Expect(counterValue(m.Registry(), "/_test/wrapped-notfound", http.MethodGet, "404")).
+				To(Equal(1.0), "wrapped fiber.ErrNotFound must bucket on its registered route, not unmatched")
+		})
+	})
+
+	Describe("Handler() lifecycle", func() {
+		It("can be called repeatedly without panicking (regression: promhttp.HandlerFor double-MustRegister)", func() {
+			// promhttp.HandlerFor with a non-nil Registry calls
+			// MustRegister(...) on the registry to instrument the scrape
+			// handler itself. Pre-fix this method built a fresh handler
+			// per call, so a second call would panic. The fix caches the
+			// handler at NewMetrics time; this spec guards the behavior.
+			m := NewMetrics()
+			Expect(func() { _ = m.Handler() }).NotTo(Panic())
+			Expect(func() { _ = m.Handler() }).NotTo(Panic())
+			Expect(func() { _ = m.Handler() }).NotTo(Panic())
+		})
+	})
+
+	Describe("/ping happy path", func() {
+		It("increments the templated /ping row with status 200", func() {
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "/ping", nil)
+			Expect(err).NotTo(HaveOccurred())
+			resp, err := server.app.Test(req)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+			// Sanity: the duration histogram also got an observation. We
+			// don't assert on bucket boundaries — Prometheus' DefBuckets
+			// can shift and the test would become flaky — only that the
+			// histogram for this (route, method) was touched.
+			body, err := metricsScrape(server)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(body).To(ContainSubstring(`tapes_apiserver_request_duration_seconds_count{method="GET",route="/ping"}`))
+
+			Expect(counterValue(server.metrics.Registry(),
+				"/ping", http.MethodGet, "200")).To(Equal(1.0))
+		})
+	})
+})
+
+// metricsScrape pulls the /metrics body once. Centralised so the assertions
+// above don't each have to repeat the request boilerplate.
+func metricsScrape(s *Server) (string, error) {
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "/metrics", nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := s.app.Test(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	// Trim trailing newline noise so callers can ContainSubstring cleanly.
+	return strings.TrimRight(string(b), "\n"), nil
+}

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/pgvector/pgvector-go v0.3.0
 	github.com/posthog/posthog-go v1.10.0
 	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/client_model v0.6.2
 	github.com/segmentio/kafka-go v0.4.50
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
@@ -92,7 +93,6 @@ require (
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/pierrec/lz4/v4 v4.1.16 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect

--- a/ingest/ingest.go
+++ b/ingest/ingest.go
@@ -364,8 +364,14 @@ func (s *Server) processTurn(turn *TurnPayload) error {
 			"agent", turn.AgentName,
 			"model", parsedReq.Model,
 		)
+		// Snapshot depth even on a drop so the gauge reflects saturation.
+		s.metrics.SetQueueDepth(s.workerPool.Len())
 		return fmt.Errorf("%w: worker queue full", ErrDownstream)
 	}
 
+	// Best-effort snapshot of post-enqueue depth. Workers may have already
+	// drained the slot we just wrote, so the value can lag actual depth — but
+	// over many turns this tracks back-pressure well enough to alert on.
+	s.metrics.SetQueueDepth(s.workerPool.Len())
 	return nil
 }

--- a/ingest/metrics.go
+++ b/ingest/metrics.go
@@ -44,7 +44,7 @@ func NewMetrics() *Metrics {
 		),
 		queueDepth: prometheus.NewGauge(prometheus.GaugeOpts{
 			Name: "tapes_ingest_worker_queue_depth",
-			Help: "Best-effort snapshot of pending items in the ingest worker queue.",
+			Help: "Best-effort snapshot of pending items in the worker queue, as observed on the ingest enqueue path. The underlying Pool is shared with the proxy enqueue paths, which do not currently update this gauge — so the value reflects ingest-side observations only.",
 		}),
 		bytesHistory: prometheus.NewHistogramVec(
 			prometheus.HistogramOpts{

--- a/proxy/worker/pool.go
+++ b/proxy/worker/pool.go
@@ -119,6 +119,14 @@ func (p *Pool) Enqueue(job Job) bool {
 	}
 }
 
+// Len returns the current number of jobs buffered in the queue. It is a
+// best-effort snapshot — workers may pick up items between the read and any
+// downstream observation — and is intended for metric instrumentation rather
+// than for routing decisions.
+func (p *Pool) Len() int {
+	return len(p.queue)
+}
+
 // Close signals workers to stop and waits for in-flight jobs to drain.
 // Call this during graceful shutdown after the proxy HTTP server has stopped.
 func (p *Pool) Close() {

--- a/proxy/worker/pool_test.go
+++ b/proxy/worker/pool_test.go
@@ -68,6 +68,34 @@ var _ = Describe("Worker Pool", func() {
 		})
 	})
 
+	Describe("Len", func() {
+		It("reports zero on an empty, drained pool", func() {
+			wp.Close()
+			Expect(wp.Len()).To(Equal(0))
+		})
+
+		It("reflects pending items still on the queue", func() {
+			// The drained-pool spec above would still pass against a
+			// stub `Len() int { return 0 }` regression — that's the
+			// hazard the production gauge actually reads. Exercise the
+			// accessor with non-zero pending items.
+			//
+			// Bypassing NewPool here is deliberate: NewPool starts
+			// workers that would drain whatever we enqueue before the
+			// assertion runs, so a pool wired to a stub queue with no
+			// consumers is the only way to read Len() deterministically
+			// across non-empty states.
+			p := &Pool{queue: make(chan Job, 4)}
+			Expect(p.Len()).To(Equal(0))
+
+			p.queue <- Job{Provider: "first"}
+			Expect(p.Len()).To(Equal(1))
+
+			p.queue <- Job{Provider: "second"}
+			Expect(p.Len()).To(Equal(2))
+		})
+	})
+
 	Describe("Multi-Turn Conversation Storage", func() {
 		// These tests exercise the worker pool's storeConversationTurn logic
 		// by enqueuing jobs and draining via wp.Close() before asserting storage state.


### PR DESCRIPTION
## Summary

Two related but independent instrumentation gaps closed in one PR (two commits). Both sit behind the cluster's `annotationAutodiscovery` configuration once a tapes release containing them lands and the per-tenant ingest pod annotation for the cloud.

### Commit 1 — Wire ingest worker queue depth gauge

The gauge `tapes_ingest_worker_queue_depth` was already registered in `ingest/metrics.go` but never `Set` anywhere — it shipped as flatline-zero. This commit:

- Adds `Pool.Len() int` to `proxy/worker/pool.go` (returns `len(p.queue)`).
- Calls `s.metrics.SetQueueDepth(s.workerPool.Len())` on both enqueue paths in `processTurn`.
- Tightens the gauge's Help text to flag that values reflect ingest-path observations only — the underlying `Pool` is shared with three proxy `Enqueue` call sites that don't currently update the gauge. Wiring those is filed as a follow-up.
- Adds a `Len()` test that exercises non-zero queue state via a stub-channel `Pool` (bypasses `NewPool` so workers don't drain before the assertion). The pre-existing drained-pool spec would have passed against a `Len() int { return 0 }` regression; this one wouldn't.

### Commit 2 — Expose Prometheus RED metrics from the API server

The tapes API server previously had no `/metrics`. 

- New `tapes_apiserver_requests_total{route,method,status}` counter, `tapes_apiserver_request_duration_seconds{route,method}` histogram, `tapes_apiserver_inflight_requests` gauge.
- `/metrics` mounted via `gofiber/adaptor/v2` (the Fiber-blessed shim — explicitly NOT `valyala/fasthttp/fasthttpadaptor`, since that mixes web frameworks).
- Fiber RED middleware ordered BEFORE `recover.New()` so panicked requests are still counted (a panic propagating through `c.Next()` would otherwise skip the post-Next counter increments and disappear from RED metrics).
- `resolveStatus` helper uses `errors.As` so a wrapped `*fiber.Error` (e.g. `fmt.Errorf("...: %w", fiber.ErrBadRequest)`) gets the wrapped status code in metrics, matching what Fiber's own ErrorHandler does.
- New `isRouterNotFound(err)` helper for the unmatched-route sentinel

Route labels stay templated (`/v1/sessions/:hash`, never the materialized URL) — bounded cardinality regardless of session count.

## Tests

- New `newTestApp()` helper for specs that exercise middleware behavior in isolation. Used by the panic, wrapped-error, and unmatched-attribution specs so they don't pollute the suite-level Server with `/_test/*` paths.
- Defensive contract test: registers a real `/` handler AND fires an unmatched URL, asserts the unmatched bucket stays distinct from the `/` row. Intentionally fragile — if anyone breaks `isRouterNotFound` or trips a related collision, this fails. Comment explicitly tells the future reader to read the rationale before papering over the assertion.
- `tapes_apiserver_*` cardinality contract verified: templated `:hash` collapses two materialized URLs onto one row; three never-registered URLs collapse to one `unmatched` row.

## Verified

- `go vet ./...` clean
- `make format` clean
- 44/44 specs in `api/`, 13/13 in `proxy/worker/`, ingest suite green
- Pre-PR review confirmed: `Pool.Len()` exported surface justified (cross-package use); `errors.As` usage textbook; constructor pattern matches `NewExampleStruct` paradigm per `AGENTS.md`; no new module deps; Ginkgo idioms consistent with neighboring suites.
