### PR TITLE
✨ feat: minimal Prometheus like web UI for visualizing dag

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -56,12 +56,17 @@ func NewServer(config Config, driver storage.Driver, log *slog.Logger) (*Server,
 
 	app.Get("/ping", s.handlePing)
 
+	// Minimal same-origin web UI. Like Prometheus's built-in UI, this is
+	// served directly by the API binary and has no frontend build step.
+	app.Get("/", s.handleWebUI)
+
 	// v1 session-oriented surface. Static paths are registered before
 	// parameterised ones so `/v1/sessions/summary` is not shadowed by
 	// `/v1/sessions/:hash`.
 	app.Get("/v1/stats", s.handleStats)
 	app.Get("/v1/sessions", s.handleListSessions)
 	app.Get("/v1/sessions/summary", s.handleListSessionsSummary)
+	app.Get("/v1/sessions/:hash/graph", s.handleGetSessionGraph)
 	app.Get("/v1/sessions/:hash", s.handleGetSession)
 	app.Get("/v1/search", s.handleSearchEndpoint)
 	app.Post("/v1/admin/seed/demo", s.handleSeedDemo)

--- a/api/api.go
+++ b/api/api.go
@@ -56,9 +56,11 @@ func NewServer(config Config, driver storage.Driver, log *slog.Logger) (*Server,
 
 	app.Get("/ping", s.handlePing)
 
-	// Minimal same-origin web UI. Like Prometheus's built-in UI, this is
-	// served directly by the API binary and has no frontend build step.
-	app.Get("/", s.handleWebUI)
+	if config.EnableWebUI {
+		// Minimal same-origin web UI. Like Prometheus's built-in UI, this is
+		// served directly by the API binary and has no frontend build step.
+		app.Get("/", s.handleWebUI)
+	}
 
 	// v1 session-oriented surface. Static paths are registered before
 	// parameterised ones so `/v1/sessions/summary` is not shadowed by

--- a/api/config.go
+++ b/api/config.go
@@ -21,4 +21,9 @@ type Config struct {
 	// Pricing is the model pricing table used by /v1/sessions/summary to
 	// compute per-session cost. When nil, sessions.DefaultPricing() is used.
 	Pricing sessions.PricingTable
+
+	// EnableWebUI serves the minimal browser UI at /. It is disabled by default
+	// so API-only servers do not expose a human-facing development UI unless
+	// explicitly requested.
+	EnableWebUI bool
 }

--- a/api/graph_handlers.go
+++ b/api/graph_handlers.go
@@ -168,11 +168,13 @@ func newGraphResponseBuilder(driver storage.Driver, requestedHash, scope string,
 		scope:         scope,
 		maxNodes:      maxNodes,
 		resp: &GraphResponse{
-			Hash:      requestedHash,
-			Scope:     scope,
-			NodeLimit: maxNodes,
-			Nodes:     []GraphNode{},
-			Links:     []GraphLink{},
+			Hash:         requestedHash,
+			Scope:        scope,
+			NodeLimit:    maxNodes,
+			Nodes:        []GraphNode{},
+			Links:        []GraphLink{},
+			Leaves:       []string{},
+			BranchPoints: []string{},
 		},
 		seenNode: make(map[string]struct{}),
 		seenLink: make(map[string]struct{}),
@@ -192,14 +194,22 @@ func (b *graphResponseBuilder) build(ctx context.Context, chain *storage.Chain) 
 		if ok, err := b.addAncestryPath(ctx, rootFirst); err != nil || !ok {
 			return b.resp, err
 		}
-		if err := b.addDescendants(ctx, rootFirst[0], 0, map[string]struct{}{rootFirst[0].Hash: {}}); err != nil {
-			return nil, err
+		pathSeen := map[string]struct{}{}
+		for i, node := range rootFirst {
+			pathSeen[node.Hash] = struct{}{}
+			var skip map[string]struct{}
+			if i+1 < len(rootFirst) {
+				skip = map[string]struct{}{rootFirst[i+1].Hash: {}}
+			}
+			if err := b.addDescendants(ctx, node, i, pathSeen, skip); err != nil {
+				return nil, err
+			}
 		}
 	case "branch":
 		if ok, err := b.addAncestryPath(ctx, rootFirst); err != nil || !ok {
 			return b.resp, err
 		}
-		if err := b.addDescendants(ctx, rootFirst[len(rootFirst)-1], len(rootFirst)-1, hashesFromNodes(rootFirst)); err != nil {
+		if err := b.addDescendants(ctx, rootFirst[len(rootFirst)-1], len(rootFirst)-1, hashesFromNodes(rootFirst), nil); err != nil {
 			return nil, err
 		}
 	case "ancestry":
@@ -224,13 +234,17 @@ func (b *graphResponseBuilder) addAncestryPath(ctx context.Context, rootFirst []
 	return true, nil
 }
 
-func (b *graphResponseBuilder) addDescendants(ctx context.Context, parent *merkle.Node, parentDepth int, pathSeen map[string]struct{}) error {
+func (b *graphResponseBuilder) addDescendants(ctx context.Context, parent *merkle.Node, parentDepth int, pathSeen, skip map[string]struct{}) error {
 	children, err := b.childrenOf(ctx, parent.Hash)
 	if err != nil {
 		return err
 	}
 
 	for _, child := range children {
+		if _, ok := skip[child.Hash]; ok {
+			b.addLink(stringPtr(parent.Hash), child.Hash)
+			continue
+		}
 		if _, ok := pathSeen[child.Hash]; ok {
 			b.resp.Truncated = true
 			b.resp.CycleDetected = true
@@ -243,7 +257,7 @@ func (b *graphResponseBuilder) addDescendants(ctx context.Context, parent *merkl
 		}
 
 		pathSeen[child.Hash] = struct{}{}
-		if err := b.addDescendants(ctx, child, parentDepth+1, pathSeen); err != nil {
+		if err := b.addDescendants(ctx, child, parentDepth+1, pathSeen, nil); err != nil {
 			return err
 		}
 		delete(pathSeen, child.Hash)

--- a/api/graph_handlers.go
+++ b/api/graph_handlers.go
@@ -1,0 +1,358 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/papercomputeco/tapes/pkg/llm"
+	"github.com/papercomputeco/tapes/pkg/merkle"
+	"github.com/papercomputeco/tapes/pkg/storage"
+)
+
+const (
+	defaultGraphMaxNodes = 500
+	upperGraphMaxNodes   = 5000
+)
+
+// GraphResponse is the graph-shaped projection for GET /v1/sessions/:hash/graph.
+type GraphResponse struct {
+	// Hash is the session/node hash requested by the caller.
+	Hash string `json:"hash"`
+
+	// RootHash is the top-most resolvable node included in the response.
+	RootHash string `json:"root_hash"`
+
+	// Scope describes which portion of the graph was loaded: root, branch, or ancestry.
+	Scope string `json:"scope"`
+
+	// NodeLimit is the maximum number of nodes the server will include.
+	NodeLimit int `json:"node_limit"`
+
+	// Nodes is the flat node list consumed by graph visualizers.
+	Nodes []GraphNode `json:"nodes"`
+
+	// Links contains parent -> child edges between included nodes.
+	Links []GraphLink `json:"links"`
+
+	// Leaves names included nodes that have no children in storage.
+	Leaves []string `json:"leaves"`
+
+	// BranchPoints names included nodes with more than one child in storage.
+	BranchPoints []string `json:"branch_points"`
+
+	// Truncated is true when the graph hit NodeLimit or the ancestry chain is incomplete.
+	Truncated bool `json:"truncated,omitempty"`
+
+	// MissingParent names the unresolved parent hash when the ancestry is incomplete.
+	MissingParent string `json:"missing_parent,omitempty"`
+
+	// CycleDetected is true when storage guarded the ancestry walk out of a cycle.
+	CycleDetected bool `json:"cycle_detected,omitempty"`
+}
+
+// GraphNode is the per-node shape used by the web UI graph visualization.
+type GraphNode struct {
+	ID            string     `json:"id"`
+	ParentID      *string    `json:"parent_id,omitempty"`
+	ParentHash    *string    `json:"parent_hash,omitempty"`
+	Type          string     `json:"type,omitempty"`
+	Role          string     `json:"role,omitempty"`
+	Preview       string     `json:"preview,omitempty"`
+	Model         string     `json:"model,omitempty"`
+	Provider      string     `json:"provider,omitempty"`
+	AgentName     string     `json:"agent_name,omitempty"`
+	Project       string     `json:"project,omitempty"`
+	StopReason    string     `json:"stop_reason,omitempty"`
+	Usage         *llm.Usage `json:"usage,omitempty"`
+	CreatedAt     time.Time  `json:"created_at,omitzero"`
+	Depth         int        `json:"depth"`
+	ChildrenCount int        `json:"children_count"`
+	IsRoot        bool       `json:"is_root"`
+	IsLeaf        bool       `json:"is_leaf"`
+	IsBranchPoint bool       `json:"is_branch_point"`
+	Selected      bool       `json:"selected"`
+}
+
+// GraphLink is a directed parent -> child edge between two included GraphNode IDs.
+type GraphLink struct {
+	Source string `json:"source"`
+	Target string `json:"target"`
+}
+
+// handleGetSessionGraph handles GET /v1/sessions/:hash/graph.
+//
+//	@Summary		Get a session graph
+//	@Description	Returns a graph-shaped projection of the same session ancestry returned by GET /v1/sessions/{hash}. scope=root loads the requested node's resolvable root and all descendants, scope=branch loads the ancestry plus descendants of the requested node, and scope=ancestry loads only the parent chain.
+//	@Tags			sessions
+//	@Produce		json
+//	@Param			hash		path	string	true	"Session hash"
+//	@Param			scope		query	string	false	"Graph scope: root, branch, or ancestry" Enums(root, branch, ancestry)
+//	@Param			max_nodes	query	int		false	"Maximum number of graph nodes to include" minimum(1) maximum(5000)
+//	@Success		200			{object}	GraphResponse
+//	@Failure		400			{object}	llm.ErrorResponse	"Missing hash or invalid query parameters"
+//	@Failure		404			{object}	llm.ErrorResponse	"Session not found"
+//	@Failure		500			{object}	llm.ErrorResponse	"Failed to load session graph"
+//	@Router			/v1/sessions/{hash}/graph [get]
+func (s *Server) handleGetSessionGraph(c *fiber.Ctx) error {
+	hash, chain, err := s.loadSessionChain(c)
+	if err != nil {
+		return s.handleLoadSessionChainError(c, hash, err)
+	}
+
+	scope := c.Query("scope", "root")
+	if !validGraphScope(scope) {
+		return c.Status(fiber.StatusBadRequest).JSON(llm.ErrorResponse{Error: "scope must be one of: root, branch, ancestry"})
+	}
+
+	maxNodes, err := parseGraphMaxNodes(c.Query("max_nodes"))
+	if err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(llm.ErrorResponse{Error: err.Error()})
+	}
+
+	builder := newGraphResponseBuilder(s.driver, hash, scope, maxNodes)
+	resp, err := builder.build(c.Context(), chain)
+	if err != nil {
+		s.logger.Error("build session graph response", "hash", hash, "scope", scope, "error", err)
+		return c.Status(fiber.StatusInternalServerError).JSON(llm.ErrorResponse{Error: "failed to load session graph"})
+	}
+
+	return c.JSON(resp)
+}
+
+func validGraphScope(scope string) bool {
+	switch scope {
+	case "root", "branch", "ancestry":
+		return true
+	default:
+		return false
+	}
+}
+
+func parseGraphMaxNodes(raw string) (int, error) {
+	if raw == "" {
+		return defaultGraphMaxNodes, nil
+	}
+	parsed, err := strconv.Atoi(raw)
+	if err != nil || parsed <= 0 {
+		return 0, errors.New("max_nodes must be a positive integer")
+	}
+	if parsed > upperGraphMaxNodes {
+		return 0, fmt.Errorf("max_nodes must be less than or equal to %d", upperGraphMaxNodes)
+	}
+	return parsed, nil
+}
+
+type graphResponseBuilder struct {
+	driver storage.Driver
+
+	requestedHash string
+	scope         string
+	maxNodes      int
+
+	resp     *GraphResponse
+	seenNode map[string]struct{}
+	seenLink map[string]struct{}
+	children map[string][]*merkle.Node
+}
+
+func newGraphResponseBuilder(driver storage.Driver, requestedHash, scope string, maxNodes int) *graphResponseBuilder {
+	return &graphResponseBuilder{
+		driver:        driver,
+		requestedHash: requestedHash,
+		scope:         scope,
+		maxNodes:      maxNodes,
+		resp: &GraphResponse{
+			Hash:      requestedHash,
+			Scope:     scope,
+			NodeLimit: maxNodes,
+			Nodes:     []GraphNode{},
+			Links:     []GraphLink{},
+		},
+		seenNode: make(map[string]struct{}),
+		seenLink: make(map[string]struct{}),
+		children: make(map[string][]*merkle.Node),
+	}
+}
+
+func (b *graphResponseBuilder) build(ctx context.Context, chain *storage.Chain) (*GraphResponse, error) {
+	rootFirst := reverseNodes(chain.Nodes)
+	b.resp.RootHash = rootFirst[0].Hash
+	b.resp.Truncated = chain.Incomplete
+	b.resp.MissingParent = chain.MissingParent
+	b.resp.CycleDetected = chain.CycleDetected
+
+	switch b.scope {
+	case "root":
+		if ok, err := b.addAncestryPath(ctx, rootFirst); err != nil || !ok {
+			return b.resp, err
+		}
+		if err := b.addDescendants(ctx, rootFirst[0], 0, map[string]struct{}{rootFirst[0].Hash: {}}); err != nil {
+			return nil, err
+		}
+	case "branch":
+		if ok, err := b.addAncestryPath(ctx, rootFirst); err != nil || !ok {
+			return b.resp, err
+		}
+		if err := b.addDescendants(ctx, rootFirst[len(rootFirst)-1], len(rootFirst)-1, hashesFromNodes(rootFirst)); err != nil {
+			return nil, err
+		}
+	case "ancestry":
+		if _, err := b.addAncestryPath(ctx, rootFirst); err != nil {
+			return b.resp, err
+		}
+	}
+
+	return b.resp, nil
+}
+
+func (b *graphResponseBuilder) addAncestryPath(ctx context.Context, rootFirst []*merkle.Node) (bool, error) {
+	for i, node := range rootFirst {
+		var parentID *string
+		if i > 0 {
+			parentID = stringPtr(rootFirst[i-1].Hash)
+		}
+		if ok, err := b.addNode(ctx, node, parentID, i); err != nil || !ok {
+			return ok, err
+		}
+	}
+	return true, nil
+}
+
+func (b *graphResponseBuilder) addDescendants(ctx context.Context, parent *merkle.Node, parentDepth int, pathSeen map[string]struct{}) error {
+	children, err := b.childrenOf(ctx, parent.Hash)
+	if err != nil {
+		return err
+	}
+
+	for _, child := range children {
+		if _, ok := pathSeen[child.Hash]; ok {
+			b.resp.Truncated = true
+			b.resp.CycleDetected = true
+			continue
+		}
+
+		ok, err := b.addNode(ctx, child, stringPtr(parent.Hash), parentDepth+1)
+		if err != nil || !ok {
+			return err
+		}
+
+		pathSeen[child.Hash] = struct{}{}
+		if err := b.addDescendants(ctx, child, parentDepth+1, pathSeen); err != nil {
+			return err
+		}
+		delete(pathSeen, child.Hash)
+	}
+
+	return nil
+}
+
+func (b *graphResponseBuilder) addNode(ctx context.Context, node *merkle.Node, parentID *string, depth int) (bool, error) {
+	if _, ok := b.seenNode[node.Hash]; ok {
+		b.addLink(parentID, node.Hash)
+		return true, nil
+	}
+	if len(b.resp.Nodes) >= b.maxNodes {
+		b.resp.Truncated = true
+		return false, nil
+	}
+
+	children, err := b.childrenOf(ctx, node.Hash)
+	if err != nil {
+		return false, err
+	}
+	childrenCount := len(children)
+
+	b.seenNode[node.Hash] = struct{}{}
+	b.resp.Nodes = append(b.resp.Nodes, GraphNode{
+		ID:            node.Hash,
+		ParentID:      copyStringPtr(parentID),
+		ParentHash:    copyStringPtr(node.ParentHash),
+		Type:          node.Bucket.Type,
+		Role:          node.Bucket.Role,
+		Preview:       makePreview(node),
+		Model:         node.Bucket.Model,
+		Provider:      node.Bucket.Provider,
+		AgentName:     node.Bucket.AgentName,
+		Project:       node.Project,
+		StopReason:    node.StopReason,
+		Usage:         node.Usage,
+		CreatedAt:     node.CreatedAt,
+		Depth:         depth,
+		ChildrenCount: childrenCount,
+		IsRoot:        parentID == nil,
+		IsLeaf:        childrenCount == 0,
+		IsBranchPoint: childrenCount > 1,
+		Selected:      node.Hash == b.requestedHash,
+	})
+
+	b.addLink(parentID, node.Hash)
+	if childrenCount == 0 {
+		b.resp.Leaves = append(b.resp.Leaves, node.Hash)
+	}
+	if childrenCount > 1 {
+		b.resp.BranchPoints = append(b.resp.BranchPoints, node.Hash)
+	}
+	return true, nil
+}
+
+func (b *graphResponseBuilder) childrenOf(ctx context.Context, hash string) ([]*merkle.Node, error) {
+	if children, ok := b.children[hash]; ok {
+		return children, nil
+	}
+
+	children, err := b.driver.GetByParent(ctx, &hash)
+	if err != nil {
+		return nil, fmt.Errorf("getting children of %s: %w", hash, err)
+	}
+	sort.Slice(children, func(i, j int) bool {
+		return merkleNodeLess(children[i], children[j])
+	})
+	b.children[hash] = children
+	return children, nil
+}
+
+func (b *graphResponseBuilder) addLink(parentID *string, childID string) {
+	if parentID == nil {
+		return
+	}
+	key := *parentID + "\x00" + childID
+	if _, ok := b.seenLink[key]; ok {
+		return
+	}
+	b.seenLink[key] = struct{}{}
+	b.resp.Links = append(b.resp.Links, GraphLink{Source: *parentID, Target: childID})
+}
+
+func merkleNodeLess(a, b *merkle.Node) bool {
+	if !a.CreatedAt.Equal(b.CreatedAt) {
+		return a.CreatedAt.Before(b.CreatedAt)
+	}
+	return a.Hash < b.Hash
+}
+
+func hashesFromNodes(nodes []*merkle.Node) map[string]struct{} {
+	out := make(map[string]struct{}, len(nodes))
+	for _, n := range nodes {
+		out[n.Hash] = struct{}{}
+	}
+	return out
+}
+
+func stringPtr(s string) *string {
+	v := s
+	return &v
+}
+
+func copyStringPtr(in *string) *string {
+	if in == nil {
+		return nil
+	}
+	v := *in
+	return &v
+}

--- a/api/graph_handlers_test.go
+++ b/api/graph_handlers_test.go
@@ -112,6 +112,16 @@ var _ = Describe("GET /v1/sessions/:hash/graph", func() {
 		Expect(body.Truncated).To(BeTrue())
 		Expect(body.NodeLimit).To(Equal(2))
 		Expect(body.Nodes).To(HaveLen(2))
+		Expect(body.Leaves).NotTo(BeNil())
+	})
+
+	It("serializes empty graph arrays as JSON arrays", func() {
+		isolated := merkle.NewNode(v1TestBucket("user", "solo", "m", "p", "claude"), nil, merkle.NodeOptions{Project: "tapes"})
+		Expect(putNode(ctx, inMem, isolated)).To(Succeed())
+
+		body := decodeGraph(server, sessionGraphPath(isolated.Hash))
+		Expect(body.Leaves).To(Equal([]string{isolated.Hash}))
+		Expect(body.BranchPoints).To(Equal([]string{}))
 	})
 
 	It("prioritizes the requested ancestry path before sibling branches when node-limited", func() {
@@ -198,7 +208,8 @@ var _ = Describe("minimal web UI", func() {
 
 		raw, err := io.ReadAll(resp.Body)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(string(raw)).To(ContainSubstring("d3@7"))
+		Expect(string(raw)).To(ContainSubstring("d3@7.9.0"))
+		Expect(string(raw)).To(ContainSubstring("integrity=\"sha256-1AqCL/P1MtPZ9HQLjuNAO+QOIV1Q7AhiAl2fT14nSI=\""))
 		Expect(string(raw)).To(ContainSubstring("/v1/sessions/"))
 		Expect(string(raw)).To(ContainSubstring("/v1/sessions/summary"))
 		Expect(string(raw)).NotTo(ContainSubstring("/v1/dags/"))

--- a/api/graph_handlers_test.go
+++ b/api/graph_handlers_test.go
@@ -173,8 +173,19 @@ var _ = Describe("minimal web UI", func() {
 
 	BeforeEach(func() {
 		var err error
-		server, err = NewServer(Config{ListenAddr: ":0"}, inmemory.NewDriver(), tapeslogger.NewNoop())
+		server, err = NewServer(Config{ListenAddr: ":0", EnableWebUI: true}, inmemory.NewDriver(), tapeslogger.NewNoop())
 		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("does not serve the UI unless explicitly enabled", func() {
+		defaultServer, err := NewServer(Config{ListenAddr: ":0"}, inmemory.NewDriver(), tapeslogger.NewNoop())
+		Expect(err).NotTo(HaveOccurred())
+
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+		Expect(err).NotTo(HaveOccurred())
+		resp, err := defaultServer.app.Test(req)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.StatusCode).To(Equal(fiber.StatusNotFound))
 	})
 
 	It("serves the D3 UI from / without a frontend build", func() {

--- a/api/graph_handlers_test.go
+++ b/api/graph_handlers_test.go
@@ -1,0 +1,242 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	tapeslogger "github.com/papercomputeco/tapes/pkg/logger"
+	"github.com/papercomputeco/tapes/pkg/merkle"
+	"github.com/papercomputeco/tapes/pkg/storage"
+	"github.com/papercomputeco/tapes/pkg/storage/inmemory"
+)
+
+var _ = Describe("GET /v1/sessions/:hash/graph", func() {
+	var (
+		server *Server
+		inMem  storage.Driver
+		ctx    context.Context
+
+		root       *merkle.Node
+		child1     *merkle.Node
+		child2     *merkle.Node
+		grandchild *merkle.Node
+	)
+
+	BeforeEach(func() {
+		logger := tapeslogger.NewNoop()
+		inMem = inmemory.NewDriver()
+		ctx = context.Background()
+
+		var err error
+		server, err = NewServer(Config{ListenAddr: ":0"}, inMem, logger)
+		Expect(err).NotTo(HaveOccurred())
+
+		baseTime := time.Date(2026, 4, 2, 9, 0, 0, 0, time.UTC)
+		root = merkle.NewNode(v1TestBucket("user", "root prompt", "claude-sonnet", "anthropic", "claude"), nil, merkle.NodeOptions{Project: "tapes"})
+		root.CreatedAt = baseTime
+		child1 = merkle.NewNode(v1TestBucket("assistant", "first branch", "claude-sonnet", "anthropic", "claude"), root, merkle.NodeOptions{Project: "tapes"})
+		child1.CreatedAt = baseTime.Add(time.Minute)
+		child2 = merkle.NewNode(v1TestBucket("assistant", "second branch", "gpt-4o", "openai", "codex"), root, merkle.NodeOptions{Project: "tapes"})
+		child2.CreatedAt = baseTime.Add(2 * time.Minute)
+		grandchild = merkle.NewNode(v1TestBucket("user", "follow-up", "claude-sonnet", "anthropic", "claude"), child1, merkle.NodeOptions{Project: "tapes"})
+		grandchild.CreatedAt = baseTime.Add(3 * time.Minute)
+
+		Expect(putNode(ctx, inMem, root)).To(Succeed())
+		Expect(putNode(ctx, inMem, child1)).To(Succeed())
+		Expect(putNode(ctx, inMem, child2)).To(Succeed())
+		Expect(putNode(ctx, inMem, grandchild)).To(Succeed())
+	})
+
+	It("defaults to the root scope so branch siblings are visible", func() {
+		body := decodeGraph(server, sessionGraphPath(grandchild.Hash))
+
+		Expect(body.Hash).To(Equal(grandchild.Hash))
+		Expect(body.RootHash).To(Equal(root.Hash))
+		Expect(body.Scope).To(Equal("root"))
+		Expect(graphNodeIDs(body.Nodes)).To(ConsistOf(root.Hash, child1.Hash, child2.Hash, grandchild.Hash))
+		Expect(body.Links).To(ConsistOf(
+			GraphLink{Source: root.Hash, Target: child1.Hash},
+			GraphLink{Source: root.Hash, Target: child2.Hash},
+			GraphLink{Source: child1.Hash, Target: grandchild.Hash},
+		))
+		Expect(body.BranchPoints).To(ConsistOf(root.Hash))
+		Expect(body.Leaves).To(ConsistOf(child2.Hash, grandchild.Hash))
+
+		rootNode := graphNodeByID(body.Nodes, root.Hash)
+		Expect(rootNode.IsRoot).To(BeTrue())
+		Expect(rootNode.IsBranchPoint).To(BeTrue())
+		Expect(rootNode.ChildrenCount).To(Equal(2))
+		Expect(rootNode.ParentID).To(BeNil())
+
+		selected := graphNodeByID(body.Nodes, grandchild.Hash)
+		Expect(selected.Selected).To(BeTrue())
+		Expect(selected.Preview).To(Equal("follow-up"))
+		Expect(selected.Depth).To(Equal(2))
+	})
+
+	It("can return just the selected branch", func() {
+		body := decodeGraph(server, sessionGraphPath(child1.Hash)+"?scope=branch")
+
+		Expect(body.Scope).To(Equal("branch"))
+		Expect(graphNodeIDs(body.Nodes)).To(ConsistOf(root.Hash, child1.Hash, grandchild.Hash))
+		Expect(body.Links).To(ConsistOf(
+			GraphLink{Source: root.Hash, Target: child1.Hash},
+			GraphLink{Source: child1.Hash, Target: grandchild.Hash},
+		))
+		Expect(body.BranchPoints).To(ContainElement(root.Hash))
+		Expect(graphNodeByID(body.Nodes, child1.Hash).Selected).To(BeTrue())
+	})
+
+	It("can return ancestry only", func() {
+		body := decodeGraph(server, sessionGraphPath(grandchild.Hash)+"?scope=ancestry")
+
+		Expect(body.Scope).To(Equal("ancestry"))
+		Expect(graphNodeIDs(body.Nodes)).To(Equal([]string{root.Hash, child1.Hash, grandchild.Hash}))
+		Expect(body.Links).To(Equal([]GraphLink{
+			{Source: root.Hash, Target: child1.Hash},
+			{Source: child1.Hash, Target: grandchild.Hash},
+		}))
+	})
+
+	It("marks responses truncated when max_nodes is reached", func() {
+		body := decodeGraph(server, sessionGraphPath(grandchild.Hash)+"?max_nodes=2")
+
+		Expect(body.Truncated).To(BeTrue())
+		Expect(body.NodeLimit).To(Equal(2))
+		Expect(body.Nodes).To(HaveLen(2))
+	})
+
+	It("prioritizes the requested ancestry path before sibling branches when node-limited", func() {
+		earlySibling := merkle.NewNode(v1TestBucket("assistant", "early sibling", "m", "p", "claude"), root, merkle.NodeOptions{Project: "tapes"})
+		earlySibling.CreatedAt = root.CreatedAt.Add(-time.Minute)
+		Expect(putNode(ctx, inMem, earlySibling)).To(Succeed())
+
+		body := decodeGraph(server, sessionGraphPath(grandchild.Hash)+"?max_nodes=3")
+		Expect(body.Truncated).To(BeTrue())
+		Expect(graphNodeIDs(body.Nodes)).To(ConsistOf(root.Hash, child1.Hash, grandchild.Hash))
+		Expect(graphNodeByID(body.Nodes, grandchild.Hash).Selected).To(BeTrue())
+	})
+
+	It("treats the top resolvable node as the visual root for incomplete ancestry", func() {
+		phantomParent := "ffff000000000000000000000000000000000000000000000000000000000000"
+		orphan := merkle.NewNode(v1TestBucket("user", "trimmed history", "m", "p", "claude"), &merkle.Node{Hash: phantomParent}, merkle.NodeOptions{Project: "tapes"})
+		orphanChild := merkle.NewNode(v1TestBucket("assistant", "still visible", "m", "p", "claude"), orphan, merkle.NodeOptions{Project: "tapes"})
+		Expect(putNode(ctx, inMem, orphan)).To(Succeed())
+		Expect(putNode(ctx, inMem, orphanChild)).To(Succeed())
+
+		body := decodeGraph(server, sessionGraphPath(orphanChild.Hash))
+		Expect(body.Truncated).To(BeTrue())
+		Expect(body.MissingParent).To(Equal(phantomParent))
+		Expect(body.RootHash).To(Equal(orphan.Hash))
+		Expect(graphNodeIDs(body.Nodes)).To(ConsistOf(orphan.Hash, orphanChild.Hash))
+
+		visualRoot := graphNodeByID(body.Nodes, orphan.Hash)
+		Expect(visualRoot.IsRoot).To(BeTrue())
+		Expect(visualRoot.ParentID).To(BeNil())
+		Expect(visualRoot.ParentHash).NotTo(BeNil())
+		Expect(*visualRoot.ParentHash).To(Equal(phantomParent))
+	})
+
+	It("returns 404 for an unknown hash", func() {
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, sessionGraphPath("does-not-exist"), nil)
+		Expect(err).NotTo(HaveOccurred())
+		resp, err := server.app.Test(req)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.StatusCode).To(Equal(fiber.StatusNotFound))
+	})
+
+	It("returns 400 for invalid query parameters", func() {
+		for _, path := range []string{
+			sessionGraphPath(grandchild.Hash) + "?scope=everything",
+			sessionGraphPath(grandchild.Hash) + "?max_nodes=0",
+			sessionGraphPath(grandchild.Hash) + "?max_nodes=5001",
+		} {
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, path, nil)
+			Expect(err).NotTo(HaveOccurred())
+			resp, err := server.app.Test(req)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.StatusCode).To(Equal(fiber.StatusBadRequest))
+		}
+	})
+})
+
+var _ = Describe("minimal web UI", func() {
+	var server *Server
+
+	BeforeEach(func() {
+		var err error
+		server, err = NewServer(Config{ListenAddr: ":0"}, inmemory.NewDriver(), tapeslogger.NewNoop())
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("serves the D3 UI from / without a frontend build", func() {
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+		Expect(err).NotTo(HaveOccurred())
+		resp, err := server.app.Test(req)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.StatusCode).To(Equal(fiber.StatusOK))
+		Expect(resp.Header.Get("Content-Type")).To(ContainSubstring("text/html"))
+
+		raw, err := io.ReadAll(resp.Body)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(raw)).To(ContainSubstring("d3@7"))
+		Expect(string(raw)).To(ContainSubstring("/v1/sessions/"))
+		Expect(string(raw)).To(ContainSubstring("/v1/sessions/summary"))
+		Expect(string(raw)).NotTo(ContainSubstring("/v1/dags/"))
+	})
+
+	It("does not catch all unknown routes", func() {
+		for _, path := range []string{"/graph", "/not-the-ui"} {
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, path, nil)
+			Expect(err).NotTo(HaveOccurred())
+			resp, err := server.app.Test(req)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.StatusCode).To(Equal(fiber.StatusNotFound))
+		}
+	})
+})
+
+func sessionGraphPath(hash string) string {
+	return "/v1/sessions/" + hash + "/graph"
+}
+
+func decodeGraph(server *Server, path string) GraphResponse {
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, path, nil)
+	Expect(err).NotTo(HaveOccurred())
+	resp, err := server.app.Test(req)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(resp.StatusCode).To(Equal(fiber.StatusOK))
+	defer resp.Body.Close()
+
+	raw, err := io.ReadAll(resp.Body)
+	Expect(err).NotTo(HaveOccurred())
+	var body GraphResponse
+	Expect(json.Unmarshal(raw, &body)).To(Succeed(), strings.TrimSpace(string(raw)))
+	return body
+}
+
+func graphNodeIDs(nodes []GraphNode) []string {
+	ids := make([]string, len(nodes))
+	for i, node := range nodes {
+		ids[i] = node.ID
+	}
+	return ids
+}
+
+func graphNodeByID(nodes []GraphNode, hash string) GraphNode {
+	for _, node := range nodes {
+		if node.ID == hash {
+			return node
+		}
+	}
+	Fail("node not found in graph response: " + hash)
+	return GraphNode{}
+}

--- a/api/graph_handlers_test.go
+++ b/api/graph_handlers_test.go
@@ -209,7 +209,7 @@ var _ = Describe("minimal web UI", func() {
 		raw, err := io.ReadAll(resp.Body)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(string(raw)).To(ContainSubstring("d3@7.9.0"))
-		Expect(string(raw)).To(ContainSubstring("integrity=\"sha256-1AqCL/P1MtPZ9HQLjuNAO+QOIV1Q7AhiAl2fT14nSI=\""))
+		Expect(string(raw)).To(ContainSubstring("integrity=\"sha256-8glLv2FBs1lyLE/kVOtsSw8OQswQzHr5IfwVj864ZTk=\""))
 		Expect(string(raw)).To(ContainSubstring("/v1/sessions/"))
 		Expect(string(raw)).To(ContainSubstring("/v1/sessions/summary"))
 		Expect(string(raw)).NotTo(ContainSubstring("/v1/dags/"))

--- a/api/v1_handlers.go
+++ b/api/v1_handlers.go
@@ -148,9 +148,9 @@ func (s *Server) handleListSessions(c *fiber.Ctx) error {
 //	@Failure		500		{object}	llm.ErrorResponse	"Failed to load session"
 //	@Router			/v1/sessions/{hash} [get]
 func (s *Server) handleGetSession(c *fiber.Ctx) error {
-	hash := c.Params("hash")
-	if hash == "" {
-		return c.Status(fiber.StatusBadRequest).JSON(llm.ErrorResponse{Error: "hash parameter required"})
+	hash, chain, err := s.loadSessionChain(c)
+	if err != nil {
+		return s.handleLoadSessionChainError(c, hash, err)
 	}
 
 	depth := 0
@@ -160,16 +160,6 @@ func (s *Server) handleGetSession(c *fiber.Ctx) error {
 			return c.Status(fiber.StatusBadRequest).JSON(llm.ErrorResponse{Error: "depth must be a positive integer"})
 		}
 		depth = parsed
-	}
-
-	chain, err := s.driver.AncestryChain(c.Context(), hash)
-	if err != nil {
-		var notFound storage.NotFoundError
-		if errors.As(err, &notFound) {
-			return c.Status(fiber.StatusNotFound).JSON(llm.ErrorResponse{Error: "session not found"})
-		}
-		s.logger.Error("load ancestry", "hash", hash, "error", err)
-		return c.Status(fiber.StatusInternalServerError).JSON(llm.ErrorResponse{Error: "failed to load session"})
 	}
 
 	// AncestryChain returns node-first (leaf) then back toward root. Slice
@@ -194,6 +184,39 @@ func (s *Server) handleGetSession(c *fiber.Ctx) error {
 		Truncated:     chain.Incomplete,
 		MissingParent: chain.MissingParent,
 	})
+}
+
+var errHashParameterRequired = errors.New("hash parameter required")
+
+func (s *Server) loadSessionChain(c *fiber.Ctx) (string, *storage.Chain, error) {
+	hash := c.Params("hash")
+	if hash == "" {
+		return "", nil, errHashParameterRequired
+	}
+
+	chain, err := s.driver.AncestryChain(c.Context(), hash)
+	if err != nil {
+		return hash, nil, err
+	}
+	if len(chain.Nodes) == 0 {
+		return hash, nil, storage.NotFoundError{Hash: hash}
+	}
+
+	return hash, chain, nil
+}
+
+func (s *Server) handleLoadSessionChainError(c *fiber.Ctx, hash string, err error) error {
+	if errors.Is(err, errHashParameterRequired) {
+		return c.Status(fiber.StatusBadRequest).JSON(llm.ErrorResponse{Error: errHashParameterRequired.Error()})
+	}
+
+	var notFound storage.NotFoundError
+	if errors.As(err, &notFound) {
+		return c.Status(fiber.StatusNotFound).JSON(llm.ErrorResponse{Error: "session not found"})
+	}
+
+	s.logger.Error("load session ancestry", "hash", hash, "error", err)
+	return c.Status(fiber.StatusInternalServerError).JSON(llm.ErrorResponse{Error: "failed to load session"})
 }
 
 // handleStats handles GET /v1/stats.

--- a/api/web_ui.go
+++ b/api/web_ui.go
@@ -1,0 +1,17 @@
+package api
+
+import (
+	_ "embed"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+// tapesWebUIHTML is intentionally a tiny, Prometheus-style UI served directly
+// from the API binary. D3 is loaded from a CDN so there is no frontend build.
+//
+//go:embed web_ui.html
+var tapesWebUIHTML string
+
+func (s *Server) handleWebUI(c *fiber.Ctx) error {
+	return c.Type("html").SendString(tapesWebUIHTML)
+}

--- a/api/web_ui.html
+++ b/api/web_ui.html
@@ -87,7 +87,7 @@
       <pre id="details">Click a node to inspect its hash, parent, and metadata.</pre>
     </section>
   </main>
-  <script src="https://cdn.jsdelivr.net/npm/d3@7.9.0/dist/d3.min.js" integrity="sha256-1AqCL/P1MtPZ9HQLjuNAO+QOIV1Q7AhiAl2fT14nSI=" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/d3@7.9.0/dist/d3.min.js" integrity="sha256-8glLv2FBs1lyLE/kVOtsSw8OQswQzHr5IfwVj864ZTk=" crossorigin="anonymous"></script>
   <script>
   (function () {
     var params = new URLSearchParams(window.location.search);

--- a/api/web_ui.html
+++ b/api/web_ui.html
@@ -87,7 +87,7 @@
       <pre id="details">Click a node to inspect its hash, parent, and metadata.</pre>
     </section>
   </main>
-  <script src="https://cdn.jsdelivr.net/npm/d3@7/dist/d3.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/d3@7.9.0/dist/d3.min.js" integrity="sha256-1AqCL/P1MtPZ9HQLjuNAO+QOIV1Q7AhiAl2fT14nSI=" crossorigin="anonymous"></script>
   <script>
   (function () {
     var params = new URLSearchParams(window.location.search);

--- a/api/web_ui.html
+++ b/api/web_ui.html
@@ -1,0 +1,296 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Tapes</title>
+  <style>
+    :root { color-scheme: light dark; --bg:#0f172a; --panel:#111827; --muted:#94a3b8; --line:#334155; --text:#e5e7eb; --accent:#38bdf8; --ok:#34d399; --warn:#f59e0b; }
+    * { box-sizing: border-box; }
+    body { margin: 0; font: 14px/1.4 ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; background: var(--bg); color: var(--text); }
+    header { display:flex; align-items:center; justify-content:space-between; gap:1rem; padding:.8rem 1rem; border-bottom:1px solid var(--line); background:#020617; }
+    header h1 { margin:0; font-size:1.1rem; letter-spacing:.04em; }
+    header nav { display:flex; gap:.8rem; align-items:center; }
+    a { color: var(--accent); text-decoration:none; }
+    a:hover { text-decoration:underline; }
+    main { display:grid; grid-template-columns: 360px minmax(0,1fr); min-height: calc(100vh - 54px); }
+    aside { border-right:1px solid var(--line); background:var(--panel); overflow:auto; }
+    .pane { padding:1rem; }
+    .controls { display:grid; gap:.6rem; }
+    .row { display:flex; gap:.5rem; align-items:center; }
+    input, select, button { border:1px solid var(--line); border-radius:6px; padding:.45rem .55rem; background:#020617; color:var(--text); font:inherit; }
+    input { width:100%; min-width:0; }
+    button { cursor:pointer; }
+    button.primary { background:#075985; border-color:#0284c7; }
+    button:hover { border-color:var(--accent); }
+    .stats { display:grid; grid-template-columns:repeat(3,1fr); gap:.5rem; margin:.8rem 0; }
+    .stat { border:1px solid var(--line); border-radius:8px; padding:.55rem; background:#020617; }
+    .stat b { display:block; font-size:1.2rem; }
+    .stat span, .muted { color:var(--muted); font-size:.85rem; }
+    #sessions { display:grid; gap:.45rem; margin-top:.8rem; }
+    .session { width:100%; text-align:left; display:grid; gap:.25rem; }
+    .session.active { border-color:var(--accent); box-shadow:0 0 0 1px var(--accent) inset; }
+    .session strong { overflow:hidden; white-space:nowrap; text-overflow:ellipsis; }
+    code { color:#bae6fd; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size:.82rem; }
+    .graph-shell { min-width:0; display:grid; grid-template-rows:auto minmax(360px,1fr) auto; }
+    #graph-meta { padding:.7rem 1rem; border-bottom:1px solid var(--line); color:var(--muted); }
+    #graph-wrap { min-height:360px; overflow:hidden; }
+    svg { width:100%; height:100%; min-height:520px; display:block; background:radial-gradient(circle at top left, rgba(56,189,248,.10), transparent 34rem); }
+    .link { fill:none; stroke:#64748b; stroke-width:1.6px; }
+    .node text { fill:var(--text); paint-order:stroke; stroke:#020617; stroke-width:3px; stroke-linejoin:round; }
+    .node circle { stroke:#0f172a; stroke-width:2px; }
+    .node.selected circle { stroke:var(--accent); stroke-width:4px; }
+    .node.branch circle { stroke:var(--warn); stroke-width:4px; }
+    #details { margin:0; padding:1rem; border-top:1px solid var(--line); max-height:260px; overflow:auto; background:#020617; }
+    .empty, .error { border:1px dashed var(--line); border-radius:8px; padding:.8rem; color:var(--muted); }
+    .error { color:#fecaca; border-color:#7f1d1d; }
+    @media (max-width: 900px) { main { grid-template-columns:1fr; } aside { border-right:0; border-bottom:1px solid var(--line); } }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Tapes</h1>
+    <nav>
+      <a href="/swagger">API</a>
+      <a href="/metrics">Metrics</a>
+    </nav>
+  </header>
+  <main>
+    <aside>
+      <div class="pane controls">
+        <div class="row">
+          <input id="hash" placeholder="node/session hash" autocomplete="off" />
+          <button id="load" class="primary">Load</button>
+        </div>
+        <div class="row">
+          <select id="scope" title="Graph scope">
+            <option value="root">root + all branches</option>
+            <option value="branch">selected branch</option>
+            <option value="ancestry">ancestry only</option>
+          </select>
+          <button id="refresh">Refresh</button>
+          <button id="seed">Seed demo</button>
+        </div>
+        <div id="status" class="muted">Loading sessions...</div>
+        <div class="stats">
+          <div class="stat"><b id="stat-sessions">-</b><span>sessions</span></div>
+          <div class="stat"><b id="stat-turns">-</b><span>turns</span></div>
+          <div class="stat"><b id="stat-roots">-</b><span>roots</span></div>
+        </div>
+        <div class="muted">Recent session heads</div>
+        <div id="sessions"></div>
+      </div>
+    </aside>
+    <section class="graph-shell">
+      <div id="graph-meta">Select a session to visualize its content-addressed graph.</div>
+      <div id="graph-wrap"><svg id="dag" role="img" aria-label="session graph visualization"></svg></div>
+      <pre id="details">Click a node to inspect its hash, parent, and metadata.</pre>
+    </section>
+  </main>
+  <script src="https://cdn.jsdelivr.net/npm/d3@7/dist/d3.min.js"></script>
+  <script>
+  (function () {
+    var params = new URLSearchParams(window.location.search);
+    var state = { sessions: [], currentHash: params.get('hash') || '', scope: params.get('scope') || 'root' };
+    var colors = { system:'#a78bfa', user:'#38bdf8', assistant:'#34d399', tool:'#f59e0b' };
+
+    function byID(id) { return document.getElementById(id); }
+    function esc(value) {
+      return String(value == null ? '' : value).replace(/[&<>"']/g, function (ch) {
+        return ({ '&':'&amp;', '<':'&lt;', '>':'&gt;', '"':'&quot;', "'":'&#39;' })[ch];
+      });
+    }
+    function shortHash(hash) { return hash ? hash.slice(0, 12) : ''; }
+    function setStatus(message, isError) {
+      var el = byID('status');
+      el.className = isError ? 'error' : 'muted';
+      el.textContent = message;
+    }
+    async function fetchJSON(path, options) {
+      var res = await fetch(path, options || {});
+      var text = await res.text();
+      var data = text ? JSON.parse(text) : {};
+      if (!res.ok) throw new Error(data.error || (res.status + ' ' + res.statusText));
+      return data;
+    }
+    function sessionHash(item) { return item.id || item.hash || ''; }
+    function sessionLabel(item) { return item.label || item.preview || shortHash(sessionHash(item)); }
+
+    async function loadStats() {
+      var stats = await fetchJSON('/v1/stats');
+      byID('stat-sessions').textContent = stats.session_count || 0;
+      byID('stat-turns').textContent = stats.turn_count || 0;
+      byID('stat-roots').textContent = stats.root_count || 0;
+    }
+
+    async function loadSessions() {
+      var data = await fetchJSON('/v1/sessions/summary?limit=50');
+      state.sessions = data.items || [];
+      renderSessions();
+      if (!state.currentHash && state.sessions.length > 0) {
+        state.currentHash = sessionHash(state.sessions[0]);
+        byID('hash').value = state.currentHash;
+      }
+    }
+
+    function renderSessions() {
+      var list = byID('sessions');
+      if (!state.sessions.length) {
+        list.innerHTML = '<div class="empty">No sessions yet. Start the proxy or click "Seed demo" for local sample data.</div>';
+        return;
+      }
+      list.innerHTML = '';
+      state.sessions.forEach(function (item) {
+        var hash = sessionHash(item);
+        var button = document.createElement('button');
+        button.className = 'session' + (hash === state.currentHash ? ' active' : '');
+        button.innerHTML = '<strong>' + esc(sessionLabel(item)) + '</strong>' +
+          '<code>' + esc(shortHash(hash)) + '</code>' +
+          '<span class="muted">' + esc([item.project, item.model, item.status].filter(Boolean).join(' · ')) + '</span>';
+        button.addEventListener('click', function () { loadDag(hash); });
+        list.appendChild(button);
+      });
+    }
+
+    async function loadDag(hash) {
+      hash = (hash || byID('hash').value || '').trim();
+      if (!hash) return;
+      state.currentHash = hash;
+      state.scope = byID('scope').value;
+      byID('hash').value = hash;
+      var query = '?scope=' + encodeURIComponent(state.scope) + '&max_nodes=500';
+      history.replaceState(null, '', '/?hash=' + encodeURIComponent(hash) + '&scope=' + encodeURIComponent(state.scope));
+      setStatus('Loading graph ' + shortHash(hash) + '...', false);
+      try {
+        var graph = await fetchJSON('/v1/sessions/' + encodeURIComponent(hash) + '/graph' + query);
+        renderSessions();
+        renderDag(graph);
+        setStatus('Loaded ' + graph.nodes.length + ' nodes.', false);
+      } catch (err) {
+        setStatus(err.message, true);
+      }
+    }
+
+    function renderDag(data) {
+      var svg = d3.select('#dag');
+      svg.on('.zoom', null);
+      svg.selectAll('*').remove();
+      var nodes = data.nodes || [];
+      if (!nodes.length) {
+        byID('graph-meta').textContent = 'No graph nodes returned.';
+        byID('details').textContent = 'No node details.';
+        return;
+      }
+
+      byID('graph-meta').textContent = data.scope + ' graph • root ' + shortHash(data.root_hash) +
+        ' • ' + nodes.length + ' nodes • ' + (data.branch_points || []).length + ' branch points' +
+        (data.truncated ? ' • truncated' : '');
+
+      var root;
+      try {
+        root = d3.stratify().id(function (d) { return d.id; }).parentId(function (d) { return d.parent_id || null; })(nodes);
+      } catch (err) {
+        byID('details').textContent = 'D3 could not stratify the graph: ' + err.message;
+        return;
+      }
+      root.sort(function (a, b) {
+        return d3.ascending(a.data.created_at || '', b.data.created_at || '') || d3.ascending(a.id, b.id);
+      });
+
+      var tree = d3.tree().nodeSize([64, 230]);
+      tree(root);
+      var laidOut = root.descendants();
+      var minX = d3.min(laidOut, function (d) { return d.x; });
+      var maxX = d3.max(laidOut, function (d) { return d.x; });
+      var maxY = d3.max(laidOut, function (d) { return d.y; });
+      var left = -90, top = minX - 90, right = maxY + 430, bottom = maxX + 90;
+      svg.attr('viewBox', [left, top, right - left, bottom - top].join(' '));
+
+      var g = svg.append('g');
+      svg.call(d3.zoom().scaleExtent([0.25, 3]).on('zoom', function (event) { g.attr('transform', event.transform); }));
+
+      g.append('g').selectAll('path')
+        .data(root.links())
+        .join('path')
+        .attr('class', 'link')
+        .attr('d', d3.linkHorizontal().x(function (d) { return d.y; }).y(function (d) { return d.x; }));
+
+      var node = g.append('g').selectAll('g')
+        .data(laidOut)
+        .join('g')
+        .attr('class', function (d) { return 'node' + (d.data.selected ? ' selected' : '') + (d.data.is_branch_point ? ' branch' : ''); })
+        .attr('transform', function (d) { return 'translate(' + d.y + ',' + d.x + ')'; })
+        .on('click', function (event, d) { event.stopPropagation(); showNode(d.data); });
+
+      node.append('circle')
+        .attr('r', function (d) { return d.data.is_branch_point ? 10 : 7; })
+        .attr('fill', function (d) { return colors[d.data.role] || '#94a3b8'; });
+
+      node.append('text')
+        .attr('x', 16)
+        .attr('dy', '-0.15em')
+        .attr('font-size', 12)
+        .text(function (d) { return (d.data.role || 'node') + ' ' + shortHash(d.data.id); });
+
+      node.append('text')
+        .attr('x', 16)
+        .attr('dy', '1.15em')
+        .attr('font-size', 11)
+        .attr('fill', '#94a3b8')
+        .text(function (d) { return (d.data.preview || '').slice(0, 54); });
+
+      node.append('title').text(function (d) { return d.data.id + '\n' + (d.data.preview || ''); });
+      var selected = nodes.find(function (n) { return n.selected; }) || nodes[0];
+      showNode(selected);
+    }
+
+    function showNode(node) {
+      byID('details').textContent = JSON.stringify({
+        hash: node.id,
+        parent_hash: node.parent_hash || null,
+        role: node.role,
+        type: node.type,
+        depth: node.depth,
+        children_count: node.children_count,
+        branch_point: node.is_branch_point,
+        model: node.model,
+        provider: node.provider,
+        agent_name: node.agent_name,
+        project: node.project,
+        created_at: node.created_at,
+        preview: node.preview
+      }, null, 2);
+    }
+
+    async function refreshAll() {
+      try {
+        setStatus('Loading sessions...', false);
+        await Promise.all([loadStats(), loadSessions()]);
+        if (state.currentHash) await loadDag(state.currentHash);
+        else setStatus('No sessions found.', false);
+      } catch (err) {
+        setStatus(err.message, true);
+      }
+    }
+
+    byID('scope').value = ['root', 'branch', 'ancestry'].indexOf(state.scope) >= 0 ? state.scope : 'root';
+    byID('hash').value = state.currentHash;
+    byID('load').addEventListener('click', function () { loadDag(); });
+    byID('hash').addEventListener('keydown', function (event) { if (event.key === 'Enter') loadDag(); });
+    byID('scope').addEventListener('change', function () { if (state.currentHash) loadDag(state.currentHash); });
+    byID('refresh').addEventListener('click', refreshAll);
+    byID('seed').addEventListener('click', async function () {
+      try {
+        setStatus('Seeding demo data...', false);
+        await fetchJSON('/v1/admin/seed/demo', { method:'POST' });
+        await refreshAll();
+      } catch (err) {
+        setStatus(err.message, true);
+      }
+    });
+
+    refreshAll();
+  })();
+  </script>
+</body>
+</html>

--- a/cmd/tapes/serve/api/api.go
+++ b/cmd/tapes/serve/api/api.go
@@ -21,6 +21,7 @@ type apiCommander struct {
 	listen      string
 	debug       bool
 	postgresDSN string
+	webUI       bool
 
 	logger *slog.Logger
 }
@@ -28,6 +29,7 @@ type apiCommander struct {
 // apiFlags defines the flags for the standalone API subcommand.
 var apiFlags = config.FlagSet{
 	config.FlagAPIListenStandalone: {Name: "listen", Shorthand: "l", ViperKey: "api.listen", Description: "Address for API server to listen on"},
+	config.FlagAPIWebUI:            {Name: "web-ui", ViperKey: "api.web_ui", Description: "Enable the minimal browser UI at /"},
 	config.FlagPostgres:            {Name: "postgres", ViperKey: "storage.postgres_dsn", Description: "PostgreSQL connection string (e.g., postgres://user:pass@host:5432/db)"},
 }
 
@@ -53,10 +55,12 @@ func NewAPICmd() *cobra.Command {
 
 			config.BindRegisteredFlags(v, cmd, cmder.flags, []string{
 				config.FlagAPIListenStandalone,
+				config.FlagAPIWebUI,
 				config.FlagPostgres,
 			})
 
 			cmder.listen = v.GetString("api.listen")
+			cmder.webUI = v.GetBool("api.web_ui")
 			cmder.postgresDSN = v.GetString("storage.postgres_dsn")
 			return nil
 		},
@@ -73,6 +77,7 @@ func NewAPICmd() *cobra.Command {
 	}
 
 	config.AddStringFlag(cmd, cmder.flags, config.FlagAPIListenStandalone, &cmder.listen)
+	config.AddBoolFlag(cmd, cmder.flags, config.FlagAPIWebUI, &cmder.webUI)
 	config.AddStringFlag(cmd, cmder.flags, config.FlagPostgres, &cmder.postgresDSN)
 
 	return cmd
@@ -88,7 +93,8 @@ func (c *apiCommander) run() error {
 	defer driver.Close()
 
 	config := api.Config{
-		ListenAddr: c.listen,
+		ListenAddr:  c.listen,
+		EnableWebUI: c.webUI,
 	}
 
 	server, err := api.NewServer(config, driver, c.logger)

--- a/cmd/tapes/serve/serve.go
+++ b/cmd/tapes/serve/serve.go
@@ -31,6 +31,7 @@ type ServeCommander struct {
 
 	proxyListen  string
 	apiListen    string
+	apiWebUI     bool
 	ingestListen string
 	upstream     string
 	debug        bool
@@ -53,6 +54,7 @@ type ServeCommander struct {
 var ServeFlags = config.FlagSet{
 	config.FlagProxyListen:    {Name: "proxy-listen", Shorthand: "p", ViperKey: "proxy.listen", Description: "Address for proxy to listen on"},
 	config.FlagAPIListen:      {Name: "api-listen", Shorthand: "a", ViperKey: "api.listen", Description: "Address for API server to listen on"},
+	config.FlagAPIWebUI:       {Name: "api-web-ui", ViperKey: "api.web_ui", Description: "Enable the minimal browser UI at /"},
 	config.FlagIngestListen:   {Name: "ingest-listen", Shorthand: "i", ViperKey: "ingest.listen", Description: "Address for ingest server to listen on (sidecar mode)"},
 	config.FlagUpstream:       {Name: "upstream", Shorthand: "u", ViperKey: "proxy.upstream", Description: "Upstream LLM provider URL"},
 	config.FlagProvider:       {Name: "provider", ViperKey: "proxy.provider", Description: "LLM provider type (anthropic, openai, ollama)"},
@@ -97,6 +99,7 @@ func NewServeCmd() *cobra.Command {
 			config.BindRegisteredFlags(v, cmd, cmder.flags, []string{
 				config.FlagProxyListen,
 				config.FlagAPIListen,
+				config.FlagAPIWebUI,
 				config.FlagIngestListen,
 				config.FlagUpstream,
 				config.FlagProvider,
@@ -117,6 +120,7 @@ func NewServeCmd() *cobra.Command {
 			cmder.postgresDSN = v.GetString("storage.postgres_dsn")
 			cmder.proxyListen = v.GetString("proxy.listen")
 			cmder.apiListen = v.GetString("api.listen")
+			cmder.apiWebUI = v.GetBool("api.web_ui")
 			cmder.ingestListen = v.GetString("ingest.listen")
 			cmder.upstream = v.GetString("proxy.upstream")
 			cmder.providerType = v.GetString("proxy.provider")
@@ -146,6 +150,7 @@ func NewServeCmd() *cobra.Command {
 
 	config.AddStringFlag(cmd, cmder.flags, config.FlagProxyListen, &cmder.proxyListen)
 	config.AddStringFlag(cmd, cmder.flags, config.FlagAPIListen, &cmder.apiListen)
+	config.AddBoolFlag(cmd, cmder.flags, config.FlagAPIWebUI, &cmder.apiWebUI)
 	config.AddStringFlag(cmd, cmder.flags, config.FlagIngestListen, &cmder.ingestListen)
 	config.AddStringFlag(cmd, cmder.flags, config.FlagUpstream, &cmder.upstream)
 	config.AddStringFlag(cmd, cmder.flags, config.FlagProvider, &cmder.providerType)
@@ -224,6 +229,7 @@ func (c *ServeCommander) run() error {
 		ListenAddr:   c.apiListen,
 		VectorDriver: proxyConfig.VectorDriver,
 		Embedder:     proxyConfig.Embedder,
+		EnableWebUI:  c.apiWebUI,
 	}
 	apiServer, err := api.NewServer(apiConfig, driver, c.logger)
 	if err != nil {

--- a/cmd/tapes/start/start.go
+++ b/cmd/tapes/start/start.go
@@ -81,6 +81,7 @@ type startConfig struct {
 	OllamaUpstream      string
 	OpenCodeProvider    string
 	Project             string
+	APIWebUI            bool
 }
 
 func NewStartCmd() *cobra.Command {
@@ -453,6 +454,7 @@ func (c *startCommander) runServices(ctx context.Context, manager *start.Manager
 		ListenAddr:   apiListener.Addr().String(),
 		VectorDriver: pgVecDriver,
 		Embedder:     embedder,
+		EnableWebUI:  startCfg.APIWebUI,
 	}
 	apiServer, err := api.NewServer(apiConfig, driver, log)
 	if err != nil {
@@ -738,6 +740,7 @@ func (c *startCommander) loadConfig() (*startConfig, error) {
 		OllamaUpstream:      resolveOllamaUpstream(provider, upstream),
 		OpenCodeProvider:    v.GetString("opencode.provider"),
 		Project:             v.GetString("proxy.project"),
+		APIWebUI:            v.GetBool("api.web_ui"),
 	}, nil
 }
 

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -402,6 +402,72 @@ const docTemplate = `{
                 }
             }
         },
+        "/v1/sessions/{hash}/graph": {
+            "get": {
+                "description": "Returns a graph-shaped projection of the same session ancestry returned by GET /v1/sessions/{hash}. scope=root loads the requested node's resolvable root and all descendants, scope=branch loads the ancestry plus descendants of the requested node, and scope=ancestry loads only the parent chain.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "sessions"
+                ],
+                "summary": "Get a session graph",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Session hash",
+                        "name": "hash",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "enum": [
+                            "root",
+                            "branch",
+                            "ancestry"
+                        ],
+                        "type": "string",
+                        "description": "Graph scope: root, branch, or ancestry",
+                        "name": "scope",
+                        "in": "query"
+                    },
+                    {
+                        "maximum": 5000,
+                        "minimum": 1,
+                        "type": "integer",
+                        "description": "Maximum number of graph nodes to include",
+                        "name": "max_nodes",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.GraphResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Missing hash or invalid query parameters",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_papercomputeco_tapes_pkg_llm.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Session not found",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_papercomputeco_tapes_pkg_llm.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Failed to load session graph",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_papercomputeco_tapes_pkg_llm.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/v1/stats": {
             "get": {
                 "description": "Returns aggregate counts for sessions, turns, and roots matching the supplied filters.",
@@ -476,6 +542,140 @@ const docTemplate = `{
         }
     },
     "definitions": {
+        "api.GraphLink": {
+            "type": "object",
+            "properties": {
+                "source": {
+                    "type": "string"
+                },
+                "target": {
+                    "type": "string"
+                }
+            }
+        },
+        "api.GraphNode": {
+            "type": "object",
+            "properties": {
+                "agent_name": {
+                    "type": "string"
+                },
+                "children_count": {
+                    "type": "integer"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "depth": {
+                    "type": "integer"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "is_branch_point": {
+                    "type": "boolean"
+                },
+                "is_leaf": {
+                    "type": "boolean"
+                },
+                "is_root": {
+                    "type": "boolean"
+                },
+                "model": {
+                    "type": "string"
+                },
+                "parent_hash": {
+                    "type": "string"
+                },
+                "parent_id": {
+                    "type": "string"
+                },
+                "preview": {
+                    "type": "string"
+                },
+                "project": {
+                    "type": "string"
+                },
+                "provider": {
+                    "type": "string"
+                },
+                "role": {
+                    "type": "string"
+                },
+                "selected": {
+                    "type": "boolean"
+                },
+                "stop_reason": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "usage": {
+                    "$ref": "#/definitions/github_com_papercomputeco_tapes_pkg_llm.Usage"
+                }
+            }
+        },
+        "api.GraphResponse": {
+            "type": "object",
+            "properties": {
+                "branch_points": {
+                    "description": "BranchPoints names included nodes with more than one child in storage.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "cycle_detected": {
+                    "description": "CycleDetected is true when storage guarded the ancestry walk out of a cycle.",
+                    "type": "boolean"
+                },
+                "hash": {
+                    "description": "Hash is the session/node hash requested by the caller.",
+                    "type": "string"
+                },
+                "leaves": {
+                    "description": "Leaves names included nodes that have no children in storage.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "links": {
+                    "description": "Links contains parent -\u003e child edges between included nodes.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/api.GraphLink"
+                    }
+                },
+                "missing_parent": {
+                    "description": "MissingParent names the unresolved parent hash when the ancestry is incomplete.",
+                    "type": "string"
+                },
+                "node_limit": {
+                    "description": "NodeLimit is the maximum number of nodes the server will include.",
+                    "type": "integer"
+                },
+                "nodes": {
+                    "description": "Nodes is the flat node list consumed by graph visualizers.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/api.GraphNode"
+                    }
+                },
+                "root_hash": {
+                    "description": "RootHash is the top-most resolvable node included in the response.",
+                    "type": "string"
+                },
+                "scope": {
+                    "description": "Scope describes which portion of the graph was loaded: root, branch, or ancestry.",
+                    "type": "string"
+                },
+                "truncated": {
+                    "description": "Truncated is true when the graph hit NodeLimit or the ancestry chain is incomplete.",
+                    "type": "boolean"
+                }
+            }
+        },
         "api.SessionListItem": {
             "type": "object",
             "properties": {
@@ -748,6 +948,13 @@ const docTemplate = `{
                     "description": "Text content (type=\"text\")",
                     "type": "string"
                 },
+                "thinking": {
+                    "description": "Thinking (type=\"thinking\") - Anthropic extended-thinking blocks.\nAnthropic emits thinking as content_block_delta frames with type\n\"thinking_delta\" followed by a \"signature_delta\" that authenticates the\nblock. Consumers treat Thinking as opaque text; the signature is persisted\nso downstream tooling can verify integrity.",
+                    "type": "string"
+                },
+                "thinking_signature": {
+                    "type": "string"
+                },
                 "tool_input": {
                     "type": "object",
                     "additionalProperties": {}
@@ -767,7 +974,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "type": {
-                    "description": "\"text\", \"image\", \"tool_use\", \"tool_result\"",
+                    "description": "\"text\", \"image\", \"tool_use\", \"tool_result\", \"thinking\"",
                     "type": "string"
                 }
             }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -398,6 +398,72 @@
                 }
             }
         },
+        "/v1/sessions/{hash}/graph": {
+            "get": {
+                "description": "Returns a graph-shaped projection of the same session ancestry returned by GET /v1/sessions/{hash}. scope=root loads the requested node's resolvable root and all descendants, scope=branch loads the ancestry plus descendants of the requested node, and scope=ancestry loads only the parent chain.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "sessions"
+                ],
+                "summary": "Get a session graph",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Session hash",
+                        "name": "hash",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "enum": [
+                            "root",
+                            "branch",
+                            "ancestry"
+                        ],
+                        "type": "string",
+                        "description": "Graph scope: root, branch, or ancestry",
+                        "name": "scope",
+                        "in": "query"
+                    },
+                    {
+                        "maximum": 5000,
+                        "minimum": 1,
+                        "type": "integer",
+                        "description": "Maximum number of graph nodes to include",
+                        "name": "max_nodes",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.GraphResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Missing hash or invalid query parameters",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_papercomputeco_tapes_pkg_llm.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Session not found",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_papercomputeco_tapes_pkg_llm.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Failed to load session graph",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_papercomputeco_tapes_pkg_llm.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/v1/stats": {
             "get": {
                 "description": "Returns aggregate counts for sessions, turns, and roots matching the supplied filters.",
@@ -472,6 +538,140 @@
         }
     },
     "definitions": {
+        "api.GraphLink": {
+            "type": "object",
+            "properties": {
+                "source": {
+                    "type": "string"
+                },
+                "target": {
+                    "type": "string"
+                }
+            }
+        },
+        "api.GraphNode": {
+            "type": "object",
+            "properties": {
+                "agent_name": {
+                    "type": "string"
+                },
+                "children_count": {
+                    "type": "integer"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "depth": {
+                    "type": "integer"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "is_branch_point": {
+                    "type": "boolean"
+                },
+                "is_leaf": {
+                    "type": "boolean"
+                },
+                "is_root": {
+                    "type": "boolean"
+                },
+                "model": {
+                    "type": "string"
+                },
+                "parent_hash": {
+                    "type": "string"
+                },
+                "parent_id": {
+                    "type": "string"
+                },
+                "preview": {
+                    "type": "string"
+                },
+                "project": {
+                    "type": "string"
+                },
+                "provider": {
+                    "type": "string"
+                },
+                "role": {
+                    "type": "string"
+                },
+                "selected": {
+                    "type": "boolean"
+                },
+                "stop_reason": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "usage": {
+                    "$ref": "#/definitions/github_com_papercomputeco_tapes_pkg_llm.Usage"
+                }
+            }
+        },
+        "api.GraphResponse": {
+            "type": "object",
+            "properties": {
+                "branch_points": {
+                    "description": "BranchPoints names included nodes with more than one child in storage.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "cycle_detected": {
+                    "description": "CycleDetected is true when storage guarded the ancestry walk out of a cycle.",
+                    "type": "boolean"
+                },
+                "hash": {
+                    "description": "Hash is the session/node hash requested by the caller.",
+                    "type": "string"
+                },
+                "leaves": {
+                    "description": "Leaves names included nodes that have no children in storage.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "links": {
+                    "description": "Links contains parent -\u003e child edges between included nodes.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/api.GraphLink"
+                    }
+                },
+                "missing_parent": {
+                    "description": "MissingParent names the unresolved parent hash when the ancestry is incomplete.",
+                    "type": "string"
+                },
+                "node_limit": {
+                    "description": "NodeLimit is the maximum number of nodes the server will include.",
+                    "type": "integer"
+                },
+                "nodes": {
+                    "description": "Nodes is the flat node list consumed by graph visualizers.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/api.GraphNode"
+                    }
+                },
+                "root_hash": {
+                    "description": "RootHash is the top-most resolvable node included in the response.",
+                    "type": "string"
+                },
+                "scope": {
+                    "description": "Scope describes which portion of the graph was loaded: root, branch, or ancestry.",
+                    "type": "string"
+                },
+                "truncated": {
+                    "description": "Truncated is true when the graph hit NodeLimit or the ancestry chain is incomplete.",
+                    "type": "boolean"
+                }
+            }
+        },
         "api.SessionListItem": {
             "type": "object",
             "properties": {
@@ -744,6 +944,13 @@
                     "description": "Text content (type=\"text\")",
                     "type": "string"
                 },
+                "thinking": {
+                    "description": "Thinking (type=\"thinking\") - Anthropic extended-thinking blocks.\nAnthropic emits thinking as content_block_delta frames with type\n\"thinking_delta\" followed by a \"signature_delta\" that authenticates the\nblock. Consumers treat Thinking as opaque text; the signature is persisted\nso downstream tooling can verify integrity.",
+                    "type": "string"
+                },
+                "thinking_signature": {
+                    "type": "string"
+                },
                 "tool_input": {
                     "type": "object",
                     "additionalProperties": {}
@@ -763,7 +970,7 @@
                     "type": "string"
                 },
                 "type": {
-                    "description": "\"text\", \"image\", \"tool_use\", \"tool_result\"",
+                    "description": "\"text\", \"image\", \"tool_use\", \"tool_result\", \"thinking\"",
                     "type": "string"
                 }
             }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,5 +1,102 @@
 basePath: /
 definitions:
+  api.GraphLink:
+    properties:
+      source:
+        type: string
+      target:
+        type: string
+    type: object
+  api.GraphNode:
+    properties:
+      agent_name:
+        type: string
+      children_count:
+        type: integer
+      created_at:
+        type: string
+      depth:
+        type: integer
+      id:
+        type: string
+      is_branch_point:
+        type: boolean
+      is_leaf:
+        type: boolean
+      is_root:
+        type: boolean
+      model:
+        type: string
+      parent_hash:
+        type: string
+      parent_id:
+        type: string
+      preview:
+        type: string
+      project:
+        type: string
+      provider:
+        type: string
+      role:
+        type: string
+      selected:
+        type: boolean
+      stop_reason:
+        type: string
+      type:
+        type: string
+      usage:
+        $ref: '#/definitions/github_com_papercomputeco_tapes_pkg_llm.Usage'
+    type: object
+  api.GraphResponse:
+    properties:
+      branch_points:
+        description: BranchPoints names included nodes with more than one child in
+          storage.
+        items:
+          type: string
+        type: array
+      cycle_detected:
+        description: CycleDetected is true when storage guarded the ancestry walk
+          out of a cycle.
+        type: boolean
+      hash:
+        description: Hash is the session/node hash requested by the caller.
+        type: string
+      leaves:
+        description: Leaves names included nodes that have no children in storage.
+        items:
+          type: string
+        type: array
+      links:
+        description: Links contains parent -> child edges between included nodes.
+        items:
+          $ref: '#/definitions/api.GraphLink'
+        type: array
+      missing_parent:
+        description: MissingParent names the unresolved parent hash when the ancestry
+          is incomplete.
+        type: string
+      node_limit:
+        description: NodeLimit is the maximum number of nodes the server will include.
+        type: integer
+      nodes:
+        description: Nodes is the flat node list consumed by graph visualizers.
+        items:
+          $ref: '#/definitions/api.GraphNode'
+        type: array
+      root_hash:
+        description: RootHash is the top-most resolvable node included in the response.
+        type: string
+      scope:
+        description: 'Scope describes which portion of the graph was loaded: root,
+          branch, or ancestry.'
+        type: string
+      truncated:
+        description: Truncated is true when the graph hit NodeLimit or the ancestry
+          chain is incomplete.
+        type: boolean
+    type: object
   api.SessionListItem:
     properties:
       agent_name:
@@ -194,6 +291,16 @@ definitions:
       text:
         description: Text content (type="text")
         type: string
+      thinking:
+        description: |-
+          Thinking (type="thinking") - Anthropic extended-thinking blocks.
+          Anthropic emits thinking as content_block_delta frames with type
+          "thinking_delta" followed by a "signature_delta" that authenticates the
+          block. Consumers treat Thinking as opaque text; the signature is persisted
+          so downstream tooling can verify integrity.
+        type: string
+      thinking_signature:
+        type: string
       tool_input:
         additionalProperties: {}
         type: object
@@ -208,7 +315,7 @@ definitions:
         description: Tool use (type="tool_use") - assistant requesting tool execution
         type: string
       type:
-        description: '"text", "image", "tool_use", "tool_result"'
+        description: '"text", "image", "tool_use", "tool_result", "thinking"'
         type: string
     type: object
   github_com_papercomputeco_tapes_pkg_llm.ErrorResponse:
@@ -524,6 +631,55 @@ paths:
           schema:
             $ref: '#/definitions/github_com_papercomputeco_tapes_pkg_llm.ErrorResponse'
       summary: Get a session chain
+      tags:
+      - sessions
+  /v1/sessions/{hash}/graph:
+    get:
+      description: Returns a graph-shaped projection of the same session ancestry
+        returned by GET /v1/sessions/{hash}. scope=root loads the requested node's
+        resolvable root and all descendants, scope=branch loads the ancestry plus
+        descendants of the requested node, and scope=ancestry loads only the parent
+        chain.
+      parameters:
+      - description: Session hash
+        in: path
+        name: hash
+        required: true
+        type: string
+      - description: 'Graph scope: root, branch, or ancestry'
+        enum:
+        - root
+        - branch
+        - ancestry
+        in: query
+        name: scope
+        type: string
+      - description: Maximum number of graph nodes to include
+        in: query
+        maximum: 5000
+        minimum: 1
+        name: max_nodes
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.GraphResponse'
+        "400":
+          description: Missing hash or invalid query parameters
+          schema:
+            $ref: '#/definitions/github_com_papercomputeco_tapes_pkg_llm.ErrorResponse'
+        "404":
+          description: Session not found
+          schema:
+            $ref: '#/definitions/github_com_papercomputeco_tapes_pkg_llm.ErrorResponse'
+        "500":
+          description: Failed to load session graph
+          schema:
+            $ref: '#/definitions/github_com_papercomputeco_tapes_pkg_llm.ErrorResponse'
+      summary: Get a session graph
       tags:
       - sessions
   /v1/sessions/summary:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -66,6 +66,7 @@ func ValidConfigKeys() []string {
 		"proxy.listen",
 		"proxy.project",
 		"api.listen",
+		"api.web_ui",
 		"ingest.listen",
 		"client.proxy_target",
 		"client.api_target",

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -27,6 +27,7 @@ func NewDefaultConfig() *Config {
 		},
 		API: APIConfig{
 			Listen: defaultAPIListen,
+			WebUI:  false,
 		},
 		Ingest: IngestConfig{
 			Listen: defaultIngestListen,

--- a/pkg/config/flags.go
+++ b/pkg/config/flags.go
@@ -31,11 +31,12 @@ type Flag struct {
 type FlagSet map[string]Flag
 
 // Flag registry keys.
-// Use these constants when calling AddStringFlag, AddUintFlag,
+// Use these constants when calling AddStringFlag, AddUintFlag, AddBoolFlag,
 // and BindRegisteredFlags to avoid typos or drift from one command to another.
 const (
 	FlagProxyListen         = "proxy-listen"
 	FlagAPIListen           = "api-listen"
+	FlagAPIWebUI            = "api-web-ui"
 	FlagUpstream            = "upstream"
 	FlagProvider            = "provider"
 	FlagPostgres            = "postgres"
@@ -76,6 +77,21 @@ func AddStringFlag(cmd *cobra.Command, fs FlagSet, key string, target *string) {
 		cmd.Flags().StringVarP(target, def.Name, def.Shorthand, defaultVal, def.Description)
 	} else {
 		cmd.Flags().StringVar(target, def.Name, defaultVal, def.Description)
+	}
+}
+
+// AddBoolFlag registers a bool flag on cmd from the given FlagSet.
+func AddBoolFlag(cmd *cobra.Command, fs FlagSet, registryKey string, target *bool) {
+	def, ok := fs[registryKey]
+	if !ok {
+		return
+	}
+
+	defaultVal := defaultBool(def.ViperKey)
+	if def.Shorthand != "" {
+		cmd.Flags().BoolVarP(target, def.Name, def.Shorthand, defaultVal, def.Description)
+	} else {
+		cmd.Flags().BoolVar(target, def.Name, defaultVal, def.Description)
 	}
 }
 
@@ -137,4 +153,9 @@ func defaultString(viperKey string) string {
 // defaultUint returns the default uint value for a viper key from NewDefaultConfig.
 func defaultUint(viperKey string) uint {
 	return getDefaultViper().GetUint(viperKey)
+}
+
+// defaultBool returns the default bool value for a viper key from NewDefaultConfig.
+func defaultBool(viperKey string) bool {
+	return getDefaultViper().GetBool(viperKey)
 }

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -31,6 +31,7 @@ type ProxyConfig struct {
 // APIConfig holds API server settings.
 type APIConfig struct {
 	Listen string `toml:"listen,omitempty" mapstructure:"listen"`
+	WebUI  bool   `toml:"web_ui,omitempty" mapstructure:"web_ui"`
 }
 
 // IngestConfig holds ingest server settings for sidecar mode.
@@ -78,6 +79,7 @@ var configKeySet = map[string]bool{
 	"proxy.listen":          true,
 	"proxy.project":         true,
 	"api.listen":            true,
+	"api.web_ui":            true,
 	"ingest.listen":         true,
 	"client.proxy_target":   true,
 	"client.api_target":     true,

--- a/pkg/config/viper.go
+++ b/pkg/config/viper.go
@@ -73,6 +73,7 @@ func setViperDefaults(v *viper.Viper) {
 
 	// API
 	v.SetDefault("api.listen", d.API.Listen)
+	v.SetDefault("api.web_ui", d.API.WebUI)
 
 	// Ingest
 	v.SetDefault("ingest.listen", d.Ingest.Listen)

--- a/pkg/merkle/dag.go
+++ b/pkg/merkle/dag.go
@@ -87,6 +87,19 @@ func (d *Dag) walkNode(node *DagNode, f func(*DagNode) (bool, error)) (bool, err
 	return true, nil
 }
 
+// walkDescendants recursively traverses descendants of the given node in
+// depth-first order. It does not visit the node itself.
+func (d *Dag) walkDescendants(node *DagNode, f func(*DagNode) (bool, error)) error {
+	for _, child := range node.Children {
+		ok, err := d.walkNode(child, f)
+		if !ok || err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // Ancestors returns the path from the given node up to the root.
 // The returned slice is ordered from the node to root (node first, root last).
 // Returns nil if the hash is not found.
@@ -116,8 +129,8 @@ func (d *Dag) Descendants(hash string) []*DagNode {
 	}
 
 	descendants := []*DagNode{}
-	_ = d.Walk(func(n *DagNode) (bool, error) {
-		descendants = append(descendants, n.Children...)
+	_ = d.walkDescendants(node, func(descendant *DagNode) (bool, error) {
+		descendants = append(descendants, descendant)
 		return true, nil
 	})
 

--- a/pkg/merkle/dag_test.go
+++ b/pkg/merkle/dag_test.go
@@ -297,6 +297,20 @@ var _ = Describe("Dag", func() {
 			Expect(hashes).To(HaveKey(child.Hash))
 			Expect(hashes).To(HaveKey(grandchild.Hash))
 		})
+
+		It("returns only descendants below the requested node", func() {
+			root := merkle.NewNode(dagTestBucket("user", "root"), nil)
+			child1 := merkle.NewNode(dagTestBucket("assistant", "child1"), root)
+			child2 := merkle.NewNode(dagTestBucket("assistant", "child2"), root)
+			grandchild := merkle.NewNode(dagTestBucket("user", "grandchild"), child1)
+
+			dag, err := buildTestDag(ctx, []*merkle.Node{root, child1, child2, grandchild}, root.Hash)
+			Expect(err).NotTo(HaveOccurred())
+
+			descendants := dag.Descendants(child1.Hash)
+			Expect(descendants).To(HaveLen(1))
+			Expect(descendants[0].Hash).To(Equal(grandchild.Hash))
+		})
 	})
 
 	Describe("IsBranching", func() {


### PR DESCRIPTION
Rough POC of a minimal Prometheus web UI that can be served off the API - critical for development tasks understanding the graph views of the DAG

<img width="2056" height="1344" alt="Screenshot 2026-05-07 at 1 57 27 PM" src="https://github.com/user-attachments/assets/667fa28e-4fa1-4191-87dd-2ebb2d6b841b" />

---

* New root `/` for serving the web UI off the API
* New `v1/sessions/:hash/graph` and handler for building graph chain of given hash - this includes a walked chain from hash's root to children
* Very minimal embedded HTML for handling the graph - D3 is pulled from CDN - in the future, we may build a small react app, [like Prometheus does](https://github.com/prometheus/prometheus/blob/main/web/ui/README.md), vs raw HTML/JS
* Adds `walkDescendants` in `pkg/merkle`, which differs from `Walk` (which recurses on the entire DAG), and recursively returns the node's descendants only

---

Related to PCC-431