### PR TITLE
🧹 chore: (pricing) add Claude Opus 4.8 (PCC-618)

### DIFF
--- a/pkg/sessions/pricing.go
+++ b/pkg/sessions/pricing.go
@@ -10,7 +10,7 @@ import (
 
 // DefaultPricing returns hardcoded pricing per million tokens for supported models.
 //
-// Last verified: 2026-04-16
+// Last verified: 2026-05-29
 // Sources:
 //   - Anthropic: https://platform.claude.com/docs/en/about-claude/pricing
 //   - OpenAI:    https://platform.openai.com/docs/pricing
@@ -23,6 +23,7 @@ import (
 func DefaultPricing() PricingTable {
 	return PricingTable{
 		// Anthropic
+		"claude-opus-4.8":   {Input: 5.00, Output: 25.00, CacheRead: 0.50, CacheWrite: 6.25},
 		"claude-opus-4.7":   {Input: 5.00, Output: 25.00, CacheRead: 0.50, CacheWrite: 6.25},
 		"claude-opus-4.6":   {Input: 5.00, Output: 25.00, CacheRead: 0.50, CacheWrite: 6.25},
 		"claude-opus-4.5":   {Input: 5.00, Output: 25.00, CacheRead: 0.50, CacheWrite: 6.25},
@@ -146,6 +147,7 @@ func NormalizeModel(model string) string {
 	normalized = strings.ReplaceAll(normalized, "-5-3", "-5.3")
 	normalized = strings.ReplaceAll(normalized, "-5-2", "-5.2")
 	normalized = strings.ReplaceAll(normalized, "-5-1", "-5.1")
+	normalized = strings.ReplaceAll(normalized, "-4-8", "-4.8")
 	normalized = strings.ReplaceAll(normalized, "-4-7", "-4.7")
 	normalized = strings.ReplaceAll(normalized, "-4-6", "-4.6")
 	normalized = strings.ReplaceAll(normalized, "-4-5", "-4.5")

--- a/pkg/sessions/summary_test.go
+++ b/pkg/sessions/summary_test.go
@@ -1,6 +1,7 @@
 package sessions_test
 
 import (
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -216,10 +217,18 @@ var _ = Describe("NormalizeModel", func() {
 	It("strips OpenAI-style date suffix", func() {
 		Expect(sessions.NormalizeModel("gpt-4o-2024-08-06")).To(Equal("gpt-4o"))
 	})
-	It("rewrites hyphenated version markers", func() {
-		Expect(sessions.NormalizeModel("claude-opus-4-6")).To(Equal("claude-opus-4.6"))
-		Expect(sessions.NormalizeModel("claude-opus-4-7")).To(Equal("claude-opus-4.7"))
-		Expect(sessions.NormalizeModel("claude-opus-4-8")).To(Equal("claude-opus-4.8"))
+	It("every Anthropic pricing key is reachable from its canonical API form", func() {
+		// Guards against forgetting the matching `-N-M` → `-N.M` rewrite when
+		// adding a new Anthropic row to DefaultPricing. The dated variant
+		// also exercises the date-suffix stripper that real API IDs carry.
+		for key := range sessions.DefaultPricing() {
+			if !strings.HasPrefix(key, "claude-") || !strings.ContainsRune(key, '.') {
+				continue
+			}
+			api := strings.ReplaceAll(key, ".", "-")
+			Expect(sessions.NormalizeModel(api)).To(Equal(key), "bare API form %q", api)
+			Expect(sessions.NormalizeModel(api+"-20260101")).To(Equal(key), "dated API form %q", api+"-20260101")
+		}
 	})
 	It("returns empty for empty input", func() {
 		Expect(sessions.NormalizeModel("")).To(Equal(""))

--- a/pkg/sessions/summary_test.go
+++ b/pkg/sessions/summary_test.go
@@ -219,6 +219,7 @@ var _ = Describe("NormalizeModel", func() {
 	It("rewrites hyphenated version markers", func() {
 		Expect(sessions.NormalizeModel("claude-opus-4-6")).To(Equal("claude-opus-4.6"))
 		Expect(sessions.NormalizeModel("claude-opus-4-7")).To(Equal("claude-opus-4.7"))
+		Expect(sessions.NormalizeModel("claude-opus-4-8")).To(Equal("claude-opus-4.8"))
 	})
 	It("returns empty for empty input", func() {
 		Expect(sessions.NormalizeModel("")).To(Equal(""))


### PR DESCRIPTION
## Summary
Assuming this is still needed. I haven't been following the tapes api updates closely as of recent, but in the past I've been manually update the pricing and adding new models as they drop. 

- Add `claude-opus-4.8` to `DefaultPricing()` at $5 input / $25 output / $0.50 cache read / $6.25 cache write (5min) per MTok — same rates as 4.7.
- Add `-4-8` → `-4.8` rewrite in `NormalizeModel` so the canonical Anthropic API ID `claude-opus-4-8` resolves correctly.
- Bump `Last verified` to 2026-05-29.
- Cover the new normalization with a test in `pkg/sessions/summary_test.go`.

Without this, sessions on Opus 4.8 silently report $0.00 cost.

Closes PCC-618.

## Verification

Pricing and model ID confirmed against Anthropic docs:
- Pricing: https://platform.claude.com/docs/en/about-claude/pricing
- Model ID `claude-opus-4-8`: https://platform.claude.com/docs/en/about-claude/models/migration-guide#migrating-from-claude-opus-47
- 4.8 is GA, listed as the current default Opus; 4.7 has moved to the legacy table.

## Out of scope (follow-ups)

- The `Pricing` struct doesn't model 1-hour cache writes ($10/MTok on 4.8) or fast-mode premium ($10 input / $50 output) — same gap that already exists for 4.7/4.6.
- The `inference_geo: "us"` 1.1x multiplier isn't applied anywhere — also pre-existing.

## Test plan

- [x] `go test ./pkg/sessions/...` passes locally
- [ ] `make unit-test` (Dagger) green in CI
- [ ] Manual: send a turn against `claude-opus-4-8-*` through the proxy and confirm the session shows non-zero cost