### PR TITLE
🔧 fix: Nightly releases logs into ECR public correctly

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -64,9 +64,11 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: us-east-1
 
-      - name: Login to ECR
-        id: login-ecr
+      - name: Login to ECR Public
+        id: login-ecr-public
         uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
 
       - name: Move nightly tag up to HEAD
         run: |


### PR DESCRIPTION
Nightly release workflows were failing due to the ECR login not correctly targeting ECR public:
https://github.com/papercomputeco/tapes/actions/workflows/nightly.yaml

This patch fixes that by using `registry-type: public`