### PR TITLE
✨ feat: stamp proxy wall-clock duration on every captured turn (PCC-514)

### DIFF
--- a/api/v1_handlers.go
+++ b/api/v1_handlers.go
@@ -102,9 +102,10 @@ type Turn struct {
 //     returned by the driver, using the configured pricing table.
 //   - TotalDurationNs is the wall-clock span MAX(created_at) − MIN(created_at)
 //     across matching nodes, in nanoseconds. It is NOT a sum of per-call
-//     durations: the underlying nodes.total_duration_ns column is currently
-//     never populated by the proxy (see PCC-514). Once that lands the SQL
-//     can switch to SUM without the JSON field name changing.
+//     durations. The underlying nodes.total_duration_ns column is now
+//     populated by the proxy with per-call wall-clock duration (PCC-514);
+//     switching this endpoint to SUM(total_duration_ns) is a separate
+//     decision since it changes the visible semantic.
 //   - CompletedCount uses leaf-status-only classification: an assistant leaf
 //     with a terminal stop_reason ("stop", "end_turn", "end-turn", "eos").
 //     This is an approximation of pkg/sessions.DetermineStatus, which also

--- a/pkg/llm/response.go
+++ b/pkg/llm/response.go
@@ -46,7 +46,16 @@ type Usage struct {
 	CacheCreationInputTokens int `json:"cache_creation_input_tokens,omitempty"`
 	CacheReadInputTokens     int `json:"cache_read_input_tokens,omitempty"`
 
-	// Timing (provider-specific, but normalized to nanoseconds where possible)
-	TotalDurationNs  int64 `json:"total_duration_ns,omitempty"`
+	// TotalDurationNs is the proxy-measured wall-clock time, in nanoseconds,
+	// from when the proxy received the client request to when the upstream
+	// response was fully assembled. Set uniformly by the proxy across providers
+	// — Anthropic and OpenAI don't surface a duration field on the wire, and
+	// Ollama's server-internal `total_duration` is intentionally overwritten so
+	// aggregate stats compare apples to apples.
+	TotalDurationNs int64 `json:"total_duration_ns,omitempty"`
+
+	// PromptDurationNs is provider-reported prompt-evaluation time, in
+	// nanoseconds. Populated by providers that surface it (currently Ollama
+	// only); left at zero otherwise.
 	PromptDurationNs int64 `json:"prompt_duration_ns,omitempty"`
 }

--- a/pkg/storage/inmemory/inmemory.go
+++ b/pkg/storage/inmemory/inmemory.go
@@ -412,8 +412,9 @@ func (s *Driver) ListSessions(_ context.Context, opts storage.ListOpts) (*storag
 // store contents.
 //
 // TotalDurationNs is wall-clock span (MAX − MIN of CreatedAt) over the
-// matching set, NOT a sum of per-call Usage.TotalDurationNs. See PCC-514
-// for the proxy gap that motivated the workaround.
+// matching set, NOT a sum of per-call Usage.TotalDurationNs. Per-call
+// duration is now persisted on nodes (PCC-514); switching this aggregate
+// to SUM is a separate decision since it changes the visible semantic.
 func (s *Driver) CountSessions(_ context.Context, opts storage.ListOpts) (storage.SessionStats, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -269,6 +269,8 @@ func (p *Proxy) handleNonStreamingProxy(c *fiber.Ctx, path, method, upstreamURL 
 				"duration", time.Since(startTime),
 			)
 
+			stampDuration(parsedResp, startTime)
+
 			// Non-blocking enqueue for async storage
 			p.workerPool.Enqueue(worker.Job{
 				Provider:  prov.Name(),
@@ -411,6 +413,8 @@ func (p *Proxy) handleSSEStreamViaCapture(r capture.Reducer, httpResp *http.Resp
 		"model", resp.Model,
 		"duration", time.Since(startTime),
 	)
+
+	stampDuration(resp, startTime)
 
 	p.workerPool.Enqueue(worker.Job{
 		Provider:  prov.Name(),
@@ -601,6 +605,7 @@ func (p *Proxy) enqueueStreamedResponse(allChunks [][]byte, fullContent string, 
 			if finalResp.Model == "" && parsedReq.Model != "" {
 				finalResp.Model = parsedReq.Model
 			}
+			stampDuration(finalResp, startTime)
 			p.workerPool.Enqueue(worker.Job{
 				Provider:  prov.Name(),
 				AgentName: agentName,
@@ -769,6 +774,22 @@ func resolveProviderOverride(path string) (string, string) {
 	}
 
 	return providerName, "/" + parts[1]
+}
+
+// stampDuration sets Usage.TotalDurationNs to the wall-clock time since
+// startTime, allocating Usage if needed. Called at every enqueue site so
+// tapes records a uniform per-call duration regardless of provider:
+// Anthropic and OpenAI don't surface call duration on the wire, and Ollama's
+// server-internal value is intentionally overwritten so aggregate stats compare
+// apples to apples. See PCC-514.
+func stampDuration(resp *llm.ChatResponse, startTime time.Time) {
+	if resp == nil {
+		return
+	}
+	if resp.Usage == nil {
+		resp.Usage = &llm.Usage{}
+	}
+	resp.Usage.TotalDurationNs = time.Since(startTime).Nanoseconds()
 }
 
 func isOpenAIAuthPath(path string) bool {

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -1038,3 +1038,133 @@ var _ = Describe("Anthropic tool_result capture", func() {
 		Expect(block.IsError).To(BeFalse())
 	})
 })
+
+var _ = Describe("Proxy-measured total duration", func() {
+	const upstreamDelay = 50 * time.Millisecond
+
+	var (
+		p        *Proxy
+		driver   storage.Driver
+		upstream *httptest.Server
+	)
+
+	AfterEach(func() {
+		if p != nil {
+			p.Close()
+		}
+		if upstream != nil {
+			upstream.Close()
+		}
+	})
+
+	Context("non-streaming response", func() {
+		BeforeEach(func() {
+			upstream = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				time.Sleep(upstreamDelay)
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				w.Write(makeOllamaResponseBody("test-model", "assistant", "hi"))
+			}))
+			p, driver = newTestProxy(upstream.URL)
+		})
+
+		It("stamps Usage.TotalDurationNs with proxy wall-clock time", func() {
+			reqBody := makeOllamaRequestBody("test-model", []ollamaTestMessage{
+				{Role: "user", Content: "hi"},
+			}, boolPtr(false))
+
+			resp, err := p.server.Test(httptest.NewRequest(http.MethodPost, "/api/chat", strings.NewReader(string(reqBody))))
+			Expect(err).NotTo(HaveOccurred())
+			resp.Body.Close()
+
+			p.Close()
+			p = nil
+
+			ctx := GinkgoT().Context()
+			leaves, err := driver.Leaves(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(leaves).To(HaveLen(1))
+			Expect(leaves[0].Usage).NotTo(BeNil())
+
+			// Must overwrite the value Ollama wired in (1_000_000 from the
+			// test fixture). Proxy wall-clock should be >= the upstream
+			// sleep delay, which is well above the fixture value.
+			Expect(leaves[0].Usage.TotalDurationNs).To(BeNumerically(">=", upstreamDelay.Nanoseconds()),
+				"TotalDurationNs should reflect proxy round-trip, not the provider-reported value")
+		})
+	})
+
+	Context("streaming response through capture", func() {
+		BeforeEach(func() {
+			upstream = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				time.Sleep(upstreamDelay)
+				w.Header().Set("Content-Type", "text/event-stream")
+				flusher, ok := w.(http.Flusher)
+				Expect(ok).To(BeTrue())
+				events := []string{
+					`event: message_start
+data: {"type":"message_start","message":{"id":"msg_x","type":"message","role":"assistant","content":[],"model":"claude-3-5-sonnet-20241022","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":1,"output_tokens":1,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}
+
+`,
+					`event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+`,
+					`event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hi"}}
+
+`,
+					`event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+`,
+					`event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":1}}
+
+`,
+					`event: message_stop
+data: {"type":"message_stop"}
+
+`,
+				}
+				for _, ev := range events {
+					fmt.Fprint(w, ev)
+					flusher.Flush()
+				}
+			}))
+
+			logger := tapeslogger.NewNoop()
+			driver = inmemory.NewDriver()
+			var err error
+			p, err = New(
+				Config{
+					ListenAddr:   ":0",
+					UpstreamURL:  upstream.URL,
+					ProviderType: "anthropic",
+				},
+				driver,
+				logger,
+			)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("stamps Usage.TotalDurationNs on the streamed assistant node", func() {
+			reqBody := `{"model":"claude-3-5-sonnet-20241022","max_tokens":8,"stream":true,"messages":[{"role":"user","content":"hi"}]}`
+
+			resp, err := p.server.Test(httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(reqBody)), -1)
+			Expect(err).NotTo(HaveOccurred())
+			resp.Body.Close()
+
+			p.Close()
+			p = nil
+
+			ctx := GinkgoT().Context()
+			leaves, err := driver.Leaves(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(leaves).To(HaveLen(1))
+			Expect(leaves[0].Bucket.Role).To(Equal("assistant"))
+			Expect(leaves[0].Usage).NotTo(BeNil())
+			Expect(leaves[0].Usage.TotalDurationNs).To(BeNumerically(">=", upstreamDelay.Nanoseconds()))
+		})
+	})
+})

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -436,6 +436,16 @@ var _ = Describe("Streaming Proxy", func() {
 			Expect(leaves[0].Bucket.Role).To(Equal("assistant"))
 			// The accumulated content from all streaming chunks
 			Expect(leaves[0].Bucket.ExtractText()).To(Equal("2+2 equals 4."))
+
+			// The wire-reported total_duration was 1_000_000 ns (1ms) in the
+			// fixture above; the proxy must overwrite it with its own
+			// wall-clock measurement so non-Ollama providers and Ollama land
+			// on the same semantic. Anything > 0 and != the wire value proves
+			// the legacy NDJSON path's stampDuration call is taking effect.
+			Expect(leaves[0].Usage).NotTo(BeNil())
+			Expect(leaves[0].Usage.TotalDurationNs).NotTo(BeZero())
+			Expect(leaves[0].Usage.TotalDurationNs).NotTo(Equal(int64(1_000_000)),
+				"proxy should overwrite Ollama's wire-reported total_duration")
 		})
 	})
 


### PR DESCRIPTION
Resolves PCC-514.

## Summary

The proxy already computed `time.Since(startTime)` for debug logs at every enqueue site, but the value was never written into the `Usage` struct that gets persisted. `Usage.TotalDurationNs` was wired end-to-end through the storage layer; only Ollama's response parser populated it from wire data, and Anthropic / OpenAI rows landed with the column NULL forever.

This PR stamps `Usage.TotalDurationNs = time.Since(startTime).Nanoseconds()` at every enqueue site so every captured turn carries a per-call duration — proxy wall-clock — regardless of provider.

## Design discussion: what does TotalDurationNs mean?

The investigation surfaced a real choice about the semantic of this field, and the tradeoffs matter enough to record here.

**The situation before this change:**

- **Ollama** populated `Usage.TotalDurationNs` from its `total_duration` response field, which Ollama computes as `time.Since(checkpointStart)` at its HTTP handler entry — i.e. **server-internal wall-clock time** (model load + prompt eval + generation + queueing). Network time is excluded.
- **Anthropic** and **OpenAI** do not return any duration field on the wire. Triple-checked: AWS Bedrock's published Anthropic response schema lists only token counts under `usage`; the official `anthropic-sdk-python` `Usage` type exposes `cache_*`, `inference_geo`, `input_tokens`, `output_tokens`, `server_tool_use`, `service_tier` — and no timing field; documented response headers are `request-id`, `anthropic-ratelimit-*`, `retry-after`. OpenAI's `usage` object is similarly token-only.
- The **proxy** had `time.Since(startTime)` available at every enqueue site, but only logged it.

**Three options were on the table:**

- **(a) Fill if absent.** Proxy writes its wall-clock value only when the provider didn't supply one. Preserves Ollama's server-internal precision; fills the gap for Anthropic / OpenAI. Per-provider semantics are mixed: Ollama rows mean "server-only," non-Ollama rows mean "proxy round-trip including network."
- **(b) Always stamp from the proxy.** One uniform semantic across providers — `TotalDurationNs` is always "tapes proxy wall-clock from request entry to response complete." Always populated. Drops Ollama's server-internal precision (≈ network round-trip from the proxy, which is negligible for loopback).
- **(c) Add a separate field.** Most precise (`TotalDurationNs` stays provider-reported; new `ProxyDurationNs` for wall-clock). Costs a schema change, migration, and consumer updates everywhere `Usage` is read.

**We picked (b)** for these reasons:

- Aggregate stats across providers become honestly comparable. `/v1/stats` and `/v1/sessions/summary` can sum or average without an apples-to-oranges caveat per provider.
- The field is now always populated for any successful captured turn. Downstream code can drop \"if duration > 0\" guards.
- The semantic — \"what the agent waited for\" — matches what tapes is for: it sits at the proxy boundary, and \"the agent's perspective\" is the natural place to measure from.
- The cost (losing Ollama's internal-only measurement) is small: for the typical loopback Ollama deployment it's ≈ 1–2ms of proxy overhead, well below the noise floor of model latency itself. If a higher-fidelity Ollama-server breakdown ever matters, the raw `total_duration` is still in the response bytes (just not in our Usage struct).

`PromptDurationNs` is intentionally left as-is in this PR: provider-populated when the wire surfaces it (Ollama only today), zero otherwise. The asymmetry is documented on the struct. Aligning that field across providers needs a separate decision (streaming time-to-first-token has different semantics than non-streaming, and Anthropic / OpenAI don't surface anything analogous on non-streaming).

## Implementation

- `proxy/proxy.go` adds a small `stampDuration(resp, startTime)` helper that allocates `Usage` if nil and sets `TotalDurationNs`. Called from the non-streaming, capture-backed streaming, and legacy SSE / NDJSON streaming paths immediately before `workerPool.Enqueue`.
- `pkg/llm/response.go` docs the new semantic on `TotalDurationNs` and the asymmetric `PromptDurationNs`.
- Doc-only cleanup of `api/v1_handlers.go` and `pkg/storage/inmemory/inmemory.go` comments that called out the gap; the wall-clock MAX − MIN aggregate in `/v1/stats` is preserved as-is, since switching to `SUM(total_duration_ns)` changes the visible semantic and deserves its own ticket.

## Hash impact

None. `Usage` lives on `merkle.NodeOptions`, not on `Bucket` — the content-addressable hash is unaffected by Usage values. Newly captured turns hash exactly as before; only the persisted Usage fields change.

## Test plan

- [x] `make test` passes.
- [x] Drive Anthropic traffic through the proxy and confirm new `nodes.total_duration_ns` rows are populated with non-zero values in the 100ms–30s range:
  ```sql
  SELECT created_at, provider, total_duration_ns FROM nodes
   WHERE role = 'assistant' AND total_duration_ns IS NOT NULL
   ORDER BY created_at DESC LIMIT 5;
  ```
- [x] Drive Ollama traffic and confirm `total_duration_ns` reflects proxy round-trip (close to but slightly higher than the previous server-internal value for loopback).
- [x] Existing tests still pass — no regressions to the existing Ollama duration-capture test in `proxy_test.go`.