### PR TITLE
🔧 fix: (merkle) keep one chain across mid-session harness drift (PCC-562)

### DIFF
--- a/pkg/merkle/node.go
+++ b/pkg/merkle/node.go
@@ -78,13 +78,44 @@ func (n *Node) computeHash() string {
 		parent = *n.ParentHash
 	}
 
-	// Marshal to JSON using an inline struct for hash computation
+	// Marshal to JSON using an inline struct for hash computation.
+	//
+	// The hash is computed over a projection of the bucket, not the
+	// bucket itself, so that "the same logical conversation turn"
+	// hashes the same across the kinds of drift agent harnesses
+	// introduce between requests in a single conversation. Concretely:
+	//
+	//   * Content text inside <system-reminder>, <command-*>, and
+	//     <local-command-*> spans is stripped (the harness rotates
+	//     this preamble — clock ticks, skills load, MCP inventory
+	//     shifts).
+	//   * Blank-line whitespace drift in the surviving prose is
+	//     normalized (the harness re-serializes user text and
+	//     occasionally inserts a stray newline).
+	//   * Routing metadata — Model, Provider, AgentName — is dropped
+	//     entirely. A single conversation may legitimately fan a
+	//     pre-flight call to Haiku and the main work to Opus; that is
+	//     a routing decision, not a new turn.
+	//
+	// The raw n.Bucket is left untouched so storage / display / labels
+	// / search still see exactly what the model received, including
+	// model identity. See PCC-562.
+	type hashableBucket struct {
+		Type    string             `json:"type"`
+		Role    string             `json:"role"`
+		Content []llm.ContentBlock `json:"content"`
+	}
+
 	data, err := json.Marshal(struct {
-		Parent  string `json:"parent"`
-		Content Bucket `json:"content"`
+		Parent  string         `json:"parent"`
+		Content hashableBucket `json:"content"`
 	}{
-		Parent:  parent,
-		Content: n.Bucket,
+		Parent: parent,
+		Content: hashableBucket{
+			Type:    n.Bucket.Type,
+			Role:    n.Bucket.Role,
+			Content: ProjectContent(n.Bucket.Content),
+		},
 	})
 	if err != nil {
 		panic("failed to marshal hash input: " + err.Error())

--- a/pkg/merkle/node.go
+++ b/pkg/merkle/node.go
@@ -92,6 +92,11 @@ func (n *Node) computeHash() string {
 	//   * Blank-line whitespace drift in the surviving prose is
 	//     normalized (the harness re-serializes user text and
 	//     occasionally inserts a stray newline).
+	//   * Zero-valued keys are pruned from tool_use ToolInput so the
+	//     streamed capture (which has Edit's "replace_all": false)
+	//     dedups with the re-sent history (which omits the default).
+	//   * ThinkingSignature is dropped — present on the live stream,
+	//     absent when the harness re-sends the same thinking block.
 	//   * Routing metadata — Model, Provider, AgentName — is dropped
 	//     entirely. A single conversation may legitimately fan a
 	//     pre-flight call to Haiku and the main work to Opus; that is

--- a/pkg/merkle/projection.go
+++ b/pkg/merkle/projection.go
@@ -143,16 +143,16 @@ func stripTaggedSpan(text, tag string) string {
 			return text
 		}
 		rest := text[start:]
-		end := strings.Index(rest, closeTag)
-		if end == -1 {
+		_, after, ok := strings.Cut(rest, closeTag)
+		if !ok {
 			return text[:start]
 		}
-		text = text[:start] + rest[end+len(closeTag):]
+		text = text[:start] + after
 	}
 }
 
 var (
-	trailingLineSpace = regexp.MustCompile(`[ \t]+\n`)
+	trailingLineSpace   = regexp.MustCompile(`[ \t]+\n`)
 	consecutiveNewlines = regexp.MustCompile(`\n{2,}`)
 )
 

--- a/pkg/merkle/projection.go
+++ b/pkg/merkle/projection.go
@@ -65,7 +65,9 @@ func ProjectContent(blocks []llm.ContentBlock) []llm.ContentBlock {
 		if len(b.ToolInput) > 0 {
 			b.ToolInput = pruneZeroValues(b.ToolInput)
 		}
-		b.ThinkingSignature = ""
+		if b.ThinkingSignature != "" {
+			b.ThinkingSignature = ""
+		}
 		out = append(out, b)
 	}
 	return out

--- a/pkg/merkle/projection.go
+++ b/pkg/merkle/projection.go
@@ -39,6 +39,15 @@ var HarnessTags = []string{
 //     the surviving prose cannot fork the chain (see PCC-562's
 //     "57a58 >" case).
 //  3. Drops any block that became empty after stripping.
+//  4. For tool_use blocks, drops zero-valued keys from ToolInput. The
+//     streamed assistant capture sees every key the model emitted
+//     including optional defaults like Edit's "replace_all": false;
+//     when that same turn is re-sent as history the harness strips
+//     those defaults. Without this step the two captures hash to
+//     different nodes and the chain branches.
+//  5. For thinking blocks, drops ThinkingSignature. Anthropic emits
+//     the signature on the live stream but the harness omits it on
+//     re-send; same shape as (4).
 //
 // The input slice and its blocks are not mutated; the returned slice is
 // independent. Bucket.Content itself stays unprojected so display,
@@ -53,9 +62,64 @@ func ProjectContent(blocks []llm.ContentBlock) []llm.ContentBlock {
 			}
 			b.Text = projected
 		}
+		if len(b.ToolInput) > 0 {
+			b.ToolInput = pruneZeroValues(b.ToolInput)
+		}
+		b.ThinkingSignature = ""
 		out = append(out, b)
 	}
 	return out
+}
+
+// pruneZeroValues returns a copy of m with zero-valued entries removed
+// and nested maps recursively pruned. A nested map that becomes empty
+// after pruning is itself dropped. Slices and other complex values are
+// passed through unchanged — extend the recursion if drift surfaces
+// inside them later.
+func pruneZeroValues(m map[string]any) map[string]any {
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		if nested, ok := v.(map[string]any); ok {
+			pruned := pruneZeroValues(nested)
+			if len(pruned) == 0 {
+				continue
+			}
+			out[k] = pruned
+			continue
+		}
+		if isZeroValue(v) {
+			continue
+		}
+		out[k] = v
+	}
+	return out
+}
+
+// isZeroValue reports whether v is the zero value for its JSON kind.
+// JSON numbers decode to float64 through encoding/json, but tool input
+// can also reach us via direct map literals, so int / int64 are covered
+// for completeness.
+func isZeroValue(v any) bool {
+	switch x := v.(type) {
+	case nil:
+		return true
+	case bool:
+		return !x
+	case string:
+		return x == ""
+	case float64:
+		return x == 0
+	case float32:
+		return x == 0
+	case int:
+		return x == 0
+	case int64:
+		return x == 0
+	case []any:
+		return len(x) == 0
+	default:
+		return false
+	}
 }
 
 func stripHarnessTags(text string) string {

--- a/pkg/merkle/projection.go
+++ b/pkg/merkle/projection.go
@@ -1,0 +1,105 @@
+package merkle
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/papercomputeco/tapes/pkg/llm"
+)
+
+// HarnessTags lists the XML-like tags emitted by agent harnesses (e.g.
+// Claude Code) that wrap mutable metadata into user-role content blocks.
+// Text wrapped in these tags drifts between turns of the same
+// conversation — the clock ticks, a skill loads, an MCP inventory
+// changes — yet none of it is part of the user's intent. Letting it
+// participate in the content-addressed hash fractures otherwise
+// continuous conversations into multiple disconnected roots. See
+// PCC-562.
+//
+// Tags are matched verbatim, so "system-reminder" matches
+// <system-reminder>…</system-reminder> but does NOT match
+// <local-command-stdout>; each suffixed variant must be listed
+// explicitly.
+var HarnessTags = []string{
+	"system-reminder",
+	"command-name",
+	"command-message",
+	"command-args",
+	"local-command-stdout",
+	"local-command-stderr",
+	"local-command-caveat",
+}
+
+// ProjectContent returns the projection of content blocks used when
+// computing a node's chain hash. The projection:
+//
+//  1. Strips every <tag>…</tag> span whose tag is in HarnessTags from
+//     each block's Text field.
+//  2. Normalizes whitespace in what remains so blank-line drift inside
+//     the surviving prose cannot fork the chain (see PCC-562's
+//     "57a58 >" case).
+//  3. Drops any block that became empty after stripping.
+//
+// The input slice and its blocks are not mutated; the returned slice is
+// independent. Bucket.Content itself stays unprojected so display,
+// labels, and search continue to see the raw text the model received.
+func ProjectContent(blocks []llm.ContentBlock) []llm.ContentBlock {
+	out := make([]llm.ContentBlock, 0, len(blocks))
+	for _, b := range blocks {
+		if b.Text != "" {
+			projected := normalizeWhitespace(stripHarnessTags(b.Text))
+			if projected == "" {
+				continue
+			}
+			b.Text = projected
+		}
+		out = append(out, b)
+	}
+	return out
+}
+
+func stripHarnessTags(text string) string {
+	for _, tag := range HarnessTags {
+		text = stripTaggedSpan(text, tag)
+	}
+	return text
+}
+
+// stripTaggedSpan removes every <tag>…</tag> span from text. An
+// unterminated open tag is treated as swallowing the rest of the
+// string, matching the behavior of sessions.StripTaggedSection.
+func stripTaggedSpan(text, tag string) string {
+	openTag := "<" + tag + ">"
+	closeTag := "</" + tag + ">"
+	for {
+		start := strings.Index(text, openTag)
+		if start == -1 {
+			return text
+		}
+		rest := text[start:]
+		end := strings.Index(rest, closeTag)
+		if end == -1 {
+			return text[:start]
+		}
+		text = text[:start] + rest[end+len(closeTag):]
+	}
+}
+
+var (
+	trailingLineSpace = regexp.MustCompile(`[ \t]+\n`)
+	consecutiveNewlines = regexp.MustCompile(`\n{2,}`)
+)
+
+// normalizeWhitespace folds away whitespace-only drift so two captures
+// of the same logical prose hash to the same value. CRLF is canonicalized
+// to LF, trailing horizontal whitespace on each line is dropped, runs of
+// two or more newlines collapse to a single newline, and the result is
+// stripped on both ends. The single-newline collapse is what catches the
+// 1-char "blank line inserted around line 58" diff documented in
+// PCC-562.
+func normalizeWhitespace(text string) string {
+	text = strings.ReplaceAll(text, "\r\n", "\n")
+	text = trailingLineSpace.ReplaceAllString(text, "\n")
+	text = consecutiveNewlines.ReplaceAllString(text, "\n")
+	return strings.TrimSpace(text)
+}

--- a/pkg/merkle/projection_test.go
+++ b/pkg/merkle/projection_test.go
@@ -83,7 +83,7 @@ var _ = Describe("ProjectContent", func() {
 			To(Equal(merkle.ProjectContent([]llm.ContentBlock{{Type: "text", Text: drift}})))
 	})
 
-	It("preserves non-text blocks verbatim", func() {
+	It("preserves a tool_use block when nothing in its input is a zero value", func() {
 		blocks := []llm.ContentBlock{
 			{Type: "tool_use", ToolName: "Bash", ToolUseID: "abc", ToolInput: map[string]any{"cmd": "ls"}},
 			{Type: "image", ImageURL: "https://example.com/x.png", MediaType: "image/png"},
@@ -94,13 +94,101 @@ var _ = Describe("ProjectContent", func() {
 		Expect(projected).To(Equal(blocks))
 	})
 
+	It("drops zero-valued keys from tool_use.ToolInput (Edit replace_all=false)", func() {
+		// Mirrors the live capture pair (7067d494 vs b8d68493): same
+		// tool_use_id, same file_path / new_string / old_string, the
+		// streamed assistant turn includes "replace_all": false while
+		// the re-sent history omits it.
+		streamed := []llm.ContentBlock{{
+			Type:      "tool_use",
+			ToolUseID: "toolu_01abc",
+			ToolName:  "Edit",
+			ToolInput: map[string]any{
+				"file_path":   "/tmp/x.md",
+				"new_string":  "next",
+				"old_string":  "prev",
+				"replace_all": false,
+			},
+		}}
+		resent := []llm.ContentBlock{{
+			Type:      "tool_use",
+			ToolUseID: "toolu_01abc",
+			ToolName:  "Edit",
+			ToolInput: map[string]any{
+				"file_path":  "/tmp/x.md",
+				"new_string": "next",
+				"old_string": "prev",
+			},
+		}}
+
+		Expect(merkle.ProjectContent(streamed)).To(Equal(merkle.ProjectContent(resent)))
+	})
+
+	It("keeps tool_input values that are not the zero value", func() {
+		blocks := []llm.ContentBlock{{
+			Type:      "tool_use",
+			ToolUseID: "toolu_keep",
+			ToolName:  "Edit",
+			ToolInput: map[string]any{
+				"file_path":   "/tmp/y.md",
+				"replace_all": true,
+				"count":       int64(3),
+				"tags":        []any{"a", "b"},
+				"nested":      map[string]any{"on": true, "off": false},
+			},
+		}}
+
+		projected := merkle.ProjectContent(blocks)
+
+		Expect(projected).To(HaveLen(1))
+		Expect(projected[0].ToolInput).To(Equal(map[string]any{
+			"file_path":   "/tmp/y.md",
+			"replace_all": true,
+			"count":       int64(3),
+			"tags":        []any{"a", "b"},
+			"nested":      map[string]any{"on": true},
+		}))
+	})
+
+	It("drops the thinking signature so streamed and re-sent thinking blocks dedup", func() {
+		streamed := []llm.ContentBlock{{
+			Type:              "thinking",
+			Thinking:          "let me check…",
+			ThinkingSignature: "EosCCmMIDRgC…",
+		}}
+		resent := []llm.ContentBlock{{
+			Type:     "thinking",
+			Thinking: "let me check…",
+		}}
+
+		Expect(merkle.ProjectContent(streamed)).To(Equal(merkle.ProjectContent(resent)))
+	})
+
+	It("preserves an image block verbatim", func() {
+		blocks := []llm.ContentBlock{{Type: "image", ImageURL: "https://example.com/x.png", MediaType: "image/png"}}
+
+		Expect(merkle.ProjectContent(blocks)).To(Equal(blocks))
+	})
+
 	It("does not mutate the input slice or its blocks", func() {
 		input := []llm.ContentBlock{
 			{Type: "text", Text: "<system-reminder>drop</system-reminder>keep"},
+			{
+				Type:              "thinking",
+				Thinking:          "x",
+				ThinkingSignature: "sig",
+			},
+			{
+				Type:      "tool_use",
+				ToolName:  "Edit",
+				ToolInput: map[string]any{"replace_all": false, "p": "/x"},
+			},
 		}
 		_ = merkle.ProjectContent(input)
 
 		Expect(input[0].Text).To(Equal("<system-reminder>drop</system-reminder>keep"))
+		Expect(input[1].ThinkingSignature).To(Equal("sig"))
+		Expect(input[2].ToolInput).To(HaveKey("replace_all"))
 	})
 
 	It("swallows an unterminated harness tag to end-of-text", func() {

--- a/pkg/merkle/projection_test.go
+++ b/pkg/merkle/projection_test.go
@@ -83,6 +83,25 @@ var _ = Describe("ProjectContent", func() {
 			To(Equal(merkle.ProjectContent([]llm.ContentBlock{{Type: "text", Text: drift}})))
 	})
 
+	It("intentionally hashes two prose turns identically when they differ only by a blank-line run", func() {
+		// PCC-562 accepted-tradeoff guard. The harness occasionally
+		// re-serializes a turn and inserts or removes a blank line
+		// (see the "57a58 >" case in the ticket evidence). To survive
+		// that drift we collapse runs of newlines, which means a
+		// future reader of two captures whose ONLY difference is a
+		// blank-line count will see them dedup. This is intended.
+		// A real user authoring two genuinely-different turns that
+		// differ only by whitespace is implausible enough that we
+		// accept the tradeoff. If this assertion ever needs to flip,
+		// PCC-562's guarantees go with it — tighten the regex
+		// somewhere else, not here.
+		paragraphed := "Explain A\n\nExplain B"
+		flattened := "Explain A\nExplain B"
+
+		Expect(merkle.ProjectContent([]llm.ContentBlock{{Type: "text", Text: paragraphed}})).
+			To(Equal(merkle.ProjectContent([]llm.ContentBlock{{Type: "text", Text: flattened}})))
+	})
+
 	It("preserves a tool_use block when nothing in its input is a zero value", func() {
 		blocks := []llm.ContentBlock{
 			{Type: "tool_use", ToolName: "Bash", ToolUseID: "abc", ToolInput: map[string]any{"cmd": "ls"}},

--- a/pkg/merkle/projection_test.go
+++ b/pkg/merkle/projection_test.go
@@ -1,0 +1,198 @@
+package merkle_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/papercomputeco/tapes/pkg/llm"
+	"github.com/papercomputeco/tapes/pkg/merkle"
+)
+
+// userBucket builds the kind of user-role bucket the worker pool
+// hashes when storing a turn — identical shape for every test below so
+// the only inputs that vary across hashes are the content blocks.
+func userBucket(content []llm.ContentBlock) merkle.Bucket {
+	return merkle.Bucket{
+		Type:      "message",
+		Role:      "user",
+		Content:   content,
+		Model:     "claude-opus-4-7",
+		Provider:  "anthropic",
+		AgentName: "claude",
+	}
+}
+
+var _ = Describe("ProjectContent", func() {
+	It("strips a <system-reminder> span and leaves the prose intact", func() {
+		blocks := []llm.ContentBlock{{
+			Type: "text",
+			Text: "<system-reminder>\n# currentDate\nToday's date is 2026-05-20.\n</system-reminder>\n\nHey Claude!",
+		}}
+
+		projected := merkle.ProjectContent(blocks)
+
+		Expect(projected).To(HaveLen(1))
+		Expect(projected[0].Text).To(Equal("Hey Claude!"))
+	})
+
+	It("drops a block that is entirely harness content", func() {
+		blocks := []llm.ContentBlock{
+			{Type: "text", Text: "<system-reminder>MCP inventory</system-reminder>"},
+			{Type: "text", Text: "<system-reminder>skill catalogue</system-reminder>"},
+			{Type: "text", Text: "Hey Claude!"},
+		}
+
+		projected := merkle.ProjectContent(blocks)
+
+		Expect(projected).To(HaveLen(1))
+		Expect(projected[0].Text).To(Equal("Hey Claude!"))
+	})
+
+	It("strips every harness tag the spec lists", func() {
+		// Each tag wraps a marker so we can prove the strip happened.
+		tags := []string{
+			"system-reminder",
+			"command-name", "command-message", "command-args",
+			"local-command-stdout", "local-command-stderr", "local-command-caveat",
+		}
+		var body string
+		for _, t := range tags {
+			body += "<" + t + ">drop-" + t + "</" + t + ">\n"
+		}
+		body += "keep"
+
+		projected := merkle.ProjectContent([]llm.ContentBlock{{Type: "text", Text: body}})
+
+		Expect(projected).To(HaveLen(1))
+		Expect(projected[0].Text).To(Equal("keep"))
+	})
+
+	It("collapses a blank line inserted between paragraphs (PCC-562 57a58 case)", func() {
+		original := "line A\nline B\nline C"
+		drift := "line A\nline B\n\nline C"
+
+		Expect(merkle.ProjectContent([]llm.ContentBlock{{Type: "text", Text: original}})).
+			To(Equal(merkle.ProjectContent([]llm.ContentBlock{{Type: "text", Text: drift}})))
+	})
+
+	It("ignores trailing whitespace and CRLF drift", func() {
+		original := "line A\nline B"
+		drift := "line A   \r\nline B  "
+
+		Expect(merkle.ProjectContent([]llm.ContentBlock{{Type: "text", Text: original}})).
+			To(Equal(merkle.ProjectContent([]llm.ContentBlock{{Type: "text", Text: drift}})))
+	})
+
+	It("preserves non-text blocks verbatim", func() {
+		blocks := []llm.ContentBlock{
+			{Type: "tool_use", ToolName: "Bash", ToolUseID: "abc", ToolInput: map[string]any{"cmd": "ls"}},
+			{Type: "image", ImageURL: "https://example.com/x.png", MediaType: "image/png"},
+		}
+
+		projected := merkle.ProjectContent(blocks)
+
+		Expect(projected).To(Equal(blocks))
+	})
+
+	It("does not mutate the input slice or its blocks", func() {
+		input := []llm.ContentBlock{
+			{Type: "text", Text: "<system-reminder>drop</system-reminder>keep"},
+		}
+		_ = merkle.ProjectContent(input)
+
+		Expect(input[0].Text).To(Equal("<system-reminder>drop</system-reminder>keep"))
+	})
+
+	It("swallows an unterminated harness tag to end-of-text", func() {
+		blocks := []llm.ContentBlock{{
+			Type: "text",
+			Text: "keep this\n<system-reminder>and then drift never closes",
+		}}
+
+		projected := merkle.ProjectContent(blocks)
+
+		Expect(projected).To(HaveLen(1))
+		Expect(projected[0].Text).To(Equal("keep this"))
+	})
+})
+
+var _ = Describe("Node.Hash with harness drift", func() {
+	prose := "Hey Claude! I'd like to exercise-claude-harness-basic, as defined in our skills directory."
+
+	It("hashes a pure-prose user turn the same as a drift-fork of that same turn (PCC-562)", func() {
+		// Matches the actual capture pair observed in the dev corpus:
+		// one root has a single prose text block; the drift fork has the
+		// same prose preceded by three <system-reminder> blocks.
+		named := merkle.NewNode(userBucket([]llm.ContentBlock{
+			{Type: "text", Text: prose},
+		}), nil)
+
+		drifted := merkle.NewNode(userBucket([]llm.ContentBlock{
+			{Type: "text", Text: "<system-reminder>\n# MCP Server Instructions\n…\n</system-reminder>"},
+			{Type: "text", Text: "<system-reminder>\nThe following skills are available…\n</system-reminder>"},
+			{Type: "text", Text: "<system-reminder>\nAs you answer the user's questions…\n</system-reminder>"},
+			{Type: "text", Text: prose},
+		}), nil)
+
+		Expect(named.Hash).To(Equal(drifted.Hash))
+	})
+
+	It("hashes the same when a stray blank line drifts inside the prose", func() {
+		original := "Para 1\nPara 2\nPara 3"
+		drifted := "Para 1\nPara 2\n\nPara 3"
+
+		a := merkle.NewNode(userBucket([]llm.ContentBlock{{Type: "text", Text: original}}), nil)
+		b := merkle.NewNode(userBucket([]llm.ContentBlock{{Type: "text", Text: drifted}}), nil)
+
+		Expect(a.Hash).To(Equal(b.Hash))
+	})
+
+	It("still produces a different hash when real user content changes", func() {
+		a := merkle.NewNode(userBucket([]llm.ContentBlock{{Type: "text", Text: "Hello world"}}), nil)
+		b := merkle.NewNode(userBucket([]llm.ContentBlock{{Type: "text", Text: "Hello there"}}), nil)
+
+		Expect(a.Hash).NotTo(Equal(b.Hash))
+	})
+
+	It("still distinguishes nodes whose parents differ", func() {
+		root := merkle.NewNode(userBucket([]llm.ContentBlock{{Type: "text", Text: "root"}}), nil)
+		other := merkle.NewNode(userBucket([]llm.ContentBlock{{Type: "text", Text: "other"}}), nil)
+
+		child1 := merkle.NewNode(userBucket([]llm.ContentBlock{{Type: "text", Text: "same"}}), root)
+		child2 := merkle.NewNode(userBucket([]llm.ContentBlock{{Type: "text", Text: "same"}}), other)
+
+		Expect(child1.Hash).NotTo(Equal(child2.Hash))
+	})
+
+	It("hashes the same when the routing model changes (Claude Code haiku→opus, PCC-562)", func() {
+		// Same observed in the live trace: the named root captured with
+		// model=claude-haiku-4-5-* must dedup against the same content
+		// captured later with model=claude-opus-4-7. Provider and
+		// AgentName are also routing-only.
+		content := []llm.ContentBlock{{Type: "text", Text: "Hey Claude!"}}
+
+		haiku := merkle.NewNode(merkle.Bucket{
+			Type: "message", Role: "user", Content: content,
+			Model: "claude-haiku-4-5-20251001", Provider: "anthropic", AgentName: "claude",
+		}, nil)
+		opus := merkle.NewNode(merkle.Bucket{
+			Type: "message", Role: "user", Content: content,
+			Model: "claude-opus-4-7", Provider: "anthropic", AgentName: "claude",
+		}, nil)
+		acrossProviders := merkle.NewNode(merkle.Bucket{
+			Type: "message", Role: "user", Content: content,
+			Model: "gpt-5", Provider: "openai", AgentName: "codex",
+		}, nil)
+
+		Expect(haiku.Hash).To(Equal(opus.Hash))
+		Expect(haiku.Hash).To(Equal(acrossProviders.Hash))
+	})
+
+	It("hashes role independently — user 'Hi' and assistant 'Hi' must not collide", func() {
+		content := []llm.ContentBlock{{Type: "text", Text: "Hi"}}
+		user := merkle.NewNode(merkle.Bucket{Type: "message", Role: "user", Content: content}, nil)
+		assistant := merkle.NewNode(merkle.Bucket{Type: "message", Role: "assistant", Content: content}, nil)
+
+		Expect(user.Hash).NotTo(Equal(assistant.Hash))
+	})
+})

--- a/pkg/merkle/projection_test.go
+++ b/pkg/merkle/projection_test.go
@@ -1,6 +1,8 @@
 package merkle_test
 
 import (
+	"strings"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -55,13 +57,13 @@ var _ = Describe("ProjectContent", func() {
 			"command-name", "command-message", "command-args",
 			"local-command-stdout", "local-command-stderr", "local-command-caveat",
 		}
-		var body string
+		var body strings.Builder
 		for _, t := range tags {
-			body += "<" + t + ">drop-" + t + "</" + t + ">\n"
+			body.WriteString("<" + t + ">drop-" + t + "</" + t + ">\n")
 		}
-		body += "keep"
+		body.WriteString("keep")
 
-		projected := merkle.ProjectContent([]llm.ContentBlock{{Type: "text", Text: body}})
+		projected := merkle.ProjectContent([]llm.ContentBlock{{Type: "text", Text: body.String()}})
 
 		Expect(projected).To(HaveLen(1))
 		Expect(projected[0].Text).To(Equal("keep"))


### PR DESCRIPTION
## Summary

[PCC-562](https://linear.app/paper-compute-co/issue/PCC-562). A single Claude Code conversation was fracturing into multiple disconnected roots in tapes because the proxy's content hash kept including parts of the bucket that drift between turns of the same conversation. Two commits, two families of drift; both addressed by projecting drift-prone fields out of the chain hash without touching what's stored.

Related to PCC-562

### Commit 1 — system-reminder + model drift

Claude Code prepends rotating `<system-reminder>` blocks (date, skills, MCP inventory) to every user turn after the first, and routes one conversation across multiple models (haiku pre-flight, then opus). Both changed the hashed content of "the same" prior turn, so the chain couldn't link and one conversation fractured into multiple roots.

**Fix:** strip harness-tag spans (`<system-reminder>`, `<command-*>`, `<local-command-*>`), normalize whitespace in the surviving prose, and drop `Model`/`Provider`/`AgentName` from the chain hash.

### Commit 2 — tool_use defaults + thinking signatures

Same fracture pattern, two more surfaces. The streamed assistant turn captures optional zero defaults (e.g. Edit's `"replace_all": false`) that the harness drops on re-send, and Anthropic's `thinking_signature` is emitted on the live stream but omitted on re-send. Both forked the chain mid-conversation.

**Fix:** prune zero-valued keys from `tool_use.ToolInput` (recursive for nested maps) and drop `ThinkingSignature` from the hash.

### Projection strategy

The raw `Bucket` is still stored verbatim — display, labels, search, and audit see exactly what the model received. Only `computeHash` (`pkg/merkle/node.go`) runs the bucket through `ProjectContent` (`pkg/merkle/projection.go`) and a `hashableBucket` subset that strips drift-prone, non-user-authored fields before SHA-256. Same content (post-projection) → same hash → chain links.

### Result

Same captured Claude Code session, reproduced across iterations of the fix:

| Stage | Nodes | Roots | Longest chain | Branch points | Leaves |
|---|---|---|---|---|---|
| Before (PCC-562 evidence)            | 51 | 3 | 42 | — | — |
| After commit 1                       | 53 | 2 | 44 | 5 | 8 |
| After commit 2                       | 49 | 2 | 44 | 2 | 4 |

The two remaining roots are: the conversation itself, and an unrelated `quota` count_tokens ping the harness fires as a separate API call. The two remaining branch points are legitimate (haiku topic-summary vs the real opus response; two genuinely different user inputs at one point in the chain) — not drift-driven sibling duplicates.

## Test plan

- [ ] `go test ./pkg/merkle/...` passes
- [ ] `go test ./pkg/capture/... ./pkg/sessions/... ./pkg/backfill/... ./pkg/storage/inmemory/... ./pkg/publisher/... ./proxy/...` passes
- [ ] Local Postgres truncate → run a Claude Code session → verify one connected root for the conversation, one root for the quota ping
- [ ] Walk `parent_hash` from the deepest leaf to the original `"Hey Claude!"` user turn without breaking

🤖 Generated with [Claude Code](https://claude.com/claude-code)