### PR TITLE
🔧 fix: bump DAGGER_VERSION 0.20.6 → 0.20.8 in CI workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ permissions:
   contents: read
 
 env:
-  DAGGER_VERSION: "0.20.6"
+  DAGGER_VERSION: "0.20.8"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/cut-release.yaml
+++ b/.github/workflows/cut-release.yaml
@@ -7,7 +7,7 @@ permissions:
   contents: write
 
 env:
-  DAGGER_VERSION: "0.20.6"
+  DAGGER_VERSION: "0.20.8"
 
 jobs:
   create-release:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -11,7 +11,7 @@ permissions:
   id-token: write
 
 env:
-  DAGGER_VERSION: "0.20.6"
+  DAGGER_VERSION: "0.20.8"
 
 jobs:
   check:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -9,7 +9,7 @@ permissions:
   pull-requests: read
 
 env:
-  DAGGER_VERSION: "0.20.6"
+  DAGGER_VERSION: "0.20.8"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,7 +5,7 @@ on:
     types: [published]
 
 env:
-  DAGGER_VERSION: "0.20.6"
+  DAGGER_VERSION: "0.20.8"
 
 jobs:
   release:


### PR DESCRIPTION
## Summary

- The CLI installed by `dagger-for-github` no longer round-trips cleanly with the current daggerverse modules at v0.20.6. The version handshake fails before `dagger call` reaches user code.
- Bumps `DAGGER_VERSION` to 0.20.8 across the workflows, matching the rest of the org repos (e.g. `paper` PR #40) that have already moved.

Refs PCC-543

## Test plan

- [x] CI / PR / release workflows pass on this PR