### PR TITLE
🔧 fix: capture tool_result fields in Anthropic request parser (PCC-523)

### DIFF
--- a/pkg/llm/provider/anthropic/anthropic.go
+++ b/pkg/llm/provider/anthropic/anthropic.go
@@ -69,6 +69,32 @@ func (p *Provider) ParseRequest(payload []byte) (*llm.ChatRequest, error) {
 					if input, ok := block["input"].(map[string]any); ok {
 						cb.ToolInput = input
 					}
+
+					// Tool result. Anthropic permits the `content` field to be
+					// either a string or an array of text/image content blocks;
+					// flatten any text into ToolOutput.
+					if toolUseID, ok := block["tool_use_id"].(string); ok {
+						cb.ToolResultID = toolUseID
+					}
+					if isError, ok := block["is_error"].(bool); ok {
+						cb.IsError = isError
+					}
+					switch tc := block["content"].(type) {
+					case string:
+						cb.ToolOutput = tc
+					case []any:
+						var parts []string
+						for _, item := range tc {
+							part, ok := item.(map[string]any)
+							if !ok {
+								continue
+							}
+							if text, ok := part["text"].(string); ok {
+								parts = append(parts, text)
+							}
+						}
+						cb.ToolOutput = strings.Join(parts, "\n")
+					}
 					converted.Content = append(converted.Content, cb)
 				}
 			}

--- a/pkg/llm/provider/anthropic/anthropic.go
+++ b/pkg/llm/provider/anthropic/anthropic.go
@@ -72,28 +72,32 @@ func (p *Provider) ParseRequest(payload []byte) (*llm.ChatRequest, error) {
 
 					// Tool result. Anthropic permits the `content` field to be
 					// either a string or an array of text/image content blocks;
-					// flatten any text into ToolOutput.
-					if toolUseID, ok := block["tool_use_id"].(string); ok {
-						cb.ToolResultID = toolUseID
-					}
-					if isError, ok := block["is_error"].(bool); ok {
-						cb.IsError = isError
-					}
-					switch tc := block["content"].(type) {
-					case string:
-						cb.ToolOutput = tc
-					case []any:
-						var parts []string
-						for _, item := range tc {
-							part, ok := item.(map[string]any)
-							if !ok {
-								continue
-							}
-							if text, ok := part["text"].(string); ok {
-								parts = append(parts, text)
-							}
+					// flatten any text into ToolOutput. Guard on cb.Type so a
+					// future block type that exposes a top-level `content` key
+					// can't silently populate ToolOutput.
+					if cb.Type == "tool_result" {
+						if toolUseID, ok := block["tool_use_id"].(string); ok {
+							cb.ToolResultID = toolUseID
 						}
-						cb.ToolOutput = strings.Join(parts, "\n")
+						if isError, ok := block["is_error"].(bool); ok {
+							cb.IsError = isError
+						}
+						switch tc := block["content"].(type) {
+						case string:
+							cb.ToolOutput = tc
+						case []any:
+							var parts []string
+							for _, item := range tc {
+								part, ok := item.(map[string]any)
+								if !ok {
+									continue
+								}
+								if text, ok := part["text"].(string); ok {
+									parts = append(parts, text)
+								}
+							}
+							cb.ToolOutput = strings.Join(parts, "\n")
+						}
 					}
 					converted.Content = append(converted.Content, cb)
 				}

--- a/pkg/llm/provider/anthropic/anthropic_test.go
+++ b/pkg/llm/provider/anthropic/anthropic_test.go
@@ -200,6 +200,90 @@ var _ = Describe("Anthropic Provider", func() {
 			})
 		})
 
+		Context("with tool result in messages", func() {
+			It("parses tool_result blocks with string content", func() {
+				payload := []byte(`{
+					"model": "claude-3-sonnet-20240229",
+					"max_tokens": 1024,
+					"messages": [
+						{
+							"role": "user",
+							"content": [
+								{
+									"type": "tool_result",
+									"tool_use_id": "toolu_123",
+									"content": "42"
+								}
+							]
+						}
+					]
+				}`)
+
+				req, err := p.ParseRequest(payload)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(req.Messages[0].Content).To(HaveLen(1))
+				Expect(req.Messages[0].Content[0].Type).To(Equal("tool_result"))
+				Expect(req.Messages[0].Content[0].ToolResultID).To(Equal("toolu_123"))
+				Expect(req.Messages[0].Content[0].ToolOutput).To(Equal("42"))
+				Expect(req.Messages[0].Content[0].IsError).To(BeFalse())
+			})
+
+			It("parses tool_result blocks with array content (text parts)", func() {
+				payload := []byte(`{
+					"model": "claude-3-sonnet-20240229",
+					"max_tokens": 1024,
+					"messages": [
+						{
+							"role": "user",
+							"content": [
+								{
+									"type": "tool_result",
+									"tool_use_id": "toolu_456",
+									"content": [
+										{"type": "text", "text": "line one"},
+										{"type": "text", "text": "line two"}
+									]
+								}
+							]
+						}
+					]
+				}`)
+
+				req, err := p.ParseRequest(payload)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(req.Messages[0].Content[0].Type).To(Equal("tool_result"))
+				Expect(req.Messages[0].Content[0].ToolResultID).To(Equal("toolu_456"))
+				Expect(req.Messages[0].Content[0].ToolOutput).To(Equal("line one\nline two"))
+			})
+
+			It("parses tool_result blocks with is_error true", func() {
+				payload := []byte(`{
+					"model": "claude-3-sonnet-20240229",
+					"max_tokens": 1024,
+					"messages": [
+						{
+							"role": "user",
+							"content": [
+								{
+									"type": "tool_result",
+									"tool_use_id": "toolu_789",
+									"content": "tool failed",
+									"is_error": true
+								}
+							]
+						}
+					]
+				}`)
+
+				req, err := p.ParseRequest(payload)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(req.Messages[0].Content[0].Type).To(Equal("tool_result"))
+				Expect(req.Messages[0].Content[0].ToolResultID).To(Equal("toolu_789"))
+				Expect(req.Messages[0].Content[0].ToolOutput).To(Equal("tool failed"))
+				Expect(req.Messages[0].Content[0].IsError).To(BeTrue())
+			})
+		})
+
 		Context("with invalid payload", func() {
 			It("returns an error for invalid JSON", func() {
 				payload := []byte(`not valid json`)

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/papercomputeco/tapes/pkg/llm"
 	tapeslogger "github.com/papercomputeco/tapes/pkg/logger"
+	"github.com/papercomputeco/tapes/pkg/merkle"
 	"github.com/papercomputeco/tapes/pkg/storage"
 	"github.com/papercomputeco/tapes/pkg/storage/inmemory"
 	"github.com/papercomputeco/tapes/proxy/header"
@@ -927,5 +928,113 @@ var _ = Describe("Storage Provider Metadata", func() {
 		Expect(leaves[0].Usage.PromptTokens).To(Equal(10))
 		Expect(leaves[0].Usage.CompletionTokens).To(Equal(5))
 		Expect(leaves[0].StopReason).To(Equal("stop"))
+	})
+})
+
+var _ = Describe("Anthropic tool_result capture", func() {
+	var (
+		p        *Proxy
+		driver   storage.Driver
+		upstream *httptest.Server
+	)
+
+	BeforeEach(func() {
+		upstream = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"id": "msg_x",
+				"type": "message",
+				"role": "assistant",
+				"model": "claude-3-5-sonnet-20241022",
+				"stop_reason": "end_turn",
+				"content": [{"type": "text", "text": "ok"}],
+				"usage": {"input_tokens": 1, "output_tokens": 1, "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0}
+			}`))
+		}))
+
+		logger := tapeslogger.NewNoop()
+		driver = inmemory.NewDriver()
+		var err error
+		p, err = New(
+			Config{
+				ListenAddr:   ":0",
+				UpstreamURL:  upstream.URL,
+				ProviderType: "anthropic",
+			},
+			driver,
+			logger,
+		)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		if p != nil {
+			p.Close()
+		}
+		upstream.Close()
+	})
+
+	It("persists tool_use_id, content, and is_error on the user tool_result node", func() {
+		reqBody := []byte(`{
+			"model": "claude-3-5-sonnet-20241022",
+			"max_tokens": 64,
+			"stream": false,
+			"messages": [
+				{"role": "user", "content": "list files"},
+				{
+					"role": "assistant",
+					"content": [
+						{
+							"type": "tool_use",
+							"id": "toolu_abc",
+							"name": "ls",
+							"input": {"path": "."}
+						}
+					]
+				},
+				{
+					"role": "user",
+					"content": [
+						{
+							"type": "tool_result",
+							"tool_use_id": "toolu_abc",
+							"content": "a.txt\nb.txt",
+							"is_error": false
+						}
+					]
+				}
+			]
+		}`)
+
+		resp, err := p.server.Test(httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(string(reqBody))))
+		Expect(err).NotTo(HaveOccurred())
+		resp.Body.Close()
+		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+		p.Close()
+		p = nil
+
+		ctx := GinkgoT().Context()
+		nodes, err := driver.List(ctx)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Locate the user tool_result node by its content block type.
+		var toolResultNode *merkle.Node
+		for _, n := range nodes {
+			if n.Bucket.Role != "user" || len(n.Bucket.Content) == 0 {
+				continue
+			}
+			if n.Bucket.Content[0].Type == "tool_result" {
+				toolResultNode = n
+				break
+			}
+		}
+		Expect(toolResultNode).NotTo(BeNil(), "expected a user node holding a tool_result block")
+
+		block := toolResultNode.Bucket.Content[0]
+		Expect(block.ToolResultID).To(Equal("toolu_abc"))
+		Expect(block.ToolOutput).To(Equal("a.txt\nb.txt"))
+		Expect(block.IsError).To(BeFalse())
 	})
 })


### PR DESCRIPTION
## Summary

- Anthropic `ParseRequest` was dropping every field of inbound `tool_result` content blocks except `type`, so persisted user turns lost `tool_use_id`, the tool output, and the error flag. The matching `tool_use` blocks on the prior assistant turn were intact — only the result side was being lost.
- Read those fields off the inbound payload and map them onto the existing `ContentBlock` fields (`ToolResultID`, `ToolOutput`, `IsError`). The `content` field is flattened from either a string or an array of text parts, per Anthropic's request schema.
- Adds unit + integration coverage so future regressions surface in CI.

Resolves PCC-523

## Test plan

- [x] `make test` passes.
- [x] Drive a successful tool call through the proxy against a real Anthropic agent; confirm the persisted user node's `content` JSONB carries `tool_result_id` and `tool_output`.
- [x] Drive a failing tool call; confirm `is_error: true` lands on the same node.
- [x] Spot-check an OpenAI tool-call session for regressions (this PR does not touch the OpenAI provider).