### PR TITLE
🔧 fix: (sessions) classify tool_use stop_reason as completed (PCC-560)

### DIFF
--- a/api/v1_handlers.go
+++ b/api/v1_handlers.go
@@ -108,11 +108,13 @@ type Turn struct {
 //     decision since it changes the visible semantic.
 //   - CompletedCount uses leaf-status-only classification: an assistant leaf
 //     with a terminal stop_reason ("stop", "end_turn", "end-turn", "eos").
-//     This is an approximation of pkg/sessions.DetermineStatus, which also
-//     considers tool errors and git activity from the full chain. Sessions
-//     where the agent shipped work (e.g. `git commit`) but the leaf is not
-//     itself terminal will undercount here. PCC-515 tracks the durable
-//     fix (denormalize derived_status on Put + backfill).
+//     This is a narrower set than pkg/sessions.DetermineStatus accepts:
+//     that classifier also treats "tool_use" / "tool_use_response" as
+//     terminal and considers tool errors and git activity from the full
+//     chain. Sessions terminating on a tool request, or where the agent
+//     shipped work (e.g. `git commit`) without a terminal leaf stop_reason,
+//     will undercount here. PCC-515 tracks the durable fix (denormalize
+//     derived_status on Put + backfill).
 type StatsResponse struct {
 	SessionCount    int     `json:"session_count"`
 	TurnCount       int     `json:"turn_count"`

--- a/pkg/sessions/status.go
+++ b/pkg/sessions/status.go
@@ -13,8 +13,13 @@ import (
 //  1. Any tool_result error in the chain → StatusFailed
 //  2. Any git commit/push in the chain → StatusCompleted (strong done signal)
 //  3. Non-assistant leaf → StatusAbandoned
-//  4. Assistant leaf with a known-terminal stop_reason → StatusCompleted
-//  5. Assistant leaf with a known-failing stop_reason → StatusFailed
+//  4. Assistant leaf with a known-terminal stop_reason → StatusCompleted.
+//     `tool_use` / `tool_use_response` count as terminal: a subagent
+//     dispatch or parallel-tool side-conversation ends when the model
+//     emits a tool request, which is the designed terminus, not a
+//     failure to respond.
+//  5. Assistant leaf with a known-failing stop_reason (the model could
+//     not produce a complete response — truncation, refusal) → StatusFailed
 //  6. Empty or otherwise unrecognised stop_reason → StatusUnknown
 func DetermineStatus(leaf *merkle.Node, hasToolError, hasGitActivity bool) string {
 	if leaf == nil {
@@ -34,9 +39,9 @@ func DetermineStatus(leaf *merkle.Node, hasToolError, hasGitActivity bool) strin
 
 	reason := strings.ToLower(strings.TrimSpace(leaf.StopReason))
 	switch reason {
-	case "stop", "end_turn", "end-turn", "eos":
+	case "stop", "end_turn", "end-turn", "eos", "tool_use", "tool_use_response":
 		return StatusCompleted
-	case "length", "max_tokens", "content_filter", "tool_use", "tool_use_response":
+	case "length", "max_tokens", "content_filter":
 		return StatusFailed
 	case "":
 		return StatusUnknown

--- a/pkg/sessions/summary_test.go
+++ b/pkg/sessions/summary_test.go
@@ -181,15 +181,22 @@ var _ = Describe("DetermineStatus", func() {
 	})
 
 	It("maps stop reasons to expected statuses", func() {
+		// tool_use / tool_use_response are the designed terminus of a
+		// subagent or parallel-tool side-conversation — the model
+		// emitted a tool request, which is the contract. length /
+		// content_filter are real model-side failures (truncation,
+		// refusal).
 		cases := map[string]string{
-			"stop":            sessions.StatusCompleted,
-			"end_turn":        sessions.StatusCompleted,
-			"length":          sessions.StatusFailed,
-			"content_filter":  sessions.StatusFailed,
-			"tool_use":        sessions.StatusFailed,
-			"some_error_code": sessions.StatusFailed,
-			"weird_thing":     sessions.StatusUnknown,
-			"":                sessions.StatusUnknown,
+			"stop":              sessions.StatusCompleted,
+			"end_turn":          sessions.StatusCompleted,
+			"tool_use":          sessions.StatusCompleted,
+			"tool_use_response": sessions.StatusCompleted,
+			"length":            sessions.StatusFailed,
+			"max_tokens":        sessions.StatusFailed,
+			"content_filter":    sessions.StatusFailed,
+			"some_error_code":   sessions.StatusFailed,
+			"weird_thing":       sessions.StatusUnknown,
+			"":                  sessions.StatusUnknown,
 		}
 		for reason, want := range cases {
 			leaf := &merkle.Node{Bucket: merkle.Bucket{Role: "assistant"}, StopReason: reason}


### PR DESCRIPTION
## Summary

- `pkg/sessions.DetermineStatus` mapped the `tool_use` and `tool_use_response` assistant stop_reasons to `StatusFailed`. Those reasons are the designed terminus of subagent-dispatch and parallel-tool side-conversations — the model returned the requested tool call, which is the contract — so short one- or two-turn inference sessions showed as failed/abandoned when they had actually succeeded.
- Move both reasons to the `StatusCompleted` arm next to `stop` / `end_turn` / `eos`. `length` / `max_tokens` / `content_filter` remain the only stop_reason-driven failures.
- Table-test in `summary_test.go` updated to match, including the previously-missing `max_tokens` case.

## Out of scope

The `/v1/stats.completed_count` SQL classifier in `api/v1_handlers.go` carries the same enum subset and is technically also affected, but PCC-515 already owns the durable chain-aware path for that endpoint.

## Test plan

- [x] `gofmt -l pkg/sessions/` clean
- [x] `go vet ./pkg/sessions/...` clean
- [x] `go test ./pkg/sessions/...` passes (table-test covers all eight stop_reason cases)
- [ ] Re-render a short inference session in the console / paper cloud and confirm it shows `completed` instead of `abandoned`

Resolves PCC-560