### PR TITLE
♻️ refactor: Tapes ingest now expects a llm.ChatResponse in its DTO

### DIFF
--- a/e2e/hurls/ingest/ingest.hurl
+++ b/e2e/hurls/ingest/ingest.hurl
@@ -12,7 +12,7 @@ HTTP 200
 jsonpath "$.status" == "ok"
 
 # ──────────────────────────────────────────────
-# 2. Single turn — OpenAI format
+# 2. Single turn — OpenAI request + reduced response
 # ──────────────────────────────────────────────
 
 POST {{host}}/v1/ingest
@@ -27,16 +27,15 @@ Content-Type: application/json
     ]
   },
   "response": {
-    "id": "chatcmpl-e2e-001",
-    "object": "chat.completion",
     "model": "gpt-4",
-    "choices": [
-      {
-        "index": 0,
-        "message": { "role": "assistant", "content": "Content addressing is a method of storing and retrieving data based on the content itself, rather than its location." },
-        "finish_reason": "stop"
-      }
-    ],
+    "message": {
+      "role": "assistant",
+      "content": [
+        { "type": "text", "text": "Content addressing is a method of storing and retrieving data based on the content itself, rather than its location." }
+      ]
+    },
+    "done": true,
+    "stop_reason": "stop",
     "usage": {
       "prompt_tokens": 12,
       "completion_tokens": 25,
@@ -49,7 +48,7 @@ HTTP 202
 jsonpath "$.status" == "accepted"
 
 # ──────────────────────────────────────────────
-# 3. Single turn — Anthropic format
+# 3. Single turn — Anthropic request + reduced response
 # ──────────────────────────────────────────────
 
 POST {{host}}/v1/ingest
@@ -66,17 +65,23 @@ Content-Type: application/json
     ]
   },
   "response": {
-    "id": "msg_e2e_002",
-    "type": "message",
-    "role": "assistant",
     "model": "claude-sonnet-4-20250514",
-    "content": [
-      { "type": "text", "text": "A Merkle DAG is a directed acyclic graph where each node is identified by a cryptographic hash of its content and links." }
-    ],
+    "message": {
+      "role": "assistant",
+      "content": [
+        { "type": "text", "text": "A Merkle DAG is a directed acyclic graph where each node is identified by a cryptographic hash of its content and links." }
+      ]
+    },
+    "done": true,
     "stop_reason": "end_turn",
     "usage": {
-      "input_tokens": 20,
-      "output_tokens": 30
+      "prompt_tokens": 20,
+      "completion_tokens": 30,
+      "total_tokens": 50
+    },
+    "extra": {
+      "id": "msg_e2e_002",
+      "type": "message"
     }
   }
 }
@@ -85,7 +90,7 @@ HTTP 202
 jsonpath "$.status" == "accepted"
 
 # ──────────────────────────────────────────────
-# 4. Single turn — Ollama format
+# 4. Single turn — Ollama request + reduced response
 # ──────────────────────────────────────────────
 
 POST {{host}}/v1/ingest
@@ -102,13 +107,20 @@ Content-Type: application/json
   },
   "response": {
     "model": "llama3",
-    "created_at": "2025-01-01T00:00:00Z",
-    "message": { "role": "assistant", "content": "Hi there! How can I help you?" },
+    "message": {
+      "role": "assistant",
+      "content": [
+        { "type": "text", "text": "Hi there! How can I help you?" }
+      ]
+    },
     "done": true,
-    "done_reason": "stop",
-    "prompt_eval_count": 5,
-    "eval_count": 10,
-    "total_duration": 500000000
+    "stop_reason": "stop",
+    "usage": {
+      "prompt_tokens": 5,
+      "completion_tokens": 10,
+      "total_tokens": 15,
+      "total_duration_ns": 500000000
+    }
   }
 }
 HTTP 202
@@ -131,10 +143,10 @@ Content-Type: application/json
         "messages": [{ "role": "user", "content": "Batch turn 1" }]
       },
       "response": {
-        "id": "chatcmpl-e2e-batch-1",
-        "object": "chat.completion",
         "model": "gpt-4",
-        "choices": [{ "index": 0, "message": { "role": "assistant", "content": "Batch response 1" }, "finish_reason": "stop" }],
+        "message": { "role": "assistant", "content": [{ "type": "text", "text": "Batch response 1" }] },
+        "done": true,
+        "stop_reason": "stop",
         "usage": { "prompt_tokens": 5, "completion_tokens": 5, "total_tokens": 10 }
       }
     },
@@ -148,9 +160,9 @@ Content-Type: application/json
       },
       "response": {
         "model": "llama3",
-        "created_at": "2025-01-01T00:00:00Z",
-        "message": { "role": "assistant", "content": "Batch response 2" },
-        "done": true
+        "message": { "role": "assistant", "content": [{ "type": "text", "text": "Batch response 2" }] },
+        "done": true,
+        "stop_reason": "stop"
       }
     }
   ]
@@ -169,7 +181,7 @@ Content-Type: application/json
 {
   "provider": "unknown-provider",
   "request": { "model": "x", "messages": [] },
-  "response": {}
+  "response": { "message": { "role": "assistant", "content": [{ "type": "text", "text": "ok" }] } }
 }
 HTTP 422
 [Asserts]
@@ -199,17 +211,17 @@ Content-Type: application/json
         "messages": [{ "role": "user", "content": "Valid turn" }]
       },
       "response": {
-        "id": "chatcmpl-e2e-partial",
-        "object": "chat.completion",
         "model": "gpt-4",
-        "choices": [{ "index": 0, "message": { "role": "assistant", "content": "OK" }, "finish_reason": "stop" }],
+        "message": { "role": "assistant", "content": [{ "type": "text", "text": "OK" }] },
+        "done": true,
+        "stop_reason": "stop",
         "usage": { "prompt_tokens": 3, "completion_tokens": 1, "total_tokens": 4 }
       }
     },
     {
       "provider": "bad-provider",
       "request": {},
-      "response": {}
+      "response": { "message": { "role": "assistant", "content": [{ "type": "text", "text": "ok" }] } }
     }
   ]
 }

--- a/ingest/contract_test.go
+++ b/ingest/contract_test.go
@@ -35,16 +35,15 @@ func mustMarshalPayload(p ingest.TurnPayload) []byte {
 
 func buildValidAnthropicOneshot() []byte {
 	req := json.RawMessage(`{"model":"claude-3-5-sonnet-20241022","max_tokens":64,"messages":[{"role":"user","content":"hi"}]}`)
-	resp := json.RawMessage(`{"id":"msg_x","type":"message","role":"assistant","model":"claude-3-5-sonnet-20241022","content":[{"type":"text","text":"hi"}],"stop_reason":"end_turn","usage":{"input_tokens":5,"output_tokens":2,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}`)
-	return mustMarshalPayload(ingest.TurnPayload{Provider: "anthropic", AgentName: "contract", RawRequest: req, RawResponse: resp})
+	return mustMarshalPayload(ingest.TurnPayload{Provider: "anthropic", AgentName: "contract", RawRequest: req, Response: reducedResponse("claude-3-5-sonnet-20241022", "hi", nil)})
 }
 
 func buildUnknownProvider() []byte {
-	return mustMarshalPayload(ingest.TurnPayload{Provider: "nope", RawRequest: json.RawMessage(`{}`), RawResponse: json.RawMessage(`{}`)})
+	return mustMarshalPayload(ingest.TurnPayload{Provider: "nope", RawRequest: json.RawMessage(`{}`), Response: reducedResponse("", "ok", nil)})
 }
 
 func buildMissingProvider() []byte {
-	return mustMarshalPayload(ingest.TurnPayload{RawRequest: json.RawMessage(`{}`), RawResponse: json.RawMessage(`{}`)})
+	return mustMarshalPayload(ingest.TurnPayload{RawRequest: json.RawMessage(`{}`), Response: reducedResponse("", "ok", nil)})
 }
 
 func buildMalformedEnvelope() []byte { return []byte(`{not json`) }
@@ -103,10 +102,9 @@ var _ = Describe("Ingest contract", func() {
 			contractCase{name: "empty_body", body: buildEmptyBody(), wantStatus: http.StatusBadRequest, wantRow: false}),
 	)
 
-	It("returns 422 when provider-specific response parse fails", func() {
+	It("returns 422 when reduced response validation fails", func() {
 		req := json.RawMessage(`{"model":"claude-3-5-sonnet","max_tokens":64,"messages":[{"role":"user","content":"hi"}]}`)
-		resp := json.RawMessage(`"this is a string, not a messages response"`)
-		payload := ingest.TurnPayload{Provider: "anthropic", RawRequest: req, RawResponse: resp}
+		payload := ingest.TurnPayload{Provider: "anthropic", RawRequest: req}
 		body, _ := json.Marshal(payload)
 
 		httpResp, err := client.Post(baseURL+"/v1/ingest", "application/json", bytes.NewReader(body))
@@ -114,6 +112,6 @@ var _ = Describe("Ingest contract", func() {
 		defer httpResp.Body.Close()
 		Expect(httpResp.StatusCode).To(Equal(http.StatusUnprocessableEntity))
 		b, _ := io.ReadAll(httpResp.Body)
-		Expect(string(b)).To(ContainSubstring("cannot parse response"))
+		Expect(string(b)).To(ContainSubstring("invalid reduced response"))
 	})
 })

--- a/ingest/ingest.go
+++ b/ingest/ingest.go
@@ -37,8 +37,9 @@ var (
 )
 
 // TurnPayload is the ingest request body for a single completed conversation turn.
-// It carries the raw provider request and response so tapes can parse, store,
-// and embed them exactly as the transparent proxy would.
+// It carries the raw provider request plus an already-reduced response.
+// Capture adapters such as tapes-extproc own protocol-specific stream reduction;
+// ingest owns request parsing, validation, and durable storage.
 type TurnPayload struct {
 	// Provider type: "openai", "anthropic", "ollama"
 	Provider string `json:"provider"`
@@ -46,11 +47,11 @@ type TurnPayload struct {
 	// AgentName optionally tags the turn (same as X-Tapes-Agent-Name header)
 	AgentName string `json:"agent_name,omitempty"`
 
-	// RawRequest is the original request body sent to the LLM provider
+	// RawRequest is the original request body sent to the LLM provider.
 	RawRequest json.RawMessage `json:"request"`
 
-	// RawResponse is the complete response body from the LLM provider
-	RawResponse json.RawMessage `json:"response"`
+	// Response is the already reduced, provider-agnostic response for the turn.
+	Response llm.ChatResponse `json:"response"`
 }
 
 // BatchPayload is the ingest request body for multiple conversation turns.
@@ -287,7 +288,7 @@ func (s *Server) handleBatchIngest(c *fiber.Ctx) error {
 		// envelope. Sum of raw request + response is a close lower bound; the
 		// JSON envelope overhead (provider, agent_name) is small and omitted to
 		// avoid re-marshaling.
-		turnBytes := len(t.RawRequest) + len(t.RawResponse)
+		turnBytes := len(t.RawRequest) + reducedResponseSize(t.Response)
 
 		start := time.Now()
 		if err := s.processTurn(t); err != nil {
@@ -327,6 +328,32 @@ func (s *Server) writeProcessTurnError(c *fiber.Ctx, err error) error {
 	return c.Status(status).JSON(llm.ErrorResponse{Error: err.Error()})
 }
 
+// reducedResponseSize provides the json marshaled size of the chat response
+func reducedResponseSize(resp llm.ChatResponse) int {
+	b, err := json.Marshal(resp)
+	if err != nil {
+		return 0
+	}
+	return len(b)
+}
+
+// validateReducedResponse is a sanity check ontop of a provided llm.ChatResponse
+// that ensures the payload to the ingest server is valid.
+func validateReducedResponse(resp *llm.ChatResponse) error {
+	if resp.Message.Role == "" {
+		return errors.New("missing response.message.role")
+	}
+	if len(resp.Message.Content) == 0 {
+		return errors.New("missing response.message.content")
+	}
+	for i, block := range resp.Message.Content {
+		if block.Type == "" {
+			return fmt.Errorf("missing response.message.content[%d].type", i)
+		}
+	}
+	return nil
+}
+
 // processTurn parses a raw turn payload and enqueues it for async DAG storage.
 // Returned errors wrap one of ErrEnvelope / ErrUnprocessable / ErrDownstream so
 // the caller can map to an HTTP status without re-parsing the message.
@@ -342,9 +369,9 @@ func (s *Server) processTurn(turn *TurnPayload) error {
 		return fmt.Errorf("%w: cannot parse request: %w", ErrUnprocessable, err)
 	}
 
-	parsedResp, err := prov.ParseResponse(turn.RawResponse)
-	if err != nil {
-		return fmt.Errorf("%w: cannot parse response: %w", ErrUnprocessable, err)
+	parsedResp := turn.Response
+	if err := validateReducedResponse(&parsedResp); err != nil {
+		return fmt.Errorf("%w: invalid reduced response: %w", ErrUnprocessable, err)
 	}
 
 	s.logger.Debug("ingesting turn",
@@ -357,7 +384,7 @@ func (s *Server) processTurn(turn *TurnPayload) error {
 		Provider:  prov.Name(),
 		AgentName: turn.AgentName,
 		Req:       parsedReq,
-		Resp:      parsedResp,
+		Resp:      &parsedResp,
 	}); !ok {
 		s.logger.Error("ingest enqueue failed: worker queue full",
 			"provider", prov.Name(),

--- a/ingest/ingest_test.go
+++ b/ingest/ingest_test.go
@@ -13,6 +13,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/papercomputeco/tapes/ingest"
+	"github.com/papercomputeco/tapes/pkg/llm"
 	tapeslogger "github.com/papercomputeco/tapes/pkg/logger"
 	"github.com/papercomputeco/tapes/pkg/storage"
 	"github.com/papercomputeco/tapes/pkg/storage/inmemory"
@@ -30,17 +31,6 @@ type ollamaMessage struct {
 	Content string `json:"content"`
 }
 
-// ollamaResponse is a minimal Ollama-format response for test fixtures.
-type ollamaResponse struct {
-	Model           string        `json:"model"`
-	CreatedAt       time.Time     `json:"created_at"`
-	Message         ollamaMessage `json:"message"`
-	Done            bool          `json:"done"`
-	DoneReason      string        `json:"done_reason,omitempty"`
-	PromptEvalCount int           `json:"prompt_eval_count,omitempty"`
-	EvalCount       int           `json:"eval_count,omitempty"`
-}
-
 // openaiRequest is a minimal OpenAI-format request for test fixtures.
 type openaiRequest struct {
 	Model    string          `json:"model"`
@@ -52,31 +42,20 @@ type openaiMessage struct {
 	Content string `json:"content"`
 }
 
-// openaiResponse is a minimal OpenAI-format response for test fixtures.
-type openaiResponse struct {
-	ID      string         `json:"id"`
-	Object  string         `json:"object"`
-	Model   string         `json:"model"`
-	Choices []openaiChoice `json:"choices"`
-	Usage   openaiUsage    `json:"usage"`
-}
-
-type openaiChoice struct {
-	Index        int           `json:"index"`
-	Message      openaiMessage `json:"message"`
-	FinishReason string        `json:"finish_reason"`
-}
-
-type openaiUsage struct {
-	PromptTokens     int `json:"prompt_tokens"`
-	CompletionTokens int `json:"completion_tokens"`
-	TotalTokens      int `json:"total_tokens"`
-}
-
 func mustJSON(v any) json.RawMessage {
 	b, err := json.Marshal(v)
 	Expect(err).NotTo(HaveOccurred())
 	return b
+}
+
+func reducedResponse(model, text string, usage *llm.Usage) llm.ChatResponse {
+	return llm.ChatResponse{
+		Model:      model,
+		Message:    llm.NewTextMessage("assistant", text),
+		Done:       true,
+		StopReason: "stop",
+		Usage:      usage,
+	}
 }
 
 func newTestServer() (*ingest.Server, storage.Driver, string) {
@@ -154,11 +133,7 @@ var _ = Describe("Ingest Server", func() {
 					Model:    "llama3",
 					Messages: []ollamaMessage{{Role: "user", Content: "Hello"}},
 				}),
-				RawResponse: mustJSON(ollamaResponse{
-					Model:   "llama3",
-					Message: ollamaMessage{Role: "assistant", Content: "Hi"},
-					Done:    true,
-				}),
+				Response: reducedResponse("llama3", "Hi", nil),
 			}
 			body, _ := json.Marshal(payload)
 			resp, err := client.Post(baseURL+"/v1/ingest", "application/json", bytes.NewReader(body))
@@ -187,9 +162,9 @@ var _ = Describe("Ingest Server", func() {
 
 		It("increments writes_total{status=unknown_provider} on unsupported provider", func() {
 			payload := ingest.TurnPayload{
-				Provider:    "bogus-provider",
-				RawRequest:  json.RawMessage(`{}`),
-				RawResponse: json.RawMessage(`{}`),
+				Provider:   "bogus-provider",
+				RawRequest: json.RawMessage(`{}`),
+				Response:   reducedResponse("", "ok", nil),
 			}
 			body, _ := json.Marshal(payload)
 			resp, err := client.Post(baseURL+"/v1/ingest", "application/json", bytes.NewReader(body))
@@ -215,11 +190,7 @@ var _ = Describe("Ingest Server", func() {
 						{Role: "user", Content: "Hello"},
 					},
 				}),
-				RawResponse: mustJSON(ollamaResponse{
-					Model:   "llama3",
-					Message: ollamaMessage{Role: "assistant", Content: "Hi there!"},
-					Done:    true,
-				}),
+				Response: reducedResponse("llama3", "Hi there!", nil),
 			}
 
 			body, _ := json.Marshal(payload)
@@ -249,22 +220,10 @@ var _ = Describe("Ingest Server", func() {
 						{Role: "user", Content: "Explain Go interfaces"},
 					},
 				}),
-				RawResponse: mustJSON(openaiResponse{
-					ID:     "chatcmpl-123",
-					Object: "chat.completion",
-					Model:  "gpt-4",
-					Choices: []openaiChoice{
-						{
-							Index:        0,
-							Message:      openaiMessage{Role: "assistant", Content: "In Go, an interface..."},
-							FinishReason: "stop",
-						},
-					},
-					Usage: openaiUsage{
-						PromptTokens:     10,
-						CompletionTokens: 20,
-						TotalTokens:      30,
-					},
+				Response: reducedResponse("gpt-4", "In Go, an interface...", &llm.Usage{
+					PromptTokens:     10,
+					CompletionTokens: 20,
+					TotalTokens:      30,
 				}),
 			}
 
@@ -278,9 +237,9 @@ var _ = Describe("Ingest Server", func() {
 
 		It("rejects an unsupported provider", func() {
 			payload := ingest.TurnPayload{
-				Provider:    "unknown-provider",
-				RawRequest:  json.RawMessage(`{}`),
-				RawResponse: json.RawMessage(`{}`),
+				Provider:   "unknown-provider",
+				RawRequest: json.RawMessage(`{}`),
+				Response:   reducedResponse("", "ok", nil),
 			}
 
 			body, _ := json.Marshal(payload)
@@ -328,11 +287,7 @@ var _ = Describe("Ingest Server", func() {
 					RawRequest: mustJSON(ollamaRequest{
 						Model: "llama3", Messages: []ollamaMessage{{Role: "user", Content: "hi"}},
 					}),
-					RawResponse: mustJSON(ollamaResponse{
-						Model:   "llama3",
-						Message: ollamaMessage{Role: "assistant", Content: "yo"},
-						Done:    true,
-					}),
+					Response: reducedResponse("llama3", "yo", nil),
 				}
 				body, _ := json.Marshal(payload)
 				r, err := client.Post(baseURL+"/v1/ingest", "application/json", bytes.NewReader(body))
@@ -384,11 +339,7 @@ var _ = Describe("Ingest Server", func() {
 							Model:    "llama3",
 							Messages: []ollamaMessage{{Role: "user", Content: "First"}},
 						}),
-						RawResponse: mustJSON(ollamaResponse{
-							Model:   "llama3",
-							Message: ollamaMessage{Role: "assistant", Content: "Response 1"},
-							Done:    true,
-						}),
+						Response: reducedResponse("llama3", "Response 1", nil),
 					},
 					{
 						Provider:  "ollama",
@@ -397,11 +348,7 @@ var _ = Describe("Ingest Server", func() {
 							Model:    "llama3",
 							Messages: []ollamaMessage{{Role: "user", Content: "Second"}},
 						}),
-						RawResponse: mustJSON(ollamaResponse{
-							Model:   "llama3",
-							Message: ollamaMessage{Role: "assistant", Content: "Response 2"},
-							Done:    true,
-						}),
+						Response: reducedResponse("llama3", "Response 2", nil),
 					},
 				},
 			}
@@ -429,16 +376,12 @@ var _ = Describe("Ingest Server", func() {
 							Model:    "llama3",
 							Messages: []ollamaMessage{{Role: "user", Content: "Valid"}},
 						}),
-						RawResponse: mustJSON(ollamaResponse{
-							Model:   "llama3",
-							Message: ollamaMessage{Role: "assistant", Content: "OK"},
-							Done:    true,
-						}),
+						Response: reducedResponse("llama3", "OK", nil),
 					},
 					{
-						Provider:    "bad-provider",
-						RawRequest:  json.RawMessage(`{}`),
-						RawResponse: json.RawMessage(`{}`),
+						Provider:   "bad-provider",
+						RawRequest: json.RawMessage(`{}`),
+						Response:   reducedResponse("", "ok", nil),
 					},
 				},
 			}
@@ -478,16 +421,12 @@ var _ = Describe("Ingest Server", func() {
 							Model:    "llama3",
 							Messages: []ollamaMessage{{Role: "user", Content: "hi"}},
 						}),
-						RawResponse: mustJSON(ollamaResponse{
-							Model:   "llama3",
-							Message: ollamaMessage{Role: "assistant", Content: "ok"},
-							Done:    true,
-						}),
+						Response: reducedResponse("llama3", "ok", nil),
 					},
 					{
-						Provider:    "bad-provider",
-						RawRequest:  json.RawMessage(`{}`),
-						RawResponse: json.RawMessage(`{}`),
+						Provider:   "bad-provider",
+						RawRequest: json.RawMessage(`{}`),
+						Response:   reducedResponse("", "ok", nil),
 					},
 				},
 			}


### PR DESCRIPTION
* Refactors the ingest server to accept a reduced `llm.ChatResponse` on the ingest server - this ensures that whatever producer maps correctly to the ingest payload expectation - before, the raw JSON message was dropping fields in our external processor since that was using `capture.Reducer` to reduce messages and send them through.
* Map tests files to match this new expectation.

---

Towards PCC-431