### PR TITLE
✨ feat: add OpenAI embedding support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,15 +49,33 @@ Install `tapes`:
 curl -fsSL https://download.tapes.dev/install | bash
 ```
 
-Run Ollama and the `tapes` services. By default, `tapes` targets embeddings on Ollama 
-with the `embeddinggema:latest` model - pull this model with `ollama pull embeddinggema`:
+Run the `tapes` services with an embedding provider. Embeddings power `tapes search`;
+choose either local Ollama or OpenAI.
+
+For local embeddings, run Ollama and pull the default `embeddinggemma` model:
 
 ```bash
+ollama pull embeddinggemma
 ollama serve
 ```
+
+Then start Tapes:
+
 ```bash
 tapes serve
 ```
+
+For OpenAI embeddings, store an API key and switch the embedding provider:
+
+```bash
+tapes auth openai
+tapes config set embedding.provider openai
+tapes serve
+```
+
+You can also provide the key with `OPENAI_API_KEY` instead of `tapes auth openai`.
+When OpenAI is selected without a key, Tapes fails at startup with an authentication
+configuration error from the OpenAI embedder.
 
 Start a chat session:
 

--- a/cmd/tapes/init/init_test.go
+++ b/cmd/tapes/init/init_test.go
@@ -138,6 +138,10 @@ var _ = Describe("Init command execution", func() {
 			Expect(cfg.Proxy.Upstream).To(Equal("https://api.openai.com"))
 			Expect(cfg.Proxy.Listen).To(Equal(":8080"))
 			Expect(cfg.API.Listen).To(Equal(":8081"))
+			Expect(cfg.Embedding.Provider).To(Equal("openai"))
+			Expect(cfg.Embedding.Target).To(Equal("https://api.openai.com"))
+			Expect(cfg.Embedding.Model).To(Equal("text-embedding-3-small"))
+			Expect(cfg.Embedding.Dimensions).To(Equal(uint(1536)))
 		})
 
 		It("creates config.toml with anthropic preset", func() {
@@ -166,7 +170,7 @@ var _ = Describe("Init command execution", func() {
 			Expect(cfg.Proxy.Upstream).To(Equal("http://localhost:11434"))
 			Expect(cfg.Embedding.Provider).To(Equal("ollama"))
 			Expect(cfg.Embedding.Target).To(Equal("http://localhost:11434"))
-			Expect(cfg.Embedding.Model).To(Equal("nomic-embed-text"))
+			Expect(cfg.Embedding.Model).To(Equal("embeddinggemma"))
 			Expect(cfg.Embedding.Dimensions).To(Equal(uint(768)))
 		})
 

--- a/cmd/tapes/serve/api/api.go
+++ b/cmd/tapes/serve/api/api.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/papercomputeco/tapes/api"
 	"github.com/papercomputeco/tapes/pkg/config"
+	"github.com/papercomputeco/tapes/pkg/credentials"
 	embeddingutils "github.com/papercomputeco/tapes/pkg/embeddings/utils"
 	"github.com/papercomputeco/tapes/pkg/logger"
 	"github.com/papercomputeco/tapes/pkg/storage/postgres"
@@ -31,6 +32,7 @@ type apiCommander struct {
 	embeddingTarget     string
 	embeddingModel      string
 	embeddingDimensions uint
+	embeddingAPIKey     string
 
 	logger *slog.Logger
 }
@@ -82,10 +84,26 @@ func NewAPICmd() *cobra.Command {
 			cmder.webUI = v.GetBool("api.web_ui")
 			cmder.postgresDSN = v.GetString("storage.postgres_dsn")
 			cmder.vectorStoreTarget = v.GetString("vector_store.target")
-			cmder.embeddingProvider = v.GetString("embedding.provider")
-			cmder.embeddingTarget = v.GetString("embedding.target")
-			cmder.embeddingModel = v.GetString("embedding.model")
-			cmder.embeddingDimensions = v.GetUint("embedding.dimensions")
+			if cmder.vectorStoreTarget == "" && cmder.postgresDSN != "" {
+				cmder.vectorStoreTarget = cmder.postgresDSN
+			}
+			embedding := config.ResolveEmbeddingConfigWithOptions(
+				v.GetString("embedding.provider"),
+				v.GetString("embedding.target"),
+				v.GetString("embedding.model"),
+				v.GetUint("embedding.dimensions"),
+				config.ResolveEmbeddingConfigOptions{
+					DimensionsSet: config.IsRegisteredFlagExplicitlySet(v, cmd, cmder.flags, config.FlagEmbeddingDims),
+				},
+			)
+			cmder.embeddingProvider = embedding.Provider
+			cmder.embeddingTarget = embedding.Target
+			cmder.embeddingModel = embedding.Model
+			cmder.embeddingDimensions = embedding.Dimensions
+			cmder.embeddingAPIKey, err = credentials.APIKeyForProvider(embedding.Provider, configDir)
+			if err != nil {
+				return fmt.Errorf("could not load embedding credentials: %w", err)
+			}
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
@@ -132,6 +150,7 @@ func (c *apiCommander) run() error {
 			TargetURL:    c.embeddingTarget,
 			Model:        c.embeddingModel,
 			Dimensions:   c.embeddingDimensions,
+			APIKey:       c.embeddingAPIKey,
 		})
 		if err != nil {
 			return fmt.Errorf("could not create new embedder: %w", err)

--- a/cmd/tapes/serve/api/api.go
+++ b/cmd/tapes/serve/api/api.go
@@ -10,9 +10,11 @@ import (
 
 	"github.com/papercomputeco/tapes/api"
 	"github.com/papercomputeco/tapes/pkg/config"
+	embeddingutils "github.com/papercomputeco/tapes/pkg/embeddings/utils"
 	"github.com/papercomputeco/tapes/pkg/logger"
 	"github.com/papercomputeco/tapes/pkg/storage/postgres"
 	"github.com/papercomputeco/tapes/pkg/telemetry"
+	"github.com/papercomputeco/tapes/pkg/vector/pgvector"
 )
 
 type apiCommander struct {
@@ -23,6 +25,13 @@ type apiCommander struct {
 	postgresDSN string
 	webUI       bool
 
+	vectorStoreTarget string
+
+	embeddingProvider   string
+	embeddingTarget     string
+	embeddingModel      string
+	embeddingDimensions uint
+
 	logger *slog.Logger
 }
 
@@ -31,6 +40,11 @@ var apiFlags = config.FlagSet{
 	config.FlagAPIListenStandalone: {Name: "listen", Shorthand: "l", ViperKey: "api.listen", Description: "Address for API server to listen on"},
 	config.FlagAPIWebUI:            {Name: "web-ui", ViperKey: "api.web_ui", Description: "Enable the minimal browser UI at /"},
 	config.FlagPostgres:            {Name: "postgres", ViperKey: "storage.postgres_dsn", Description: "PostgreSQL connection string (e.g., postgres://user:pass@host:5432/db)"},
+	config.FlagVectorStoreTgt:      {Name: "vector-store-target", ViperKey: "vector_store.target", Description: "pgvector connection string (defaults to storage.postgres_dsn when unset)"},
+	config.FlagEmbeddingProv:       {Name: "embedding-provider", ViperKey: "embedding.provider", Description: "Embedding provider type (e.g., ollama, openai)"},
+	config.FlagEmbeddingTgt:        {Name: "embedding-target", ViperKey: "embedding.target", Description: "Embedding provider URL"},
+	config.FlagEmbeddingModel:      {Name: "embedding-model", ViperKey: "embedding.model", Description: "Embedding model name (e.g., text-embedding-3-small)"},
+	config.FlagEmbeddingDims:       {Name: "embedding-dimensions", ViperKey: "embedding.dimensions", Description: "Embedding dimensionality"},
 }
 
 const apiLongDesc string = `Run the Tapes API server for inspecting, managing, and query agent sessions.`
@@ -57,11 +71,21 @@ func NewAPICmd() *cobra.Command {
 				config.FlagAPIListenStandalone,
 				config.FlagAPIWebUI,
 				config.FlagPostgres,
+				config.FlagVectorStoreTgt,
+				config.FlagEmbeddingProv,
+				config.FlagEmbeddingTgt,
+				config.FlagEmbeddingModel,
+				config.FlagEmbeddingDims,
 			})
 
 			cmder.listen = v.GetString("api.listen")
 			cmder.webUI = v.GetBool("api.web_ui")
 			cmder.postgresDSN = v.GetString("storage.postgres_dsn")
+			cmder.vectorStoreTarget = v.GetString("vector_store.target")
+			cmder.embeddingProvider = v.GetString("embedding.provider")
+			cmder.embeddingTarget = v.GetString("embedding.target")
+			cmder.embeddingModel = v.GetString("embedding.model")
+			cmder.embeddingDimensions = v.GetUint("embedding.dimensions")
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
@@ -79,6 +103,11 @@ func NewAPICmd() *cobra.Command {
 	config.AddStringFlag(cmd, cmder.flags, config.FlagAPIListenStandalone, &cmder.listen)
 	config.AddBoolFlag(cmd, cmder.flags, config.FlagAPIWebUI, &cmder.webUI)
 	config.AddStringFlag(cmd, cmder.flags, config.FlagPostgres, &cmder.postgresDSN)
+	config.AddStringFlag(cmd, cmder.flags, config.FlagVectorStoreTgt, &cmder.vectorStoreTarget)
+	config.AddStringFlag(cmd, cmder.flags, config.FlagEmbeddingProv, &cmder.embeddingProvider)
+	config.AddStringFlag(cmd, cmder.flags, config.FlagEmbeddingTgt, &cmder.embeddingTarget)
+	config.AddStringFlag(cmd, cmder.flags, config.FlagEmbeddingModel, &cmder.embeddingModel)
+	config.AddUintFlag(cmd, cmder.flags, config.FlagEmbeddingDims, &cmder.embeddingDimensions)
 
 	return cmd
 }
@@ -92,12 +121,41 @@ func (c *apiCommander) run() error {
 	}
 	defer driver.Close()
 
-	config := api.Config{
+	apiConfig := api.Config{
 		ListenAddr:  c.listen,
 		EnableWebUI: c.webUI,
 	}
 
-	server, err := api.NewServer(config, driver, c.logger)
+	if c.vectorStoreTarget != "" {
+		apiConfig.Embedder, err = embeddingutils.NewEmbedder(&embeddingutils.NewEmbedderOpts{
+			ProviderType: c.embeddingProvider,
+			TargetURL:    c.embeddingTarget,
+			Model:        c.embeddingModel,
+			Dimensions:   c.embeddingDimensions,
+		})
+		if err != nil {
+			return fmt.Errorf("could not create new embedder: %w", err)
+		}
+		defer apiConfig.Embedder.Close()
+
+		apiConfig.VectorDriver, err = pgvector.NewDriver(context.Background(), &pgvector.Config{
+			ConnString: c.vectorStoreTarget,
+			Dimensions: c.embeddingDimensions,
+		}, c.logger)
+		if err != nil {
+			return fmt.Errorf("could not create new vector driver: %w", err)
+		}
+		defer apiConfig.VectorDriver.Close()
+
+		c.logger.Info("vector search enabled",
+			"vector_store_target", c.vectorStoreTarget,
+			"embedding_provider", c.embeddingProvider,
+			"embedding_target", c.embeddingTarget,
+			"embedding_model", c.embeddingModel,
+		)
+	}
+
+	server, err := api.NewServer(apiConfig, driver, c.logger)
 	if err != nil {
 		return fmt.Errorf("could not build new api server: %w", err)
 	}

--- a/cmd/tapes/serve/ingest/ingest.go
+++ b/cmd/tapes/serve/ingest/ingest.go
@@ -188,6 +188,7 @@ func (c *ingestCommander) run() error {
 			ProviderType: c.embeddingProvider,
 			TargetURL:    c.embeddingTarget,
 			Model:        c.embeddingModel,
+			Dimensions:   c.embeddingDimensions,
 		})
 		if err != nil {
 			return fmt.Errorf("could not create new embedder: %w", err)

--- a/cmd/tapes/serve/ingest/ingest.go
+++ b/cmd/tapes/serve/ingest/ingest.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/papercomputeco/tapes/ingest"
 	"github.com/papercomputeco/tapes/pkg/config"
+	"github.com/papercomputeco/tapes/pkg/credentials"
 	embeddingutils "github.com/papercomputeco/tapes/pkg/embeddings/utils"
 	"github.com/papercomputeco/tapes/pkg/git"
 	"github.com/papercomputeco/tapes/pkg/logger"
@@ -36,6 +37,7 @@ type ingestCommander struct {
 	embeddingTarget     string
 	embeddingModel      string
 	embeddingDimensions uint
+	embeddingAPIKey     string
 
 	kafkaBrokers  string
 	kafkaTopic    string
@@ -52,9 +54,9 @@ var ingestFlags = config.FlagSet{
 	config.FlagPostgres:               {Name: "postgres", ViperKey: "storage.postgres_dsn", Description: "PostgreSQL connection string (e.g., postgres://user:pass@host:5432/db)"},
 	config.FlagProject:                {Name: "project", ViperKey: "proxy.project", Description: "Project name to tag sessions (default: auto-detect from git)"},
 	config.FlagVectorStoreTgt:         {Name: "vector-store-target", ViperKey: "vector_store.target", Description: "pgvector connection string (defaults to storage.postgres_dsn when unset)"},
-	config.FlagEmbeddingProv:          {Name: "embedding-provider", ViperKey: "embedding.provider", Description: "Embedding provider type (e.g., ollama)"},
+	config.FlagEmbeddingProv:          {Name: "embedding-provider", ViperKey: "embedding.provider", Description: "Embedding provider type (e.g., ollama, openai)"},
 	config.FlagEmbeddingTgt:           {Name: "embedding-target", ViperKey: "embedding.target", Description: "Embedding provider URL"},
-	config.FlagEmbeddingModel:         {Name: "embedding-model", ViperKey: "embedding.model", Description: "Embedding model name (e.g., nomic-embed-text)"},
+	config.FlagEmbeddingModel:         {Name: "embedding-model", ViperKey: "embedding.model", Description: "Embedding model name (e.g., embeddinggemma, text-embedding-3-small)"},
 	config.FlagEmbeddingDims:          {Name: "embedding-dimensions", ViperKey: "embedding.dimensions", Description: "Embedding dimensionality"},
 	config.FlagKafkaBrokers:           {Name: "kafka-brokers", ViperKey: "publisher.kafka.brokers", Description: "Comma separated list of broker ip:port pairs"},
 	config.FlagKafkaClientID:          {Name: "kafka-client-id", ViperKey: "publisher.kafka.client_id", Description: "Optional Kafka client.id"},
@@ -110,10 +112,23 @@ func NewIngestCmd() *cobra.Command {
 			cmder.postgresDSN = v.GetString("storage.postgres_dsn")
 			cmder.project = v.GetString("proxy.project")
 			cmder.vectorStoreTarget = v.GetString("vector_store.target")
-			cmder.embeddingProvider = v.GetString("embedding.provider")
-			cmder.embeddingTarget = v.GetString("embedding.target")
-			cmder.embeddingModel = v.GetString("embedding.model")
-			cmder.embeddingDimensions = v.GetUint("embedding.dimensions")
+			embedding := config.ResolveEmbeddingConfigWithOptions(
+				v.GetString("embedding.provider"),
+				v.GetString("embedding.target"),
+				v.GetString("embedding.model"),
+				v.GetUint("embedding.dimensions"),
+				config.ResolveEmbeddingConfigOptions{
+					DimensionsSet: config.IsRegisteredFlagExplicitlySet(v, cmd, cmder.flags, config.FlagEmbeddingDims),
+				},
+			)
+			cmder.embeddingProvider = embedding.Provider
+			cmder.embeddingTarget = embedding.Target
+			cmder.embeddingModel = embedding.Model
+			cmder.embeddingDimensions = embedding.Dimensions
+			cmder.embeddingAPIKey, err = credentials.APIKeyForProvider(embedding.Provider, configDir)
+			if err != nil {
+				return fmt.Errorf("could not load embedding credentials: %w", err)
+			}
 			if cmder.vectorStoreTarget == "" && cmder.postgresDSN != "" {
 				cmder.vectorStoreTarget = cmder.postgresDSN
 			}
@@ -189,6 +204,7 @@ func (c *ingestCommander) run() error {
 			TargetURL:    c.embeddingTarget,
 			Model:        c.embeddingModel,
 			Dimensions:   c.embeddingDimensions,
+			APIKey:       c.embeddingAPIKey,
 		})
 		if err != nil {
 			return fmt.Errorf("could not create new embedder: %w", err)

--- a/cmd/tapes/serve/proxy/proxy.go
+++ b/cmd/tapes/serve/proxy/proxy.go
@@ -197,6 +197,7 @@ func (c *proxyCommander) run() error {
 			ProviderType: c.embeddingProvider,
 			TargetURL:    c.embeddingTarget,
 			Model:        c.embeddingModel,
+			Dimensions:   c.embeddingDimensions,
 		})
 		if err != nil {
 			return fmt.Errorf("creating embedder: %w", err)

--- a/cmd/tapes/serve/proxy/proxy.go
+++ b/cmd/tapes/serve/proxy/proxy.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/papercomputeco/tapes/pkg/config"
+	"github.com/papercomputeco/tapes/pkg/credentials"
 	embeddingutils "github.com/papercomputeco/tapes/pkg/embeddings/utils"
 	"github.com/papercomputeco/tapes/pkg/git"
 	"github.com/papercomputeco/tapes/pkg/logger"
@@ -42,6 +43,7 @@ type proxyCommander struct {
 	embeddingTarget     string
 	embeddingModel      string
 	embeddingDimensions uint
+	embeddingAPIKey     string
 
 	logger *slog.Logger
 }
@@ -56,9 +58,9 @@ var proxyFlags = config.FlagSet{
 	config.FlagPostgres:              {Name: "postgres", ViperKey: "storage.postgres_dsn", Description: "PostgreSQL connection string (e.g., postgres://user:pass@host:5432/db)"},
 	config.FlagProject:               {Name: "project", ViperKey: "proxy.project", Description: "Project name to tag sessions (default: auto-detect from git)"},
 	config.FlagVectorStoreTgt:        {Name: "vector-store-target", ViperKey: "vector_store.target", Description: "pgvector connection string (defaults to storage.postgres_dsn when unset)"},
-	config.FlagEmbeddingProv:         {Name: "embedding-provider", ViperKey: "embedding.provider", Description: "Embedding provider type (e.g., ollama)"},
+	config.FlagEmbeddingProv:         {Name: "embedding-provider", ViperKey: "embedding.provider", Description: "Embedding provider type (e.g., ollama, openai)"},
 	config.FlagEmbeddingTgt:          {Name: "embedding-target", ViperKey: "embedding.target", Description: "Embedding provider URL"},
-	config.FlagEmbeddingModel:        {Name: "embedding-model", ViperKey: "embedding.model", Description: "Embedding model name (e.g., nomic-embed-text)"},
+	config.FlagEmbeddingModel:        {Name: "embedding-model", ViperKey: "embedding.model", Description: "Embedding model name (e.g., embeddinggemma, text-embedding-3-small)"},
 	config.FlagEmbeddingDims:         {Name: "embedding-dimensions", ViperKey: "embedding.dimensions", Description: "Embedding dimensionality"},
 	config.FlagKafkaBrokers:          {Name: "kafka-brokers", ViperKey: "publisher.kafka.brokers", Description: "Comma separated list of broker ip:port pairs"},
 	config.FlagKafkaClientID:         {Name: "kafka-client-id", ViperKey: "publisher.kafka.client_id", Description: "Optional Kafka client.id"},
@@ -113,10 +115,23 @@ func NewProxyCmd() *cobra.Command {
 			cmder.upstream = v.GetString("proxy.upstream")
 			cmder.providerType = v.GetString("proxy.provider")
 			cmder.vectorStoreTarget = v.GetString("vector_store.target")
-			cmder.embeddingProvider = v.GetString("embedding.provider")
-			cmder.embeddingTarget = v.GetString("embedding.target")
-			cmder.embeddingModel = v.GetString("embedding.model")
-			cmder.embeddingDimensions = v.GetUint("embedding.dimensions")
+			embedding := config.ResolveEmbeddingConfigWithOptions(
+				v.GetString("embedding.provider"),
+				v.GetString("embedding.target"),
+				v.GetString("embedding.model"),
+				v.GetUint("embedding.dimensions"),
+				config.ResolveEmbeddingConfigOptions{
+					DimensionsSet: config.IsRegisteredFlagExplicitlySet(v, cmd, cmder.flags, config.FlagEmbeddingDims),
+				},
+			)
+			cmder.embeddingProvider = embedding.Provider
+			cmder.embeddingTarget = embedding.Target
+			cmder.embeddingModel = embedding.Model
+			cmder.embeddingDimensions = embedding.Dimensions
+			cmder.embeddingAPIKey, err = credentials.APIKeyForProvider(embedding.Provider, configDir)
+			if err != nil {
+				return fmt.Errorf("could not load embedding credentials: %w", err)
+			}
 			cmder.project = v.GetString("proxy.project")
 			cmder.postgresDSN = v.GetString("storage.postgres_dsn")
 			if cmder.vectorStoreTarget == "" && cmder.postgresDSN != "" {
@@ -198,6 +213,7 @@ func (c *proxyCommander) run() error {
 			TargetURL:    c.embeddingTarget,
 			Model:        c.embeddingModel,
 			Dimensions:   c.embeddingDimensions,
+			APIKey:       c.embeddingAPIKey,
 		})
 		if err != nil {
 			return fmt.Errorf("creating embedder: %w", err)

--- a/cmd/tapes/serve/serve.go
+++ b/cmd/tapes/serve/serve.go
@@ -198,6 +198,7 @@ func (c *ServeCommander) run() error {
 		ProviderType: c.embeddingProvider,
 		TargetURL:    c.embeddingTarget,
 		Model:        c.embeddingModel,
+		Dimensions:   c.embeddingDimensions,
 	})
 	if err != nil {
 		return fmt.Errorf("creating embedder: %w", err)

--- a/cmd/tapes/serve/serve.go
+++ b/cmd/tapes/serve/serve.go
@@ -17,6 +17,7 @@ import (
 	proxycmder "github.com/papercomputeco/tapes/cmd/tapes/serve/proxy"
 	"github.com/papercomputeco/tapes/ingest"
 	"github.com/papercomputeco/tapes/pkg/config"
+	"github.com/papercomputeco/tapes/pkg/credentials"
 	embeddingutils "github.com/papercomputeco/tapes/pkg/embeddings/utils"
 	"github.com/papercomputeco/tapes/pkg/git"
 	"github.com/papercomputeco/tapes/pkg/logger"
@@ -46,6 +47,7 @@ type ServeCommander struct {
 	embeddingTarget     string
 	embeddingModel      string
 	embeddingDimensions uint
+	embeddingAPIKey     string
 
 	logger *slog.Logger
 }
@@ -61,9 +63,9 @@ var ServeFlags = config.FlagSet{
 	config.FlagPostgres:       {Name: "postgres", ViperKey: "storage.postgres_dsn", Description: "PostgreSQL connection string (e.g., postgres://user:pass@host:5432/db)"},
 	config.FlagProject:        {Name: "project", ViperKey: "proxy.project", Description: "Project name to tag sessions (default: auto-detect from git)"},
 	config.FlagVectorStoreTgt: {Name: "vector-store-target", ViperKey: "vector_store.target", Description: "pgvector connection string (defaults to storage.postgres_dsn when unset)"},
-	config.FlagEmbeddingProv:  {Name: "embedding-provider", ViperKey: "embedding.provider", Description: "Embedding provider type (e.g., ollama)"},
+	config.FlagEmbeddingProv:  {Name: "embedding-provider", ViperKey: "embedding.provider", Description: "Embedding provider type (e.g., ollama, openai)"},
 	config.FlagEmbeddingTgt:   {Name: "embedding-target", ViperKey: "embedding.target", Description: "Embedding provider URL"},
-	config.FlagEmbeddingModel: {Name: "embedding-model", ViperKey: "embedding.model", Description: "Embedding model name (e.g., nomic-embed-text)"},
+	config.FlagEmbeddingModel: {Name: "embedding-model", ViperKey: "embedding.model", Description: "Embedding model name (e.g., embeddinggemma, text-embedding-3-small)"},
 	config.FlagEmbeddingDims:  {Name: "embedding-dimensions", ViperKey: "embedding.dimensions", Description: "Embedding dimensionality"},
 }
 
@@ -125,10 +127,23 @@ func NewServeCmd() *cobra.Command {
 			cmder.upstream = v.GetString("proxy.upstream")
 			cmder.providerType = v.GetString("proxy.provider")
 			cmder.vectorStoreTarget = v.GetString("vector_store.target")
-			cmder.embeddingProvider = v.GetString("embedding.provider")
-			cmder.embeddingTarget = v.GetString("embedding.target")
-			cmder.embeddingModel = v.GetString("embedding.model")
-			cmder.embeddingDimensions = v.GetUint("embedding.dimensions")
+			embedding := config.ResolveEmbeddingConfigWithOptions(
+				v.GetString("embedding.provider"),
+				v.GetString("embedding.target"),
+				v.GetString("embedding.model"),
+				v.GetUint("embedding.dimensions"),
+				config.ResolveEmbeddingConfigOptions{
+					DimensionsSet: config.IsRegisteredFlagExplicitlySet(v, cmd, cmder.flags, config.FlagEmbeddingDims),
+				},
+			)
+			cmder.embeddingProvider = embedding.Provider
+			cmder.embeddingTarget = embedding.Target
+			cmder.embeddingModel = embedding.Model
+			cmder.embeddingDimensions = embedding.Dimensions
+			cmder.embeddingAPIKey, err = credentials.APIKeyForProvider(embedding.Provider, configDir)
+			if err != nil {
+				return fmt.Errorf("could not load embedding credentials: %w", err)
+			}
 			cmder.project = v.GetString("proxy.project")
 
 			if cmder.project == "" {
@@ -199,6 +214,7 @@ func (c *ServeCommander) run() error {
 		TargetURL:    c.embeddingTarget,
 		Model:        c.embeddingModel,
 		Dimensions:   c.embeddingDimensions,
+		APIKey:       c.embeddingAPIKey,
 	})
 	if err != nil {
 		return fmt.Errorf("creating embedder: %w", err)

--- a/cmd/tapes/start/start.go
+++ b/cmd/tapes/start/start.go
@@ -76,6 +76,7 @@ type startConfig struct {
 	EmbeddingTarget     string
 	EmbeddingModel      string
 	EmbeddingDimensions uint
+	EmbeddingAPIKey     string
 	DefaultProvider     string
 	DefaultUpstream     string
 	OllamaUpstream      string
@@ -416,6 +417,7 @@ func (c *startCommander) runServices(ctx context.Context, manager *start.Manager
 		TargetURL:    startCfg.EmbeddingTarget,
 		Model:        startCfg.EmbeddingModel,
 		Dimensions:   startCfg.EmbeddingDimensions,
+		APIKey:       startCfg.EmbeddingAPIKey,
 	})
 	if err != nil {
 		return fmt.Errorf("could not create new embedder: %w", err)
@@ -728,14 +730,28 @@ func (c *startCommander) loadConfig() (*startConfig, error) {
 
 	provider := v.GetString("proxy.provider")
 	upstream := v.GetString("proxy.upstream")
+	embedding := config.ResolveEmbeddingConfigWithOptions(
+		v.GetString("embedding.provider"),
+		v.GetString("embedding.target"),
+		v.GetString("embedding.model"),
+		v.GetUint("embedding.dimensions"),
+		config.ResolveEmbeddingConfigOptions{
+			DimensionsSet: config.ExplicitConfigKeySet(v, "embedding.dimensions"),
+		},
+	)
+	embeddingAPIKey, err := credentials.APIKeyForProvider(embedding.Provider, c.configDir)
+	if err != nil {
+		return nil, fmt.Errorf("loading embedding credentials: %w", err)
+	}
 
 	return &startConfig{
 		PostgresDSN:         v.GetString("storage.postgres_dsn"),
 		VectorStoreTarget:   v.GetString("vector_store.target"),
-		EmbeddingProvider:   v.GetString("embedding.provider"),
-		EmbeddingTarget:     v.GetString("embedding.target"),
-		EmbeddingModel:      v.GetString("embedding.model"),
-		EmbeddingDimensions: v.GetUint("embedding.dimensions"),
+		EmbeddingProvider:   embedding.Provider,
+		EmbeddingTarget:     embedding.Target,
+		EmbeddingModel:      embedding.Model,
+		EmbeddingDimensions: embedding.Dimensions,
+		EmbeddingAPIKey:     embeddingAPIKey,
 		DefaultProvider:     provider,
 		DefaultUpstream:     upstream,
 		OllamaUpstream:      resolveOllamaUpstream(provider, upstream),

--- a/cmd/tapes/start/start.go
+++ b/cmd/tapes/start/start.go
@@ -415,6 +415,7 @@ func (c *startCommander) runServices(ctx context.Context, manager *start.Manager
 		ProviderType: startCfg.EmbeddingProvider,
 		TargetURL:    startCfg.EmbeddingTarget,
 		Model:        startCfg.EmbeddingModel,
+		Dimensions:   startCfg.EmbeddingDimensions,
 	})
 	if err != nil {
 		return fmt.Errorf("could not create new embedder: %w", err)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -264,6 +264,7 @@ func PresetConfig(name string) (*Config, error) {
 				ProxyTarget: "http://localhost:8080",
 				APITarget:   "http://localhost:8081",
 			},
+			Embedding: ResolveEmbeddingConfig("openai", "", "", 0),
 		}, nil
 
 	case "anthropic":
@@ -298,12 +299,7 @@ func PresetConfig(name string) (*Config, error) {
 				ProxyTarget: "http://localhost:8080",
 				APITarget:   "http://localhost:8081",
 			},
-			Embedding: EmbeddingConfig{
-				Provider:   "ollama",
-				Target:     "http://localhost:11434",
-				Model:      "nomic-embed-text",
-				Dimensions: 768,
-			},
+			Embedding: ResolveEmbeddingConfig("ollama", "", "", 0),
 		}, nil
 
 	default:

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -547,6 +547,10 @@ var _ = Describe("PresetConfig", func() {
 		Expect(cfg.API.Listen).To(Equal(":8081"))
 		Expect(cfg.Client.ProxyTarget).To(Equal("http://localhost:8080"))
 		Expect(cfg.Client.APITarget).To(Equal("http://localhost:8081"))
+		Expect(cfg.Embedding.Provider).To(Equal("openai"))
+		Expect(cfg.Embedding.Target).To(Equal("https://api.openai.com"))
+		Expect(cfg.Embedding.Model).To(Equal("text-embedding-3-small"))
+		Expect(cfg.Embedding.Dimensions).To(Equal(uint(1536)))
 	})
 
 	It("returns anthropic preset with correct defaults", func() {
@@ -573,7 +577,7 @@ var _ = Describe("PresetConfig", func() {
 		Expect(cfg.Client.APITarget).To(Equal("http://localhost:8081"))
 		Expect(cfg.Embedding.Provider).To(Equal("ollama"))
 		Expect(cfg.Embedding.Target).To(Equal("http://localhost:11434"))
-		Expect(cfg.Embedding.Model).To(Equal("nomic-embed-text"))
+		Expect(cfg.Embedding.Model).To(Equal("embeddinggemma"))
 		Expect(cfg.Embedding.Dimensions).To(Equal(uint(768)))
 	})
 
@@ -592,6 +596,38 @@ var _ = Describe("PresetConfig", func() {
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("unknown preset"))
 		Expect(cfg).To(BeNil())
+	})
+})
+
+var _ = Describe("ResolveEmbeddingConfig", func() {
+	It("uses OpenAI defaults when provider inherits local embedding defaults", func() {
+		cfg := config.ResolveEmbeddingConfig("openai", "http://localhost:11434", "embeddinggemma", 768)
+		Expect(cfg.Provider).To(Equal("openai"))
+		Expect(cfg.Target).To(Equal("https://api.openai.com"))
+		Expect(cfg.Model).To(Equal("text-embedding-3-small"))
+		Expect(cfg.Dimensions).To(Equal(uint(1536)))
+	})
+
+	It("preserves explicit OpenAI dimensions", func() {
+		cfg := config.ResolveEmbeddingConfigWithOptions(
+			"openai",
+			"http://localhost:11434",
+			"embeddinggemma",
+			768,
+			config.ResolveEmbeddingConfigOptions{DimensionsSet: true},
+		)
+		Expect(cfg.Provider).To(Equal("openai"))
+		Expect(cfg.Target).To(Equal("https://api.openai.com"))
+		Expect(cfg.Model).To(Equal("text-embedding-3-small"))
+		Expect(cfg.Dimensions).To(Equal(uint(768)))
+	})
+
+	It("defaults Ollama to embeddinggemma at 768 dimensions", func() {
+		cfg := config.ResolveEmbeddingConfig("ollama", "", "", 0)
+		Expect(cfg.Provider).To(Equal("ollama"))
+		Expect(cfg.Target).To(Equal("http://localhost:11434"))
+		Expect(cfg.Model).To(Equal("embeddinggemma"))
+		Expect(cfg.Dimensions).To(Equal(uint(768)))
 	})
 })
 

--- a/pkg/config/embedding_defaults.go
+++ b/pkg/config/embedding_defaults.go
@@ -1,0 +1,77 @@
+package config
+
+import "strings"
+
+const (
+	defaultOpenAIEmbeddingTarget     = "https://api.openai.com"
+	defaultOpenAIEmbeddingModel      = "text-embedding-3-small"
+	defaultOpenAIEmbeddingDimensions = 1536
+
+	legacyOllamaEmbeddingModel = "nomic-embed-text"
+)
+
+// ResolveEmbeddingConfigOptions describes which values came from explicit
+// user input instead of inherited defaults.
+type ResolveEmbeddingConfigOptions struct {
+	DimensionsSet bool
+}
+
+// ResolveEmbeddingConfig normalizes provider-specific embedding defaults after
+// config, flags, and environment variables have been merged.
+func ResolveEmbeddingConfig(provider, target, model string, dimensions uint) EmbeddingConfig {
+	return ResolveEmbeddingConfigWithOptions(provider, target, model, dimensions, ResolveEmbeddingConfigOptions{})
+}
+
+// ResolveEmbeddingConfigWithOptions normalizes provider-specific embedding
+// defaults while preserving explicitly configured values.
+func ResolveEmbeddingConfigWithOptions(provider, target, model string, dimensions uint, opts ResolveEmbeddingConfigOptions) EmbeddingConfig {
+	switch strings.ToLower(provider) {
+	case "openai":
+		inheritedLocalTarget := target == "" || target == defaultEmbeddingTarget || target == defaultUpstream
+		inheritedLocalModel := model == "" || model == defaultEmbeddingModel || model == legacyOllamaEmbeddingModel
+		inheritedLocalDimensions := dimensions == 0 || (!opts.DimensionsSet && dimensions == defaultEmbeddingDimensions && (inheritedLocalTarget || inheritedLocalModel))
+
+		if inheritedLocalTarget {
+			target = defaultOpenAIEmbeddingTarget
+		}
+		if inheritedLocalModel {
+			model = defaultOpenAIEmbeddingModel
+		}
+		if inheritedLocalDimensions {
+			dimensions = defaultOpenAIEmbeddingDimensions
+		}
+
+		return EmbeddingConfig{
+			Provider:   "openai",
+			Target:     target,
+			Model:      model,
+			Dimensions: dimensions,
+		}
+
+	case "ollama":
+		if target == "" {
+			target = defaultEmbeddingTarget
+		}
+		if model == "" || model == legacyOllamaEmbeddingModel {
+			model = defaultEmbeddingModel
+		}
+		if dimensions == 0 {
+			dimensions = defaultEmbeddingDimensions
+		}
+
+		return EmbeddingConfig{
+			Provider:   "ollama",
+			Target:     target,
+			Model:      model,
+			Dimensions: dimensions,
+		}
+
+	default:
+		return EmbeddingConfig{
+			Provider:   provider,
+			Target:     target,
+			Model:      model,
+			Dimensions: dimensions,
+		}
+	}
+}

--- a/pkg/config/flags.go
+++ b/pkg/config/flags.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"os"
+	"strings"
 	"sync"
 
 	"github.com/spf13/cobra"
@@ -127,6 +129,36 @@ func BindRegisteredFlags(v *viper.Viper, cmd *cobra.Command, fs FlagSet, registr
 
 		_ = v.BindPFlag(def.ViperKey, f)
 	}
+}
+
+// IsRegisteredFlagExplicitlySet reports whether a registered flag's value came
+// from a CLI flag, environment variable, or config file rather than defaults.
+func IsRegisteredFlagExplicitlySet(v *viper.Viper, cmd *cobra.Command, fs FlagSet, registryKey string) bool {
+	def, ok := fs[registryKey]
+	if !ok {
+		return false
+	}
+
+	if f := cmd.Flags().Lookup(def.Name); f != nil && f.Changed {
+		return true
+	}
+
+	if ExplicitConfigKeySet(v, def.ViperKey) {
+		return true
+	}
+
+	return false
+}
+
+// ExplicitConfigKeySet reports whether a config key was supplied through the
+// environment or the loaded config file.
+func ExplicitConfigKeySet(v *viper.Viper, key string) bool {
+	envKey := "TAPES_" + strings.ToUpper(strings.ReplaceAll(key, ".", "_"))
+	if _, ok := os.LookupEnv(envKey); ok {
+		return true
+	}
+
+	return v.InConfig(key)
 }
 
 // cachedDefaultViper is a lazily-initialized viper instance with all defaults

--- a/pkg/credentials/credentials.go
+++ b/pkg/credentials/credentials.go
@@ -133,6 +133,39 @@ func (m *Manager) GetKey(provider string) (string, error) {
 	return pc.APIKey, nil
 }
 
+// GetKeyUnlessEnvSet returns the stored API key for provider unless the
+// provider's environment variable is already set.
+func (m *Manager) GetKeyUnlessEnvSet(provider string) (string, error) {
+	envVar := EnvVarForProvider(provider)
+	if envVar == "" {
+		return "", nil
+	}
+	if os.Getenv(envVar) != "" {
+		return "", nil
+	}
+
+	return m.GetKey(provider)
+}
+
+// APIKeyForProvider returns a stored API key for provider when the matching
+// environment variable is not already set.
+func APIKeyForProvider(provider, configDir string) (string, error) {
+	envVar := EnvVarForProvider(provider)
+	if envVar == "" {
+		return "", nil
+	}
+	if os.Getenv(envVar) != "" {
+		return "", nil
+	}
+
+	mgr, err := NewManager(configDir)
+	if err != nil {
+		return "", err
+	}
+
+	return mgr.GetKeyUnlessEnvSet(provider)
+}
+
 // RemoveKey deletes the stored credential for a provider.
 func (m *Manager) RemoveKey(provider string) error {
 	creds, err := m.Load()

--- a/pkg/credentials/credentials_test.go
+++ b/pkg/credentials/credentials_test.go
@@ -160,6 +160,37 @@ api_key = "sk-test-key"
 		})
 	})
 
+	Describe("GetKeyUnlessEnvSet", func() {
+		It("returns stored API key when provider env var is unset", func() {
+			mgr, err := credentials.NewManager(tmpDir)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(mgr.SetKey("openai", "sk-stored")).To(Succeed())
+
+			key, err := mgr.GetKeyUnlessEnvSet("openai")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(key).To(Equal("sk-stored"))
+		})
+
+		It("lets provider env var take precedence over stored credentials", func() {
+			mgr, err := credentials.NewManager(tmpDir)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(mgr.SetKey("openai", "sk-stored")).To(Succeed())
+			value, ok := os.LookupEnv("OPENAI_API_KEY")
+			Expect(os.Setenv("OPENAI_API_KEY", "sk-env")).To(Succeed())
+			DeferCleanup(func() {
+				if ok {
+					Expect(os.Setenv("OPENAI_API_KEY", value)).To(Succeed())
+					return
+				}
+				Expect(os.Unsetenv("OPENAI_API_KEY")).To(Succeed())
+			})
+
+			key, err := mgr.GetKeyUnlessEnvSet("openai")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(key).To(BeEmpty())
+		})
+	})
+
 	Describe("RemoveKey", func() {
 		It("removes an existing key", func() {
 			mgr, err := credentials.NewManager(tmpDir)

--- a/pkg/embeddings/openai/openai.go
+++ b/pkg/embeddings/openai/openai.go
@@ -1,0 +1,176 @@
+// Package openai implements pkg/embeddings's Embedder client for OpenAI's
+// embeddings API.
+package openai
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/papercomputeco/tapes/pkg/embeddings"
+	"github.com/papercomputeco/tapes/pkg/vector"
+)
+
+const (
+	// DefaultEmbeddingModel is OpenAI's default Tapes embedding model.
+	DefaultEmbeddingModel = "text-embedding-3-small"
+
+	// DefaultBaseURL is the OpenAI API base URL.
+	DefaultBaseURL = "https://api.openai.com/v1"
+
+	maxErrorBodyBytes = 4 << 10
+)
+
+// Embedder wraps OpenAI's embeddings API.
+type Embedder struct {
+	baseURL    string
+	model      string
+	apiKey     string
+	dimensions uint
+	httpClient *http.Client
+}
+
+// EmbedderConfig holds configuration for the OpenAI embedder.
+type EmbedderConfig struct {
+	// BaseURL is the OpenAI-compatible API URL. It may include or omit /v1.
+	// Defaults to DefaultBaseURL if empty.
+	BaseURL string
+
+	// Model is the embedding model to use.
+	// Defaults to DefaultEmbeddingModel if empty.
+	Model string
+
+	// APIKey is the OpenAI API key. Defaults to OPENAI_API_KEY if empty.
+	APIKey string
+
+	// Dimensions optionally requests shortened embeddings for text-embedding-3
+	// models. Leave 0 to use the model default.
+	Dimensions uint
+}
+
+type embedRequest struct {
+	Model          string `json:"model"`
+	Input          string `json:"input"`
+	EncodingFormat string `json:"encoding_format,omitempty"`
+	Dimensions     uint   `json:"dimensions,omitempty"`
+}
+
+type embedResponse struct {
+	Data []struct {
+		Embedding []float32 `json:"embedding"`
+	} `json:"data"`
+}
+
+// NewEmbedder creates a new embedder using OpenAI's embeddings API.
+func NewEmbedder(cfg EmbedderConfig) (*Embedder, error) {
+	baseURL := cfg.BaseURL
+	if baseURL == "" {
+		baseURL = DefaultBaseURL
+	}
+	baseURL, err := normalizeBaseURL(baseURL)
+	if err != nil {
+		return nil, err
+	}
+
+	model := cfg.Model
+	if model == "" {
+		model = DefaultEmbeddingModel
+	}
+
+	apiKey := cfg.APIKey
+	if apiKey == "" {
+		apiKey = os.Getenv("OPENAI_API_KEY")
+	}
+	if apiKey == "" {
+		return nil, errors.New("OPENAI_API_KEY is required for openai embeddings")
+	}
+
+	return &Embedder{
+		baseURL:    baseURL,
+		model:      model,
+		apiKey:     apiKey,
+		dimensions: cfg.Dimensions,
+		httpClient: &http.Client{
+			Timeout: 60 * time.Second,
+		},
+	}, nil
+}
+
+// Embed converts text into a vector embedding.
+func (e *Embedder) Embed(ctx context.Context, text string) ([]float32, error) {
+	reqBody := embedRequest{
+		Model:          e.model,
+		Input:          text,
+		EncodingFormat: "float",
+		Dimensions:     e.dimensions,
+	}
+
+	jsonBody, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("%w: marshaling request: %w", vector.ErrEmbedding, err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, e.baseURL+"/embeddings", bytes.NewReader(jsonBody))
+	if err != nil {
+		return nil, fmt.Errorf("%w: creating request: %w", vector.ErrEmbedding, err)
+	}
+	req.Header.Set("Authorization", "Bearer "+e.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := e.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("%w: sending request: %w", vector.ErrEmbedding, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodyBytes))
+		return nil, fmt.Errorf("%w: openai returned status %d: %s", vector.ErrEmbedding, resp.StatusCode, string(body))
+	}
+
+	var embedResp embedResponse
+	if err := json.NewDecoder(resp.Body).Decode(&embedResp); err != nil {
+		return nil, fmt.Errorf("%w: decoding response: %w", vector.ErrEmbedding, err)
+	}
+
+	if len(embedResp.Data) == 0 || len(embedResp.Data[0].Embedding) == 0 {
+		return nil, fmt.Errorf("%w: no embeddings returned", vector.ErrEmbedding)
+	}
+
+	return embedResp.Data[0].Embedding, nil
+}
+
+// Close releases resources held by the embedder.
+func (e *Embedder) Close() error {
+	return nil
+}
+
+func normalizeBaseURL(raw string) (string, error) {
+	raw = strings.TrimRight(raw, "/")
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", fmt.Errorf("invalid OpenAI embedding base URL: %w", err)
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return "", fmt.Errorf("invalid OpenAI embedding base URL: %q", raw)
+	}
+	if !pathContainsSegment(u.Path, "v1") {
+		u.Path = strings.TrimRight(u.Path, "/") + "/v1"
+	}
+	return strings.TrimRight(u.String(), "/"), nil
+}
+
+func pathContainsSegment(path string, segment string) bool {
+	return slices.Contains(strings.Split(path, "/"), segment)
+}
+
+var _ embeddings.Embedder = (*Embedder)(nil)

--- a/pkg/embeddings/openai/openai_test.go
+++ b/pkg/embeddings/openai/openai_test.go
@@ -1,0 +1,111 @@
+package openai
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestOpenAI(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "OpenAI Embeddings Suite")
+}
+
+var _ = Describe("Embedder", func() {
+	It("posts to the OpenAI embeddings API", func(ctx SpecContext) {
+		var gotPath string
+		var gotAuth string
+		var gotBody map[string]any
+
+		embedder := &Embedder{
+			baseURL:    "https://api.openai.test/v1",
+			model:      "text-embedding-3-small",
+			apiKey:     "sk-test",
+			dimensions: 3,
+			httpClient: &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+				gotPath = r.URL.Path
+				gotAuth = r.Header.Get("Authorization")
+				Expect(json.NewDecoder(r.Body).Decode(&gotBody)).To(Succeed())
+
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewBufferString(`{"data":[{"embedding":[0.1,0.2,0.3]}]}`)),
+					Header:     make(http.Header),
+				}, nil
+			})},
+		}
+
+		embedding, err := embedder.Embed(ctx, "hello")
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(gotPath).To(Equal("/v1/embeddings"))
+		Expect(gotAuth).To(Equal("Bearer sk-test"))
+		Expect(gotBody).To(HaveKeyWithValue("model", "text-embedding-3-small"))
+		Expect(gotBody).To(HaveKeyWithValue("input", "hello"))
+		Expect(gotBody).To(HaveKeyWithValue("dimensions", float64(3)))
+		Expect(embedding).To(ConsistOf(float32(0.1), float32(0.2), float32(0.3)))
+	})
+
+	It("requires an API key", func() {
+		value, ok := os.LookupEnv("OPENAI_API_KEY")
+		Expect(os.Unsetenv("OPENAI_API_KEY")).To(Succeed())
+		DeferCleanup(func() {
+			if ok {
+				Expect(os.Setenv("OPENAI_API_KEY", value)).To(Succeed())
+				return
+			}
+			Expect(os.Unsetenv("OPENAI_API_KEY")).To(Succeed())
+		})
+
+		_, err := NewEmbedder(EmbedderConfig{})
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("limits error response bodies", func(ctx SpecContext) {
+		embedder := &Embedder{
+			baseURL: "https://api.openai.test/v1",
+			model:   "text-embedding-3-small",
+			apiKey:  "sk-test",
+			httpClient: &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusBadGateway,
+					Body:       io.NopCloser(strings.NewReader(strings.Repeat("x", maxErrorBodyBytes+32))),
+					Header:     make(http.Header),
+				}, nil
+			})},
+		}
+
+		_, err := embedder.Embed(ctx, "hello")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring(strings.Repeat("x", maxErrorBodyBytes)))
+		Expect(err.Error()).NotTo(ContainSubstring(strings.Repeat("x", maxErrorBodyBytes+1)))
+	})
+})
+
+var _ = Describe("normalizeBaseURL", func() {
+	DescribeTable("normalizes base URLs",
+		func(raw string, expected string) {
+			actual, err := normalizeBaseURL(raw)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(actual).To(Equal(expected))
+		},
+		Entry("adds v1 to a host root", "https://api.openai.test", "https://api.openai.test/v1"),
+		Entry("preserves an existing v1 suffix", "https://api.openai.test/v1", "https://api.openai.test/v1"),
+		Entry("adds v1 to a proxy prefix", "https://proxy.test/openai", "https://proxy.test/openai/v1"),
+		Entry("preserves v1 as a path segment before additional segments", "https://proxy.test/openai/v1/extra", "https://proxy.test/openai/v1/extra"),
+		Entry("does not treat v10 as v1", "https://proxy.test/openai/v10", "https://proxy.test/openai/v10/v1"),
+	)
+})
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}

--- a/pkg/embeddings/utils/new.go
+++ b/pkg/embeddings/utils/new.go
@@ -6,12 +6,14 @@ import (
 
 	"github.com/papercomputeco/tapes/pkg/embeddings"
 	"github.com/papercomputeco/tapes/pkg/embeddings/ollama"
+	"github.com/papercomputeco/tapes/pkg/embeddings/openai"
 )
 
 type NewEmbedderOpts struct {
 	ProviderType string
 	TargetURL    string
 	Model        string
+	Dimensions   uint
 }
 
 func NewEmbedder(o *NewEmbedderOpts) (embeddings.Embedder, error) {
@@ -20,6 +22,12 @@ func NewEmbedder(o *NewEmbedderOpts) (embeddings.Embedder, error) {
 		return ollama.NewEmbedder(ollama.EmbedderConfig{
 			BaseURL: o.TargetURL,
 			Model:   o.Model,
+		})
+	case "openai":
+		return openai.NewEmbedder(openai.EmbedderConfig{
+			BaseURL:    o.TargetURL,
+			Model:      o.Model,
+			Dimensions: o.Dimensions,
 		})
 	default:
 		return nil, fmt.Errorf("unsupported embedding provider: %s", o.ProviderType)

--- a/pkg/embeddings/utils/new.go
+++ b/pkg/embeddings/utils/new.go
@@ -14,6 +14,7 @@ type NewEmbedderOpts struct {
 	TargetURL    string
 	Model        string
 	Dimensions   uint
+	APIKey       string
 }
 
 func NewEmbedder(o *NewEmbedderOpts) (embeddings.Embedder, error) {
@@ -27,6 +28,7 @@ func NewEmbedder(o *NewEmbedderOpts) (embeddings.Embedder, error) {
 		return openai.NewEmbedder(openai.EmbedderConfig{
 			BaseURL:    o.TargetURL,
 			Model:      o.Model,
+			APIKey:     o.APIKey,
 			Dimensions: o.Dimensions,
 		})
 	default:

--- a/pkg/embeddings/utils/new_test.go
+++ b/pkg/embeddings/utils/new_test.go
@@ -1,0 +1,44 @@
+package embeddingutils_test
+
+import (
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	embeddingutils "github.com/papercomputeco/tapes/pkg/embeddings/utils"
+)
+
+var _ = Describe("NewEmbedder", func() {
+	BeforeEach(func() {
+		value, ok := os.LookupEnv("OPENAI_API_KEY")
+		Expect(os.Unsetenv("OPENAI_API_KEY")).To(Succeed())
+		DeferCleanup(func() {
+			if ok {
+				Expect(os.Setenv("OPENAI_API_KEY", value)).To(Succeed())
+				return
+			}
+			Expect(os.Unsetenv("OPENAI_API_KEY")).To(Succeed())
+		})
+	})
+
+	It("uses the provided OpenAI API key", func() {
+		embedder, err := embeddingutils.NewEmbedder(&embeddingutils.NewEmbedderOpts{
+			ProviderType: "openai",
+			TargetURL:    "https://api.openai.test",
+			Model:        "text-embedding-3-small",
+			APIKey:       "sk-stored",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(embedder.Close()).To(Succeed())
+	})
+
+	It("fails when OpenAI has no API key", func() {
+		_, err := embeddingutils.NewEmbedder(&embeddingutils.NewEmbedderOpts{
+			ProviderType: "openai",
+			TargetURL:    "https://api.openai.test",
+			Model:        "text-embedding-3-small",
+		})
+		Expect(err).To(MatchError(ContainSubstring("OPENAI_API_KEY is required")))
+	})
+})

--- a/pkg/embeddings/utils/utils_suite_test.go
+++ b/pkg/embeddings/utils/utils_suite_test.go
@@ -1,0 +1,13 @@
+package embeddingutils_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestEmbeddingUtils(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Embedding Utils Suite")
+}

--- a/skills/search/SKILL.md
+++ b/skills/search/SKILL.md
@@ -20,18 +20,30 @@ Use this skill when you need to:
 The tapes search command requires:
 1. A Postgres-backed tapes API or local tapes runtime
 2. A pgvector-backed vector index in the same Postgres database
-3. An embedding provider (for example Ollama) to convert queries to vectors
+3. An embedding provider, either Ollama or OpenAI, to convert queries to vectors
 
 ## Quick Start
 
+Start the API with Ollama embeddings:
+
 ```bash
-tapes search "<your query>" \
-  --postgres postgres://tapes:tapes@localhost:5432/tapes?sslmode=disable \
-  --vector-store-provider pgvector \
-  --vector-store-target postgres://tapes:tapes@localhost:5432/tapes?sslmode=disable \
-  --embedding-provider ollama \
-  --embedding-target http://localhost:11434 \
-  --embedding-model nomic-embed-text
+ollama pull embeddinggemma
+ollama serve
+tapes serve
+```
+
+Or start the API with OpenAI embeddings:
+
+```bash
+tapes auth openai
+tapes config set embedding.provider openai
+tapes serve
+```
+
+Then search through the API:
+
+```bash
+tapes search "<your query>"
 ```
 
 ## Command Reference
@@ -42,16 +54,11 @@ tapes search "<your query>" \
 tapes search <query> [flags]
 ```
 
-### Required Flags
+### API Flag
 
 | Flag | Description | Example |
 |------|-------------|---------|
-| `--postgres` | Postgres connection string | `postgres://tapes:tapes@localhost:5432/tapes?sslmode=disable` |
-| `--vector-store-provider` | Vector store type | `pgvector` |
-| `--vector-store-target` | Vector store target | `postgres://tapes:tapes@localhost:5432/tapes?sslmode=disable` |
-| `--embedding-provider` | Embedding provider type | `ollama` |
-| `--embedding-target` | Embedding provider URL | `http://localhost:11434` |
-| `--embedding-model` | Embedding model name | `nomic-embed-text` |
+| `--api-target` | Tapes API server URL | `http://localhost:8081` |
 
 ### Optional Flags
 
@@ -66,12 +73,7 @@ tapes search <query> [flags]
 
 ```bash
 tapes search "how to configure logging" \
-  --postgres postgres://tapes:tapes@localhost:5432/tapes?sslmode=disable \
-  --vector-store-provider pgvector \
-  --vector-store-target postgres://tapes:tapes@localhost:5432/tapes?sslmode=disable \
-  --embedding-provider ollama \
-  --embedding-target http://localhost:11434 \
-  --embedding-model nomic-embed-text
+  --api-target http://localhost:8081
 ```
 
 ### Get More Results
@@ -79,12 +81,7 @@ tapes search "how to configure logging" \
 ```bash
 tapes search "error handling patterns" \
   --top 10 \
-  --postgres postgres://tapes:tapes@localhost:5432/tapes?sslmode=disable \
-  --vector-store-provider pgvector \
-  --vector-store-target postgres://tapes:tapes@localhost:5432/tapes?sslmode=disable \
-  --embedding-provider ollama \
-  --embedding-target http://localhost:11434 \
-  --embedding-model nomic-embed-text
+  --api-target http://localhost:8081
 ```
 
 ### Debug Mode
@@ -92,12 +89,7 @@ tapes search "error handling patterns" \
 ```bash
 tapes search "authentication flow" \
   --debug \
-  --postgres postgres://tapes:tapes@localhost:5432/tapes?sslmode=disable \
-  --vector-store-provider pgvector \
-  --vector-store-target postgres://tapes:tapes@localhost:5432/tapes?sslmode=disable \
-  --embedding-provider ollama \
-  --embedding-target http://localhost:11434 \
-  --embedding-model nomic-embed-text
+  --api-target http://localhost:8081
 ```
 
 ## Output Format


### PR DESCRIPTION
## Summary

- Adds an OpenAI-compatible embedding provider behind the existing
  embedding interface.
- Keeps local development on Ollama by default, using `embeddinggemma`
  at 768 dimensions unless OpenAI is selected explicitly.
- Defaults OpenAI embedding config to `https://api.openai.com`,
  `text-embedding-3-small`, and 1536 dimensions when the provider is
  `openai`.
- Lets local embedding services use the key stored by `tapes auth openai`
  when `OPENAI_API_KEY` is not already set.
- Documents the local choice between Ollama and OpenAI embeddings.

## How it works

Embedding config is normalized after flags, environment, and config files
are merged. The selected provider supplies any omitted provider-specific
defaults, so local Ollama and OpenAI do not share a single dimensions or
model default.

The OpenAI provider uses the same `Embedder` contract as Ollama. It
normalizes the configured API base URL, sends embedding requests to the
OpenAI-compatible endpoint, and returns vectors through the existing
embedding path.

For local runs, an explicit `OPENAI_API_KEY` still wins. If it is absent
and OpenAI embeddings are selected, Tapes falls back to the OpenAI
credential stored by `tapes auth openai`.

## Behavior matrix

| Scenario | Before | After |
|---|---|---|
| Default local embeddings | Ollama settings were implicit in shared defaults | Ollama stays explicit: `embeddinggemma`, 768 dimensions |
| OpenAI selected without model/dimensions | Missing provider-specific defaults | OpenAI defaults to `text-embedding-3-small`, 1536 dimensions |
| OpenAI selected with `OPENAI_API_KEY` | No OpenAI embedder path | Environment key is used |
| OpenAI selected without `OPENAI_API_KEY` | No OpenAI embedder path | Stored `tapes auth openai` credential is used when present |

## Test plan

- [x] `go test ./pkg/credentials ./pkg/embeddings/utils ./pkg/embeddings/openai`
- [x] `make format`
- [x] `make test`
- [x] `git diff --check`
- [x] `direnv exec . dagger call build export --path=./build`
- [x] `direnv exec . make test-kafka-e2e`

Refs PCC-579
