### PR TITLE
✨ feat: session-grained /v1/stats with chain-aware status

### DIFF
--- a/api/admin_handlers.go
+++ b/api/admin_handlers.go
@@ -10,6 +10,7 @@ import (
 	"github.com/papercomputeco/tapes/pkg/backfill"
 	"github.com/papercomputeco/tapes/pkg/deck"
 	"github.com/papercomputeco/tapes/pkg/llm"
+	"github.com/papercomputeco/tapes/pkg/storage"
 )
 
 type seedDemoRequest struct {
@@ -77,4 +78,21 @@ func (s *Server) handleBackfillUsage(c *fiber.Ctx) error {
 	}
 
 	return c.JSON(result)
+}
+
+// handleBackfillSessionStatus recomputes derived_status for existing
+// sessions whose rows predate the ingest-time computation. Live ingest
+// keeps status current, so this is a one-shot for legacy/pre-feature data;
+// it is idempotent and safe to re-run.
+func (s *Server) handleBackfillSessionStatus(c *fiber.Ctx) error {
+	bf, ok := s.driver.(storage.SessionStatusBackfiller)
+	if !ok {
+		return c.Status(fiber.StatusNotImplemented).JSON(llm.ErrorResponse{Error: "driver does not support session-status backfill"})
+	}
+	res, err := bf.BackfillSessionStatus(c.Context())
+	if err != nil {
+		s.logger.Error("backfill session status", "error", err)
+		return c.Status(fiber.StatusInternalServerError).JSON(llm.ErrorResponse{Error: err.Error()})
+	}
+	return c.JSON(fiber.Map{"scanned": res.Scanned, "updated": res.Updated})
 }

--- a/api/api.go
+++ b/api/api.go
@@ -83,6 +83,7 @@ func NewServer(config Config, driver storage.Driver, log *slog.Logger) (*Server,
 
 	app.Post("/v1/admin/seed/demo", s.handleSeedDemo)
 	app.Post("/v1/admin/backfill/usage", s.handleBackfillUsage)
+	app.Post("/v1/admin/backfill/session-status", s.handleBackfillSessionStatus)
 
 	// API reference UI. Always mounted — the viewer JS comes from a CDN
 	// at view time, so the binary cost is negligible.

--- a/api/sessions_handlers.go
+++ b/api/sessions_handlers.go
@@ -49,6 +49,7 @@ type SessionItem struct {
 	TotalInputTokens  int64          `json:"total_input_tokens"`
 	TotalOutputTokens int64          `json:"total_output_tokens"`
 	TotalCostUsd      float64        `json:"total_cost_usd"`
+	DerivedStatus     string         `json:"derived_status"`
 	HarnessMetadata   map[string]any `json:"harness_metadata,omitempty"`
 	Preview           string         `json:"preview,omitempty"`
 }
@@ -95,6 +96,7 @@ func sessionItemFromStorage(s storage.SessionRecord) SessionItem {
 		TotalInputTokens:  s.TotalInputTokens,
 		TotalOutputTokens: s.TotalOutputTokens,
 		TotalCostUsd:      s.TotalCostUsd,
+		DerivedStatus:     s.DerivedStatus,
 		HarnessMetadata:   s.HarnessMetadata,
 		Preview:           s.Preview,
 	}

--- a/api/v1_handlers.go
+++ b/api/v1_handlers.go
@@ -106,6 +106,7 @@ type Turn struct {
 //     derived_status on Put + backfill).
 type StatsResponse struct {
 	SessionCount    int     `json:"session_count"`
+	StemCount       int     `json:"stem_count"`
 	TurnCount       int     `json:"turn_count"`
 	RootCount       int     `json:"root_count"`
 	CompletedCount  int     `json:"completed_count"`
@@ -262,6 +263,7 @@ func (s *Server) handleStats(c *fiber.Ctx) error {
 
 	return c.JSON(StatsResponse{
 		SessionCount:    stats.SessionCount,
+		StemCount:       stats.StemCount,
 		TurnCount:       stats.TurnCount,
 		RootCount:       stats.RootCount,
 		CompletedCount:  stats.CompletedCount,

--- a/api/v1_handlers_test.go
+++ b/api/v1_handlers_test.go
@@ -164,11 +164,13 @@ var _ = Describe("v1 session handlers", func() {
 
 			It("returns unfiltered totals with zero aggregates", func() {
 				body := decodeStats(server, "/v1/stats")
-				Expect(body.SessionCount).To(Equal(2))
+				// Nodes are Put directly (no session envelope), so the
+				// session-grained metrics are 0; StemCount carries the
+				// leaf-based total (2 leaves).
+				Expect(body.StemCount).To(Equal(2))
+				Expect(body.SessionCount).To(Equal(0))
 				Expect(body.TurnCount).To(Equal(3))
 				Expect(body.RootCount).To(Equal(1))
-				// No Usage on any node, no pricing match for model "m", no
-				// stop_reason → completed_count and the aggregates stay zero.
 				Expect(body.CompletedCount).To(Equal(0))
 				Expect(body.TotalCost).To(Equal(0.0))
 				Expect(body.InputTokens).To(Equal(int64(0)))
@@ -178,7 +180,8 @@ var _ = Describe("v1 session handlers", func() {
 
 			It("applies the project filter", func() {
 				body := decodeStats(server, "/v1/stats?project=tapes")
-				Expect(body.SessionCount).To(Equal(1))
+				Expect(body.StemCount).To(Equal(1))
+				Expect(body.SessionCount).To(Equal(0))
 				Expect(body.TurnCount).To(Equal(2))
 				Expect(body.RootCount).To(Equal(1))
 				Expect(body.CompletedCount).To(Equal(0))
@@ -277,7 +280,8 @@ var _ = Describe("v1 session handlers", func() {
 				seedSession(seedOpts{tag: "b", project: "tapes", inputTokens: 500_000, outputTok: 250_000, stop: ""})
 
 				body := decodeStats(richServer, "/v1/stats")
-				Expect(body.SessionCount).To(Equal(2))
+				Expect(body.StemCount).To(Equal(2))
+				Expect(body.SessionCount).To(Equal(0))
 				Expect(body.TurnCount).To(Equal(4))
 				Expect(body.RootCount).To(Equal(2))
 				Expect(body.InputTokens).To(Equal(int64(1_500_000)))
@@ -287,8 +291,10 @@ var _ = Describe("v1 session handlers", func() {
 				// (baseTime+4s) − (baseTime+1s) = 3s.
 				Expect(body.TotalDurationNs).To(Equal(3 * int64(time.Second)))
 				Expect(body.ToolCalls).To(Equal(2))
-				// Leaf-status: session 1's assistant leaf has stop_reason "stop"; session 2's is empty.
-				Expect(body.CompletedCount).To(Equal(1))
+				// completed_count is session-grained (sessions.derived_status);
+				// these nodes are Put without sessions, so it stays 0. Chain-
+				// aware completion is covered in the postgres ingest specs.
+				Expect(body.CompletedCount).To(Equal(0))
 			})
 
 			It("narrows folded aggregates by the project filter", func() {
@@ -297,26 +303,32 @@ var _ = Describe("v1 session handlers", func() {
 				seedSession(seedOpts{tag: "b", project: "other", inputTokens: 999_999, outputTok: 999_999, stop: "stop"})
 
 				body := decodeStats(richServer, "/v1/stats?project=tapes")
-				Expect(body.SessionCount).To(Equal(1))
+				Expect(body.StemCount).To(Equal(1))
+				Expect(body.SessionCount).To(Equal(0))
 				Expect(body.InputTokens).To(Equal(int64(1_000_000)))
 				Expect(body.OutputTokens).To(Equal(int64(500_000)))
 				Expect(body.TotalCost).To(BeNumerically("~", 25.0, 0.0001))
 				// Wall-clock window narrows to the tapes-project pair (+1s..+2s) = 1s.
 				Expect(body.TotalDurationNs).To(Equal(int64(time.Second)))
-				Expect(body.CompletedCount).To(Equal(1))
+				Expect(body.CompletedCount).To(Equal(0))
 			})
 
-			It("classifies completed_count using leaf stop_reason only", func() {
-				// Sessions across the spectrum of leaf states.
+			It("reports session-grained completed_count as 0 on a non-session (Put-only) store", func() {
+				// Five leaf-chains across the spectrum of leaf states. They are
+				// Put without a session envelope, so no sessions.derived_status
+				// rows exist: completed_count (session-grained) is 0 while
+				// StemCount counts the five leaves. Chain-aware completed_count
+				// is exercised by the postgres ingest specs.
 				seedSession(seedOpts{tag: "completed-stop", project: "tapes", stop: "stop"})
 				seedSession(seedOpts{tag: "completed-end_turn", project: "tapes", stop: "end_turn"})
-				seedSession(seedOpts{tag: "completed-eos", project: "tapes", stop: "EOS"}) // case-insensitive
+				seedSession(seedOpts{tag: "completed-eos", project: "tapes", stop: "EOS"})
 				seedSession(seedOpts{tag: "failed-length", project: "tapes", stop: "length"})
 				seedSession(seedOpts{tag: "unknown", project: "tapes", stop: ""})
 
 				body := decodeStats(richServer, "/v1/stats")
-				Expect(body.SessionCount).To(Equal(5))
-				Expect(body.CompletedCount).To(Equal(3))
+				Expect(body.StemCount).To(Equal(5))
+				Expect(body.SessionCount).To(Equal(0))
+				Expect(body.CompletedCount).To(Equal(0))
 			})
 
 			// Regression guard: nodes.total_duration_ns is currently never
@@ -337,6 +349,7 @@ var _ = Describe("v1 session handlers", func() {
 			It("returns zeros across every field for an empty store", func() {
 				body := decodeStats(richServer, "/v1/stats")
 				Expect(body.SessionCount).To(Equal(0))
+				Expect(body.StemCount).To(Equal(0))
 				Expect(body.TurnCount).To(Equal(0))
 				Expect(body.RootCount).To(Equal(0))
 				Expect(body.CompletedCount).To(Equal(0))

--- a/migrations/1780956959_session_status.down.sql
+++ b/migrations/1780956959_session_status.down.sql
@@ -1,0 +1,8 @@
+-- Inverse of 1780956959_session_status.up.sql. Purely additive columns +
+-- index, so the down direction is a clean drop with no data reshaping.
+
+DROP INDEX IF EXISTS sessions_derived_status_idx;
+
+ALTER TABLE sessions DROP COLUMN IF EXISTS has_git_activity;
+ALTER TABLE sessions DROP COLUMN IF EXISTS has_tool_error;
+ALTER TABLE sessions DROP COLUMN IF EXISTS derived_status;

--- a/migrations/1780956959_session_status.up.sql
+++ b/migrations/1780956959_session_status.up.sql
@@ -1,0 +1,26 @@
+-- Adds per-session derived status to the sessions table so /v1/stats and
+-- /v1/sessions can report session-grained, chain-aware completion without
+-- re-walking the merkle DAG on every read (PCC-515, PCC-565).
+--
+-- derived_status mirrors pkg/sessions.DetermineStatus. It is recomputed at
+-- ingest from two sticky signals plus the session's latest assistant leaf:
+--   has_tool_error   — any tool_result with is_error in the session
+--   has_git_activity — any `git commit` / `git push` tool_use in the session
+-- Both default false and only ever flip to true, so status can be recomputed
+-- incrementally per turn inside the ingest Tx without a chain walk. Existing
+-- rows take the 'unknown' default until the one-shot backfill runs.
+--
+-- The index is (org_id, derived_status): /v1/stats filters completed_count
+-- per org by status, and the session list queries are already org-scoped.
+
+ALTER TABLE sessions
+    ADD COLUMN IF NOT EXISTS derived_status text NOT NULL DEFAULT 'unknown';
+
+ALTER TABLE sessions
+    ADD COLUMN IF NOT EXISTS has_tool_error boolean NOT NULL DEFAULT false;
+
+ALTER TABLE sessions
+    ADD COLUMN IF NOT EXISTS has_git_activity boolean NOT NULL DEFAULT false;
+
+CREATE INDEX IF NOT EXISTS sessions_derived_status_idx
+    ON sessions (org_id, derived_status);

--- a/migrations/1781029244_session_tool_counts.down.sql
+++ b/migrations/1781029244_session_tool_counts.down.sql
@@ -1,0 +1,9 @@
+-- Inverse of 1781029244_session_tool_counts.up.sql. Restores has_tool_error
+-- (defaulting false — the precise pre-drop values are not recoverable) and
+-- drops the count columns.
+
+ALTER TABLE sessions
+    ADD COLUMN IF NOT EXISTS has_tool_error boolean NOT NULL DEFAULT false;
+
+ALTER TABLE sessions DROP COLUMN IF EXISTS tool_error_count;
+ALTER TABLE sessions DROP COLUMN IF EXISTS tool_result_count;

--- a/migrations/1781029244_session_tool_counts.up.sql
+++ b/migrations/1781029244_session_tool_counts.up.sql
@@ -1,0 +1,15 @@
+-- Replace the has_tool_error boolean with tool_result_count /
+-- tool_error_count. derived_status now applies a failure-rate rule
+-- (a single recovered tool error no longer marks a whole session failed)
+-- alongside the unrecovered-terminal-error rule, which needs counts rather
+-- than a flag. The counts are cumulative across the session, maintained at
+-- ingest the same way has_tool_error was. See pkg/sessions.DetermineStatus.
+
+ALTER TABLE sessions
+    ADD COLUMN IF NOT EXISTS tool_result_count integer NOT NULL DEFAULT 0;
+
+ALTER TABLE sessions
+    ADD COLUMN IF NOT EXISTS tool_error_count integer NOT NULL DEFAULT 0;
+
+ALTER TABLE sessions
+    DROP COLUMN IF EXISTS has_tool_error;

--- a/pkg/sessions/content.go
+++ b/pkg/sessions/content.go
@@ -48,11 +48,33 @@ func CountToolCalls(blocks []llm.ContentBlock) int {
 // BlocksHaveToolError reports whether any tool_result block is marked as an error.
 func BlocksHaveToolError(blocks []llm.ContentBlock) bool {
 	for _, block := range blocks {
-		if block.Type == "tool_result" && block.IsError {
+		if block.Type == blockTypeToolResult && block.IsError {
 			return true
 		}
 	}
 	return false
+}
+
+// CountToolResults returns how many tool_result blocks are in the slice.
+func CountToolResults(blocks []llm.ContentBlock) int {
+	count := 0
+	for _, block := range blocks {
+		if block.Type == blockTypeToolResult {
+			count++
+		}
+	}
+	return count
+}
+
+// CountToolResultErrors returns how many tool_result blocks are marked errors.
+func CountToolResultErrors(blocks []llm.ContentBlock) int {
+	count := 0
+	for _, block := range blocks {
+		if block.Type == blockTypeToolResult && block.IsError {
+			count++
+		}
+	}
+	return count
 }
 
 // gitCommandPatterns matches common git commit and push invocations inside

--- a/pkg/sessions/status.go
+++ b/pkg/sessions/status.go
@@ -6,49 +6,68 @@ import (
 	"github.com/papercomputeco/tapes/pkg/merkle"
 )
 
-// DetermineStatus classifies a session based on its terminal (leaf) node and
-// a pair of flags derived from scanning the full ancestry.
+// DetermineStatus classifies a session from its terminal (leaf) node, a
+// git-activity flag, and the session's tool_result success/failure counts.
+//
+// A single mid-conversation tool error is normal agentic behaviour (a failed
+// grep, a missing file) that the model routinely recovers from, so it no
+// longer marks the whole session failed. "Failed" now means the session
+// either ended broken or was dominated by errors.
 //
 // Precedence:
-//  1. Any tool_result error in the chain → StatusFailed
-//  2. Any git commit/push in the chain → StatusCompleted (strong done signal)
-//  3. Non-assistant leaf → StatusAbandoned
+//  1. Unrecovered terminal error → StatusFailed. The session ended on an error
+//     the model never came back from: a non-assistant leaf carrying a
+//     tool_result error (no assistant turn followed it), or an assistant leaf
+//     with a known-failing stop_reason (length / max_tokens / content_filter /
+//     *error*). An assistant turn after an error means the model saw it and
+//     responded — recovered, not failed.
+//  2. Git commit/push anywhere → StatusCompleted. Shipped work and ended clean
+//     (rule 1 already ruled out a broken ending); outranks the error-rate
+//     check so a noisy-but-recovered session that shipped reads as completed.
+//  3. tool_error_count / tool_result_count > 1/2 → StatusFailed. The session
+//     limped along mostly erroring.
 //  4. Assistant leaf with a known-terminal stop_reason → StatusCompleted.
-//     `tool_use` / `tool_use_response` count as terminal: a subagent
-//     dispatch or parallel-tool side-conversation ends when the model
-//     emits a tool request, which is the designed terminus, not a
-//     failure to respond.
-//  5. Assistant leaf with a known-failing stop_reason (the model could
-//     not produce a complete response — truncation, refusal) → StatusFailed
-//  6. Empty or otherwise unrecognised stop_reason → StatusUnknown
-func DetermineStatus(leaf *merkle.Node, hasToolError, hasGitActivity bool) string {
+//     `tool_use` / `tool_use_response` count as terminal (designed terminus of
+//     a subagent dispatch / parallel-tool side-conversation — see PCC-560).
+//  5. Non-assistant leaf (no terminal error) → StatusAbandoned.
+//  6. Empty or otherwise unrecognised stop_reason → StatusUnknown.
+func DetermineStatus(leaf *merkle.Node, hasGitActivity bool, toolResultCount, toolErrorCount int) string {
 	if leaf == nil {
 		return StatusUnknown
 	}
-	if hasToolError {
+
+	role := strings.ToLower(leaf.Bucket.Role)
+	reason := strings.ToLower(strings.TrimSpace(leaf.StopReason))
+	failingStop := reason == "length" || reason == "max_tokens" || reason == "content_filter" || strings.Contains(reason, "error")
+
+	// 1. Unrecovered terminal error — ended broken.
+	if role != roleAssistant && BlocksHaveToolError(leaf.Bucket.Content) {
 		return StatusFailed
 	}
+	if role == roleAssistant && failingStop {
+		return StatusFailed
+	}
+
+	// 2. Shipped work and ended clean.
 	if hasGitActivity {
 		return StatusCompleted
 	}
 
-	role := strings.ToLower(leaf.Bucket.Role)
-	if role != roleAssistant {
-		return StatusAbandoned
+	// 3. Mostly errors across the session.
+	if toolResultCount > 0 && toolErrorCount*2 > toolResultCount {
+		return StatusFailed
 	}
 
-	reason := strings.ToLower(strings.TrimSpace(leaf.StopReason))
-	switch reason {
-	case "stop", "end_turn", "end-turn", "eos", "tool_use", "tool_use_response":
-		return StatusCompleted
-	case "length", "max_tokens", "content_filter":
-		return StatusFailed
-	case "":
-		return StatusUnknown
-	default:
-		if strings.Contains(reason, "error") {
-			return StatusFailed
+	// 4. Assistant leaf with a terminal stop_reason.
+	if role == roleAssistant {
+		switch reason {
+		case "stop", "end_turn", "end-turn", "eos", "tool_use", "tool_use_response":
+			return StatusCompleted
+		default:
+			return StatusUnknown
 		}
 	}
-	return StatusUnknown
+
+	// 5. Non-assistant leaf, no terminal error → abandoned.
+	return StatusAbandoned
 }

--- a/pkg/sessions/summary.go
+++ b/pkg/sessions/summary.go
@@ -27,18 +27,18 @@ func BuildSummary(nodes []*merkle.Node, pricing PricingTable) (SessionSummary, m
 	inputTokens := int64(0)
 	outputTokens := int64(0)
 
-	hasToolError := false
+	toolResults := 0
+	toolErrors := 0
 	hasGitActivity := false
 	var lastModel string
 
-	// Walk every node once: derive tool errors, git activity, per-model cost,
-	// and running token totals in a single pass.
+	// Walk every node once: derive tool-result counts, git activity, per-model
+	// cost, and running token totals in a single pass.
 	for _, n := range nodes {
 		blocks := n.Bucket.Content
 		toolCalls += CountToolCalls(blocks)
-		if BlocksHaveToolError(blocks) {
-			hasToolError = true
-		}
+		toolResults += CountToolResults(blocks)
+		toolErrors += CountToolResultErrors(blocks)
 		if BlocksHaveGitActivity(blocks) {
 			hasGitActivity = true
 		}
@@ -82,7 +82,7 @@ func BuildSummary(nodes []*merkle.Node, pricing PricingTable) (SessionSummary, m
 	inputCost, outputCost, totalCost := SumModelCosts(modelCosts)
 
 	leaf := nodes[len(nodes)-1]
-	status := DetermineStatus(leaf, hasToolError, hasGitActivity)
+	status := DetermineStatus(leaf, hasGitActivity, toolResults, toolErrors)
 
 	project := ""
 	agentName := ""

--- a/pkg/sessions/summary_test.go
+++ b/pkg/sessions/summary_test.go
@@ -92,15 +92,45 @@ var _ = Describe("BuildSummary", func() {
 		Expect(modelCosts).To(HaveKey("test-model"))
 	})
 
-	It("reports failed status when a tool_result error appears anywhere in the chain", func() {
+	It("reports completed when tool errors are a recovered minority and the leaf ended cleanly", func() {
+		// 1 error out of 3 tool_results (33%), and a clean assistant turn
+		// followed — the model recovered, so this is not a failure.
 		root := newNode("user", "run something", "test-model", nil, baseTime, "", nil)
-		root.Bucket.Content = append(root.Bucket.Content, llm.ContentBlock{
-			Type:    "tool_result",
-			IsError: true,
-		})
+		root.Bucket.Content = append(root.Bucket.Content,
+			llm.ContentBlock{Type: "tool_result", IsError: true},
+			llm.ContentBlock{Type: "tool_result"},
+			llm.ContentBlock{Type: "tool_result"},
+		)
 		leaf := newNode("assistant", "done", "test-model", &root.Hash, baseTime.Add(time.Second), "stop", nil)
 
 		_, _, status, err := sessions.BuildSummary([]*merkle.Node{root, leaf}, pricing)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(status).To(Equal(sessions.StatusCompleted))
+	})
+
+	It("reports failed when tool errors exceed half of tool results", func() {
+		root := newNode("user", "run something", "test-model", nil, baseTime, "", nil)
+		root.Bucket.Content = append(root.Bucket.Content,
+			llm.ContentBlock{Type: "tool_result", IsError: true},
+			llm.ContentBlock{Type: "tool_result", IsError: true},
+			llm.ContentBlock{Type: "tool_result"},
+		)
+		leaf := newNode("assistant", "done", "test-model", &root.Hash, baseTime.Add(time.Second), "stop", nil)
+
+		_, _, status, err := sessions.BuildSummary([]*merkle.Node{root, leaf}, pricing)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(status).To(Equal(sessions.StatusFailed))
+	})
+
+	It("reports failed when the session ends on an unrecovered tool error", func() {
+		root := newNode("user", "run something", "test-model", nil, baseTime, "", nil)
+		asst := newNode("assistant", "calling a tool", "test-model", &root.Hash, baseTime.Add(time.Second), "tool_use", nil)
+		asst.Bucket.Content = []llm.ContentBlock{{Type: "tool_use", ToolName: "Bash"}}
+		// Leaf is a user-role tool_result error with no assistant turn after it.
+		errLeaf := newNode("user", "", "test-model", &asst.Hash, baseTime.Add(2*time.Second), "", nil)
+		errLeaf.Bucket.Content = []llm.ContentBlock{{Type: "tool_result", IsError: true}}
+
+		_, _, status, err := sessions.BuildSummary([]*merkle.Node{root, asst, errLeaf}, pricing)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(status).To(Equal(sessions.StatusFailed))
 	})
@@ -161,31 +191,48 @@ var _ = Describe("BuildSummary", func() {
 })
 
 var _ = Describe("DetermineStatus", func() {
+	errLeaf := func(role string) *merkle.Node {
+		return &merkle.Node{Bucket: merkle.Bucket{Role: role, Content: []llm.ContentBlock{{Type: "tool_result", IsError: true}}}}
+	}
+
 	It("returns unknown for a nil leaf", func() {
-		Expect(sessions.DetermineStatus(nil, false, false)).To(Equal(sessions.StatusUnknown))
+		Expect(sessions.DetermineStatus(nil, false, 0, 0)).To(Equal(sessions.StatusUnknown))
 	})
 
-	It("prefers failed over completed when both signals are present", func() {
+	It("returns failed when the session ends on an unrecovered tool error", func() {
+		Expect(sessions.DetermineStatus(errLeaf("user"), false, 1, 1)).To(Equal(sessions.StatusFailed))
+	})
+
+	It("does not fail on a recovered minority of tool errors", func() {
+		// Clean assistant leaf; only 1 of 4 tool_results errored (25%).
 		leaf := &merkle.Node{Bucket: merkle.Bucket{Role: "assistant"}, StopReason: "stop"}
-		Expect(sessions.DetermineStatus(leaf, true, true)).To(Equal(sessions.StatusFailed))
+		Expect(sessions.DetermineStatus(leaf, false, 4, 1)).To(Equal(sessions.StatusCompleted))
 	})
 
-	It("returns completed for git activity regardless of stop reason", func() {
+	It("returns failed when tool errors exceed half of tool results", func() {
+		leaf := &merkle.Node{Bucket: merkle.Bucket{Role: "assistant"}, StopReason: "stop"}
+		Expect(sessions.DetermineStatus(leaf, false, 4, 3)).To(Equal(sessions.StatusFailed))
+	})
+
+	It("returns completed for git activity, outranking a high error rate", func() {
 		leaf := &merkle.Node{Bucket: merkle.Bucket{Role: "assistant"}}
-		Expect(sessions.DetermineStatus(leaf, false, true)).To(Equal(sessions.StatusCompleted))
+		Expect(sessions.DetermineStatus(leaf, true, 4, 4)).To(Equal(sessions.StatusCompleted))
 	})
 
-	It("returns abandoned for a user-role leaf", func() {
+	It("returns failed for an unrecovered terminal error even with git activity", func() {
+		Expect(sessions.DetermineStatus(errLeaf("user"), true, 1, 1)).To(Equal(sessions.StatusFailed))
+	})
+
+	It("returns abandoned for a user-role leaf with no terminal error", func() {
 		leaf := &merkle.Node{Bucket: merkle.Bucket{Role: "user"}}
-		Expect(sessions.DetermineStatus(leaf, false, false)).To(Equal(sessions.StatusAbandoned))
+		Expect(sessions.DetermineStatus(leaf, false, 0, 0)).To(Equal(sessions.StatusAbandoned))
 	})
 
-	It("maps stop reasons to expected statuses", func() {
+	It("maps assistant-leaf stop reasons to expected statuses", func() {
 		// tool_use / tool_use_response are the designed terminus of a
-		// subagent or parallel-tool side-conversation — the model
-		// emitted a tool request, which is the contract. length /
-		// content_filter are real model-side failures (truncation,
-		// refusal).
+		// subagent or parallel-tool side-conversation — the model emitted a
+		// tool request, which is the contract. length / content_filter are
+		// real model-side failures (truncation, refusal).
 		cases := map[string]string{
 			"stop":              sessions.StatusCompleted,
 			"end_turn":          sessions.StatusCompleted,
@@ -200,7 +247,7 @@ var _ = Describe("DetermineStatus", func() {
 		}
 		for reason, want := range cases {
 			leaf := &merkle.Node{Bucket: merkle.Bucket{Role: "assistant"}, StopReason: reason}
-			Expect(sessions.DetermineStatus(leaf, false, false)).
+			Expect(sessions.DetermineStatus(leaf, false, 0, 0)).
 				To(Equal(want), "stop_reason=%q", reason)
 		}
 	})

--- a/pkg/sessions/types.go
+++ b/pkg/sessions/types.go
@@ -77,7 +77,8 @@ const (
 
 // Internal content-block constants used by the derivation helpers.
 const (
-	blockTypeToolUse = "tool_use"
-	roleAssistant    = "assistant"
-	roleUser         = "user"
+	blockTypeToolUse    = "tool_use"
+	blockTypeToolResult = "tool_result"
+	roleAssistant       = "assistant"
+	roleUser            = "user"
 )

--- a/pkg/storage/inmemory/inmemory.go
+++ b/pkg/storage/inmemory/inmemory.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"sort"
-	"strings"
 	"sync"
 	"time"
 
@@ -14,17 +13,6 @@ import (
 	"github.com/papercomputeco/tapes/pkg/sessions"
 	"github.com/papercomputeco/tapes/pkg/storage"
 )
-
-// terminalStopReasons mirrors the leaf-status branch of
-// pkg/sessions.DetermineStatus: an assistant leaf with one of these
-// stop_reason values classifies as completed without any chain walk.
-// Kept in sync with status.go in the sessions package.
-var terminalStopReasons = map[string]struct{}{
-	"stop":     {},
-	"end_turn": {},
-	"end-turn": {},
-	"eos":      {},
-}
 
 // Driver implements Storer using an in-memory map.
 type Driver struct {
@@ -446,12 +434,13 @@ func (s *Driver) CountSessions(_ context.Context, opts storage.ListOpts) (storag
 			}
 		}
 
+		// The in-memory driver does not track first-class sessions (no
+		// session_id / sessions table), so SessionCount and CompletedCount
+		// stay 0 — matching a Postgres store that has nodes but no session
+		// rows. StemCount is the leaf-based metric that is always available.
 		isLeaf := !hasChildren[node.Hash]
 		if isLeaf {
-			stats.SessionCount++
-			if leafIsCompleted(node) {
-				stats.CompletedCount++
-			}
+			stats.StemCount++
 		}
 		if node.ParentHash == nil || *node.ParentHash == "" {
 			stats.RootCount++
@@ -480,19 +469,6 @@ func (s *Driver) CountSessions(_ context.Context, opts storage.ListOpts) (storag
 		stats.TotalDurationNs = maxCreated.Sub(minCreated).Nanoseconds()
 	}
 	return stats, nil
-}
-
-// leafIsCompleted reports whether a leaf node satisfies the leaf-only
-// "completed" rule used by /v1/stats: assistant role plus a terminal
-// stop_reason. Not equivalent to pkg/sessions.DetermineStatus, which
-// also walks the chain for tool errors and git activity — see the
-// SessionStats.CompletedCount godoc.
-func leafIsCompleted(n *merkle.Node) bool {
-	if strings.ToLower(n.Bucket.Role) != "assistant" {
-		return false
-	}
-	_, ok := terminalStopReasons[strings.ToLower(strings.TrimSpace(n.StopReason))]
-	return ok
 }
 
 // computeHasChildren builds a set of node hashes that are referenced as a

--- a/pkg/storage/list.go
+++ b/pkg/storage/list.go
@@ -82,8 +82,17 @@ type Page[T any] struct {
 // of a matching leaf session. This mirrors the long-standing TurnCount
 // semantic: the filter is per-node, not per-chain.
 type SessionStats struct {
-	// SessionCount is the number of leaf nodes matching the filter.
+	// SessionCount is the number of distinct first-class sessions touched by
+	// the matching nodes (keyed on nodes.session_id). Nodes with no
+	// session_id — legacy or non-session-tracked writers, including the
+	// in-memory driver — do not contribute, so a store with no session rows
+	// reports 0. See StemCount for the leaf-based metric.
 	SessionCount int
+
+	// StemCount is the number of leaf nodes (Merkle chains) matching the
+	// filter — one per /v1/stems entry. This is the value SessionCount
+	// reported before the sessions table existed.
+	StemCount int
 
 	// TurnCount is the number of nodes (turns) matching the filter.
 	TurnCount int
@@ -91,12 +100,11 @@ type SessionStats struct {
 	// RootCount is the number of root nodes (no parent) matching the filter.
 	RootCount int
 
-	// CompletedCount is the number of leaf nodes whose terminal classification
-	// is "completed" using leaf-only inputs (assistant role + a terminal
-	// stop_reason). This intentionally diverges from
-	// pkg/sessions.DetermineStatus, which also walks the chain to detect
-	// tool errors and git activity. The leaf-only form is fast and
-	// satisfiable in a single SQL aggregate.
+	// CompletedCount is the number of distinct sessions whose chain-aware
+	// derived_status is "completed" (computed at ingest via
+	// pkg/sessions.DetermineStatus, read from the sessions table). Like
+	// SessionCount it is session-grained: a store with no session rows
+	// reports 0.
 	CompletedCount int
 
 	// InputTokens / OutputTokens are SUMs over the matching node set,

--- a/pkg/storage/postgres/gensqlc/aggregate_sessions.sql.go
+++ b/pkg/storage/postgres/gensqlc/aggregate_sessions.sql.go
@@ -23,8 +23,11 @@ WITH filtered AS (
         n.completion_tokens,
         n.cache_creation_input_tokens,
         n.cache_read_input_tokens,
+        n.session_id,
+        s.derived_status,
         EXISTS (SELECT 1 FROM nodes c WHERE c.parent_hash = n.hash) AS has_child
     FROM nodes n
+    LEFT JOIN sessions s ON s.id = n.session_id
     WHERE ($1::text IS NULL OR n.project = $1::text)
       AND ($2::text IS NULL OR n.agent_name = $2::text)
       AND ($3::text IS NULL OR n.model = $3::text)
@@ -34,12 +37,11 @@ WITH filtered AS (
 )
 SELECT
     COUNT(*)::bigint                                                         AS turn_count,
-    COUNT(*) FILTER (WHERE NOT has_child)::bigint                            AS session_count,
+    COUNT(DISTINCT session_id)::bigint                                       AS session_count,
+    COUNT(*) FILTER (WHERE NOT has_child)::bigint                            AS stem_count,
     COUNT(*) FILTER (WHERE parent_hash IS NULL)::bigint                      AS root_count,
-    COUNT(*) FILTER (
-        WHERE NOT has_child
-          AND LOWER(role) = 'assistant'
-          AND LOWER(stop_reason) IN ('stop', 'end_turn', 'end-turn', 'eos')
+    COUNT(DISTINCT session_id) FILTER (
+        WHERE derived_status = 'completed'
     )::bigint                                                                AS completed_count,
     COALESCE(SUM(prompt_tokens), 0)::bigint                                  AS input_tokens,
     COALESCE(SUM(completion_tokens), 0)::bigint                              AS output_tokens,
@@ -69,6 +71,7 @@ type AggregateSessionsParams struct {
 type AggregateSessionsRow struct {
 	TurnCount           int64
 	SessionCount        int64
+	StemCount           int64
 	RootCount           int64
 	CompletedCount      int64
 	InputTokens         int64
@@ -79,16 +82,22 @@ type AggregateSessionsRow struct {
 	ToolCalls           int64
 }
 
-// Single-pass aggregate that powers /v1/stats. All counts and SUMs apply
-// to the set of nodes matching the supplied per-node filters; a "session"
-// is identified as a leaf node (no child references it as parent_hash).
+// Single-pass aggregate that powers /v1/stats. SUMs and turn/stem/root
+// counts apply to the set of nodes matching the supplied per-node filters.
 //
-// completed_count is leaf-status-only: assistant role plus a terminal
-// stop_reason. It deliberately omits the chain-context overrides
-// (hasToolError / hasGitActivity) that pkg/sessions.DetermineStatus
-// applies, so a single SQL aggregate is sufficient. See StatsResponse
-// in api/v1_handlers.go for the rationale, and PCC-515 for the durable
-// chain-aware fix.
+// session_count and completed_count are session-grained, keyed on the
+// first-class sessions table via nodes.session_id (PCC-565):
+//
+//	session_count   = distinct sessions touched by the matching nodes
+//	completed_count = distinct sessions whose denormalized derived_status
+//	                  is 'completed' (chain-aware, computed at ingest by
+//	                  pkg/sessions.DetermineStatus — PCC-515)
+//
+// Nodes with no session_id (legacy / non-session-tracked writers) are not
+// counted as sessions; COUNT(DISTINCT session_id) ignores their NULLs.
+//
+// stem_count is the leaf count (one per Merkle chain, matching /v1/stems) —
+// the value session_count used to report before the sessions table existed.
 //
 // total_duration_ns is wall-clock span MAX(created_at) - MIN(created_at)
 // across the matching set, NOT SUM(nodes.total_duration_ns). The
@@ -115,6 +124,7 @@ func (q *Queries) AggregateSessions(ctx context.Context, arg AggregateSessionsPa
 	err := row.Scan(
 		&i.TurnCount,
 		&i.SessionCount,
+		&i.StemCount,
 		&i.RootCount,
 		&i.CompletedCount,
 		&i.InputTokens,

--- a/pkg/storage/postgres/gensqlc/models.go
+++ b/pkg/storage/postgres/gensqlc/models.go
@@ -51,6 +51,7 @@ type Session struct {
 	TotalCostUsd      pgtype.Numeric
 	TurnCount         int32
 	DerivedStatus     string
-	HasToolError      bool
 	HasGitActivity    bool
+	ToolResultCount   int32
+	ToolErrorCount    int32
 }

--- a/pkg/storage/postgres/gensqlc/models.go
+++ b/pkg/storage/postgres/gensqlc/models.go
@@ -50,4 +50,7 @@ type Session struct {
 	TotalOutputTokens int64
 	TotalCostUsd      pgtype.Numeric
 	TurnCount         int32
+	DerivedStatus     string
+	HasToolError      bool
+	HasGitActivity    bool
 }

--- a/pkg/storage/postgres/gensqlc/sessions.sql.go
+++ b/pkg/storage/postgres/gensqlc/sessions.sql.go
@@ -12,7 +12,7 @@ import (
 )
 
 const getSessionByNaturalKey = `-- name: GetSessionByNaturalKey :one
-SELECT id, org_id, auth_subject, harness_id, harness_session_id, name, cwd, harness_version, parent_session_id, started_at, last_seen_at, ended_at, harness_metadata, total_input_tokens, total_output_tokens, total_cost_usd, turn_count, derived_status, has_tool_error, has_git_activity FROM sessions
+SELECT id, org_id, auth_subject, harness_id, harness_session_id, name, cwd, harness_version, parent_session_id, started_at, last_seen_at, ended_at, harness_metadata, total_input_tokens, total_output_tokens, total_cost_usd, turn_count, derived_status, has_git_activity, tool_result_count, tool_error_count FROM sessions
 WHERE org_id = $1
   AND harness_id = $2
   AND harness_session_id = $3
@@ -50,14 +50,15 @@ func (q *Queries) GetSessionByNaturalKey(ctx context.Context, arg GetSessionByNa
 		&i.TotalCostUsd,
 		&i.TurnCount,
 		&i.DerivedStatus,
-		&i.HasToolError,
 		&i.HasGitActivity,
+		&i.ToolResultCount,
+		&i.ToolErrorCount,
 	)
 	return i, err
 }
 
 const getSessionRecord = `-- name: GetSessionRecord :one
-SELECT id, org_id, auth_subject, harness_id, harness_session_id, name, cwd, harness_version, parent_session_id, started_at, last_seen_at, ended_at, harness_metadata, total_input_tokens, total_output_tokens, total_cost_usd, turn_count, derived_status, has_tool_error, has_git_activity FROM sessions
+SELECT id, org_id, auth_subject, harness_id, harness_session_id, name, cwd, harness_version, parent_session_id, started_at, last_seen_at, ended_at, harness_metadata, total_input_tokens, total_output_tokens, total_cost_usd, turn_count, derived_status, has_git_activity, tool_result_count, tool_error_count FROM sessions
 WHERE org_id = $1 AND id = $2
 `
 
@@ -88,8 +89,9 @@ func (q *Queries) GetSessionRecord(ctx context.Context, arg GetSessionRecordPara
 		&i.TotalCostUsd,
 		&i.TurnCount,
 		&i.DerivedStatus,
-		&i.HasToolError,
 		&i.HasGitActivity,
+		&i.ToolResultCount,
+		&i.ToolErrorCount,
 	)
 	return i, err
 }
@@ -200,7 +202,7 @@ func (q *Queries) ListNodesBySession(ctx context.Context, sessionID pgtype.UUID)
 }
 
 const listSessionRecords = `-- name: ListSessionRecords :many
-SELECT id, org_id, auth_subject, harness_id, harness_session_id, name, cwd, harness_version, parent_session_id, started_at, last_seen_at, ended_at, harness_metadata, total_input_tokens, total_output_tokens, total_cost_usd, turn_count, derived_status, has_tool_error, has_git_activity FROM sessions
+SELECT id, org_id, auth_subject, harness_id, harness_session_id, name, cwd, harness_version, parent_session_id, started_at, last_seen_at, ended_at, harness_metadata, total_input_tokens, total_output_tokens, total_cost_usd, turn_count, derived_status, has_git_activity, tool_result_count, tool_error_count FROM sessions
 WHERE org_id = $1
   AND (
     $2::timestamptz IS NULL
@@ -253,8 +255,9 @@ func (q *Queries) ListSessionRecords(ctx context.Context, arg ListSessionRecords
 			&i.TotalCostUsd,
 			&i.TurnCount,
 			&i.DerivedStatus,
-			&i.HasToolError,
 			&i.HasGitActivity,
+			&i.ToolResultCount,
+			&i.ToolErrorCount,
 		); err != nil {
 			return nil, err
 		}
@@ -324,30 +327,33 @@ func (q *Queries) UpdateSessionCounters(ctx context.Context, arg UpdateSessionCo
 
 const updateSessionStatus = `-- name: UpdateSessionStatus :exec
 UPDATE sessions
-   SET has_tool_error   = $1,
-       has_git_activity = $2,
-       derived_status   = $3
- WHERE id = $4
+   SET has_git_activity  = $1,
+       tool_result_count = $2,
+       tool_error_count  = $3,
+       derived_status    = $4
+ WHERE id = $5
 `
 
 type UpdateSessionStatusParams struct {
-	HasToolError   bool
-	HasGitActivity bool
-	DerivedStatus  string
-	ID             pgtype.UUID
+	HasGitActivity  bool
+	ToolResultCount int32
+	ToolErrorCount  int32
+	DerivedStatus   string
+	ID              pgtype.UUID
 }
 
-// Persist the recomputed chain-aware status. has_tool_error and
-// has_git_activity are sticky signals OR-accumulated across all the
-// session's turns and stems — the caller computes the new values in Go
-// from the prior row state plus the current turn, so this query just
-// writes them. derived_status mirrors pkg/sessions.DetermineStatus over
-// those flags and the session's latest leaf. Called by ingest in the
-// same Tx as UpdateSessionCounters.
+// Persist the recomputed chain-aware status. has_git_activity is a sticky
+// flag and tool_result_count / tool_error_count are cumulative totals, all
+// accumulated across the session's turns and stems — the caller computes the
+// new values in Go from the prior row state plus this turn's new nodes, so
+// this query just writes them. derived_status mirrors
+// pkg/sessions.DetermineStatus over those signals and the session's latest
+// leaf. Called by ingest in the same Tx as UpdateSessionCounters.
 func (q *Queries) UpdateSessionStatus(ctx context.Context, arg UpdateSessionStatusParams) error {
 	_, err := q.db.Exec(ctx, updateSessionStatus,
-		arg.HasToolError,
 		arg.HasGitActivity,
+		arg.ToolResultCount,
+		arg.ToolErrorCount,
 		arg.DerivedStatus,
 		arg.ID,
 	)
@@ -390,7 +396,7 @@ SET last_seen_at     = $10,
     cwd              = COALESCE($7, sessions.cwd),
     harness_version  = COALESCE($8, sessions.harness_version),
     parent_session_id = COALESCE($9, sessions.parent_session_id)
-RETURNING id, org_id, auth_subject, harness_id, harness_session_id, name, cwd, harness_version, parent_session_id, started_at, last_seen_at, ended_at, harness_metadata, total_input_tokens, total_output_tokens, total_cost_usd, turn_count, derived_status, has_tool_error, has_git_activity
+RETURNING id, org_id, auth_subject, harness_id, harness_session_id, name, cwd, harness_version, parent_session_id, started_at, last_seen_at, ended_at, harness_metadata, total_input_tokens, total_output_tokens, total_cost_usd, turn_count, derived_status, has_git_activity, tool_result_count, tool_error_count
 `
 
 type UpsertSessionParams struct {
@@ -457,8 +463,9 @@ func (q *Queries) UpsertSession(ctx context.Context, arg UpsertSessionParams) (S
 		&i.TotalCostUsd,
 		&i.TurnCount,
 		&i.DerivedStatus,
-		&i.HasToolError,
 		&i.HasGitActivity,
+		&i.ToolResultCount,
+		&i.ToolErrorCount,
 	)
 	return i, err
 }

--- a/pkg/storage/postgres/gensqlc/sessions.sql.go
+++ b/pkg/storage/postgres/gensqlc/sessions.sql.go
@@ -12,7 +12,7 @@ import (
 )
 
 const getSessionByNaturalKey = `-- name: GetSessionByNaturalKey :one
-SELECT id, org_id, auth_subject, harness_id, harness_session_id, name, cwd, harness_version, parent_session_id, started_at, last_seen_at, ended_at, harness_metadata, total_input_tokens, total_output_tokens, total_cost_usd, turn_count FROM sessions
+SELECT id, org_id, auth_subject, harness_id, harness_session_id, name, cwd, harness_version, parent_session_id, started_at, last_seen_at, ended_at, harness_metadata, total_input_tokens, total_output_tokens, total_cost_usd, turn_count, derived_status, has_tool_error, has_git_activity FROM sessions
 WHERE org_id = $1
   AND harness_id = $2
   AND harness_session_id = $3
@@ -49,12 +49,15 @@ func (q *Queries) GetSessionByNaturalKey(ctx context.Context, arg GetSessionByNa
 		&i.TotalOutputTokens,
 		&i.TotalCostUsd,
 		&i.TurnCount,
+		&i.DerivedStatus,
+		&i.HasToolError,
+		&i.HasGitActivity,
 	)
 	return i, err
 }
 
 const getSessionRecord = `-- name: GetSessionRecord :one
-SELECT id, org_id, auth_subject, harness_id, harness_session_id, name, cwd, harness_version, parent_session_id, started_at, last_seen_at, ended_at, harness_metadata, total_input_tokens, total_output_tokens, total_cost_usd, turn_count FROM sessions
+SELECT id, org_id, auth_subject, harness_id, harness_session_id, name, cwd, harness_version, parent_session_id, started_at, last_seen_at, ended_at, harness_metadata, total_input_tokens, total_output_tokens, total_cost_usd, turn_count, derived_status, has_tool_error, has_git_activity FROM sessions
 WHERE org_id = $1 AND id = $2
 `
 
@@ -84,6 +87,9 @@ func (q *Queries) GetSessionRecord(ctx context.Context, arg GetSessionRecordPara
 		&i.TotalOutputTokens,
 		&i.TotalCostUsd,
 		&i.TurnCount,
+		&i.DerivedStatus,
+		&i.HasToolError,
+		&i.HasGitActivity,
 	)
 	return i, err
 }
@@ -194,7 +200,7 @@ func (q *Queries) ListNodesBySession(ctx context.Context, sessionID pgtype.UUID)
 }
 
 const listSessionRecords = `-- name: ListSessionRecords :many
-SELECT id, org_id, auth_subject, harness_id, harness_session_id, name, cwd, harness_version, parent_session_id, started_at, last_seen_at, ended_at, harness_metadata, total_input_tokens, total_output_tokens, total_cost_usd, turn_count FROM sessions
+SELECT id, org_id, auth_subject, harness_id, harness_session_id, name, cwd, harness_version, parent_session_id, started_at, last_seen_at, ended_at, harness_metadata, total_input_tokens, total_output_tokens, total_cost_usd, turn_count, derived_status, has_tool_error, has_git_activity FROM sessions
 WHERE org_id = $1
   AND (
     $2::timestamptz IS NULL
@@ -246,6 +252,9 @@ func (q *Queries) ListSessionRecords(ctx context.Context, arg ListSessionRecords
 			&i.TotalOutputTokens,
 			&i.TotalCostUsd,
 			&i.TurnCount,
+			&i.DerivedStatus,
+			&i.HasToolError,
+			&i.HasGitActivity,
 		); err != nil {
 			return nil, err
 		}
@@ -349,7 +358,7 @@ SET last_seen_at     = $10,
     cwd              = COALESCE($7, sessions.cwd),
     harness_version  = COALESCE($8, sessions.harness_version),
     parent_session_id = COALESCE($9, sessions.parent_session_id)
-RETURNING id, org_id, auth_subject, harness_id, harness_session_id, name, cwd, harness_version, parent_session_id, started_at, last_seen_at, ended_at, harness_metadata, total_input_tokens, total_output_tokens, total_cost_usd, turn_count
+RETURNING id, org_id, auth_subject, harness_id, harness_session_id, name, cwd, harness_version, parent_session_id, started_at, last_seen_at, ended_at, harness_metadata, total_input_tokens, total_output_tokens, total_cost_usd, turn_count, derived_status, has_tool_error, has_git_activity
 `
 
 type UpsertSessionParams struct {
@@ -415,6 +424,9 @@ func (q *Queries) UpsertSession(ctx context.Context, arg UpsertSessionParams) (S
 		&i.TotalOutputTokens,
 		&i.TotalCostUsd,
 		&i.TurnCount,
+		&i.DerivedStatus,
+		&i.HasToolError,
+		&i.HasGitActivity,
 	)
 	return i, err
 }

--- a/pkg/storage/postgres/gensqlc/sessions.sql.go
+++ b/pkg/storage/postgres/gensqlc/sessions.sql.go
@@ -322,6 +322,38 @@ func (q *Queries) UpdateSessionCounters(ctx context.Context, arg UpdateSessionCo
 	return err
 }
 
+const updateSessionStatus = `-- name: UpdateSessionStatus :exec
+UPDATE sessions
+   SET has_tool_error   = $1,
+       has_git_activity = $2,
+       derived_status   = $3
+ WHERE id = $4
+`
+
+type UpdateSessionStatusParams struct {
+	HasToolError   bool
+	HasGitActivity bool
+	DerivedStatus  string
+	ID             pgtype.UUID
+}
+
+// Persist the recomputed chain-aware status. has_tool_error and
+// has_git_activity are sticky signals OR-accumulated across all the
+// session's turns and stems — the caller computes the new values in Go
+// from the prior row state plus the current turn, so this query just
+// writes them. derived_status mirrors pkg/sessions.DetermineStatus over
+// those flags and the session's latest leaf. Called by ingest in the
+// same Tx as UpdateSessionCounters.
+func (q *Queries) UpdateSessionStatus(ctx context.Context, arg UpdateSessionStatusParams) error {
+	_, err := q.db.Exec(ctx, updateSessionStatus,
+		arg.HasToolError,
+		arg.HasGitActivity,
+		arg.DerivedStatus,
+		arg.ID,
+	)
+	return err
+}
+
 const upsertSession = `-- name: UpsertSession :one
 INSERT INTO sessions (
     id,

--- a/pkg/storage/postgres/postgres.go
+++ b/pkg/storage/postgres/postgres.go
@@ -329,6 +329,7 @@ func (d *Driver) CountSessions(ctx context.Context, opts storage.ListOpts) (stor
 
 	return storage.SessionStats{
 		SessionCount:        int(row.SessionCount),
+		StemCount:           int(row.StemCount),
 		TurnCount:           int(row.TurnCount),
 		RootCount:           int(row.RootCount),
 		CompletedCount:      int(row.CompletedCount),

--- a/pkg/storage/postgres/queries/aggregate_sessions.sql
+++ b/pkg/storage/postgres/queries/aggregate_sessions.sql
@@ -1,15 +1,19 @@
 -- name: AggregateSessions :one
 --
--- Single-pass aggregate that powers /v1/stats. All counts and SUMs apply
--- to the set of nodes matching the supplied per-node filters; a "session"
--- is identified as a leaf node (no child references it as parent_hash).
+-- Single-pass aggregate that powers /v1/stats. SUMs and turn/stem/root
+-- counts apply to the set of nodes matching the supplied per-node filters.
 --
--- completed_count is leaf-status-only: assistant role plus a terminal
--- stop_reason. It deliberately omits the chain-context overrides
--- (hasToolError / hasGitActivity) that pkg/sessions.DetermineStatus
--- applies, so a single SQL aggregate is sufficient. See StatsResponse
--- in api/v1_handlers.go for the rationale, and PCC-515 for the durable
--- chain-aware fix.
+-- session_count and completed_count are session-grained, keyed on the
+-- first-class sessions table via nodes.session_id (PCC-565):
+--   session_count   = distinct sessions touched by the matching nodes
+--   completed_count = distinct sessions whose denormalized derived_status
+--                     is 'completed' (chain-aware, computed at ingest by
+--                     pkg/sessions.DetermineStatus — PCC-515)
+-- Nodes with no session_id (legacy / non-session-tracked writers) are not
+-- counted as sessions; COUNT(DISTINCT session_id) ignores their NULLs.
+--
+-- stem_count is the leaf count (one per Merkle chain, matching /v1/stems) —
+-- the value session_count used to report before the sessions table existed.
 --
 -- total_duration_ns is wall-clock span MAX(created_at) - MIN(created_at)
 -- across the matching set, NOT SUM(nodes.total_duration_ns). The
@@ -34,8 +38,11 @@ WITH filtered AS (
         n.completion_tokens,
         n.cache_creation_input_tokens,
         n.cache_read_input_tokens,
+        n.session_id,
+        s.derived_status,
         EXISTS (SELECT 1 FROM nodes c WHERE c.parent_hash = n.hash) AS has_child
     FROM nodes n
+    LEFT JOIN sessions s ON s.id = n.session_id
     WHERE (sqlc.narg(project_filter)::text IS NULL OR n.project = sqlc.narg(project_filter)::text)
       AND (sqlc.narg(agent_filter)::text IS NULL OR n.agent_name = sqlc.narg(agent_filter)::text)
       AND (sqlc.narg(model_filter)::text IS NULL OR n.model = sqlc.narg(model_filter)::text)
@@ -45,12 +52,11 @@ WITH filtered AS (
 )
 SELECT
     COUNT(*)::bigint                                                         AS turn_count,
-    COUNT(*) FILTER (WHERE NOT has_child)::bigint                            AS session_count,
+    COUNT(DISTINCT session_id)::bigint                                       AS session_count,
+    COUNT(*) FILTER (WHERE NOT has_child)::bigint                            AS stem_count,
     COUNT(*) FILTER (WHERE parent_hash IS NULL)::bigint                      AS root_count,
-    COUNT(*) FILTER (
-        WHERE NOT has_child
-          AND LOWER(role) = 'assistant'
-          AND LOWER(stop_reason) IN ('stop', 'end_turn', 'end-turn', 'eos')
+    COUNT(DISTINCT session_id) FILTER (
+        WHERE derived_status = 'completed'
     )::bigint                                                                AS completed_count,
     COALESCE(SUM(prompt_tokens), 0)::bigint                                  AS input_tokens,
     COALESCE(SUM(completion_tokens), 0)::bigint                              AS output_tokens,

--- a/pkg/storage/postgres/queries/sessions.sql
+++ b/pkg/storage/postgres/queries/sessions.sql
@@ -106,17 +106,18 @@ UPDATE sessions
  WHERE id = sqlc.arg(id);
 
 -- name: UpdateSessionStatus :exec
--- Persist the recomputed chain-aware status. has_tool_error and
--- has_git_activity are sticky signals OR-accumulated across all the
--- session's turns and stems — the caller computes the new values in Go
--- from the prior row state plus the current turn, so this query just
--- writes them. derived_status mirrors pkg/sessions.DetermineStatus over
--- those flags and the session's latest leaf. Called by ingest in the
--- same Tx as UpdateSessionCounters.
+-- Persist the recomputed chain-aware status. has_git_activity is a sticky
+-- flag and tool_result_count / tool_error_count are cumulative totals, all
+-- accumulated across the session's turns and stems — the caller computes the
+-- new values in Go from the prior row state plus this turn's new nodes, so
+-- this query just writes them. derived_status mirrors
+-- pkg/sessions.DetermineStatus over those signals and the session's latest
+-- leaf. Called by ingest in the same Tx as UpdateSessionCounters.
 UPDATE sessions
-   SET has_tool_error   = sqlc.arg(has_tool_error),
-       has_git_activity = sqlc.arg(has_git_activity),
-       derived_status   = sqlc.arg(derived_status)
+   SET has_git_activity  = sqlc.arg(has_git_activity),
+       tool_result_count = sqlc.arg(tool_result_count),
+       tool_error_count  = sqlc.arg(tool_error_count),
+       derived_status    = sqlc.arg(derived_status)
  WHERE id = sqlc.arg(id);
 
 -- name: ListSessionRecords :many

--- a/pkg/storage/postgres/queries/sessions.sql
+++ b/pkg/storage/postgres/queries/sessions.sql
@@ -105,6 +105,20 @@ UPDATE sessions
        total_cost_usd      = total_cost_usd      + sqlc.arg(cost_usd_delta)
  WHERE id = sqlc.arg(id);
 
+-- name: UpdateSessionStatus :exec
+-- Persist the recomputed chain-aware status. has_tool_error and
+-- has_git_activity are sticky signals OR-accumulated across all the
+-- session's turns and stems — the caller computes the new values in Go
+-- from the prior row state plus the current turn, so this query just
+-- writes them. derived_status mirrors pkg/sessions.DetermineStatus over
+-- those flags and the session's latest leaf. Called by ingest in the
+-- same Tx as UpdateSessionCounters.
+UPDATE sessions
+   SET has_tool_error   = sqlc.arg(has_tool_error),
+       has_git_activity = sqlc.arg(has_git_activity),
+       derived_status   = sqlc.arg(derived_status)
+ WHERE id = sqlc.arg(id);
+
 -- name: ListSessionRecords :many
 -- Paginated list of sessions for an org ordered newest-first (last_seen_at DESC, id DESC).
 -- Pass NULL cursor values to start from the beginning.

--- a/pkg/storage/postgres/session_ingest.go
+++ b/pkg/storage/postgres/session_ingest.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"math/big"
 	"strconv"
 	"time"
@@ -172,35 +173,36 @@ func (d *Driver) IngestTurn(ctx context.Context, req storage.IngestTurnRequest) 
 		}
 		countersUpdated = true
 
-		// Recompute the session's chain-aware status. has_tool_error and
-		// has_git_activity are sticky across every turn and stem of the
-		// session, so OR this turn's signals into the row's prior state
-		// (sessionRow reflects the pre-turn values via UpsertSession's
-		// RETURNING). derived_status mirrors pkg/sessions.DetermineStatus
-		// over the accumulated flags and this turn's leaf — req.Nodes is
-		// validated root->leaf, so the last node is the leaf.
-		hasToolError, hasGitActivity := sessionRow.HasToolError, sessionRow.HasGitActivity
-		for _, n := range req.Nodes {
-			if hasToolError && hasGitActivity {
-				break
-			}
+		// Recompute the session's chain-aware status. has_git_activity is
+		// sticky and the tool-result counts are cumulative across every turn
+		// and stem; sessionRow carries the pre-turn totals via UpsertSession's
+		// RETURNING. We accumulate over newNodes (the genuinely new rows this
+		// turn) rather than req.Nodes — the full chain is re-sent every turn,
+		// so counting it would multiply the totals; OR-only booleans tolerated
+		// that, counts do not. derived_status mirrors
+		// pkg/sessions.DetermineStatus over the totals and this turn's leaf
+		// (req.Nodes is validated root->leaf, so the last node is the leaf).
+		hasGitActivity := sessionRow.HasGitActivity
+		toolResultCount := int(sessionRow.ToolResultCount)
+		toolErrorCount := int(sessionRow.ToolErrorCount)
+		for _, n := range newNodes {
 			if n == nil {
 				continue
 			}
-			if sessions.BlocksHaveToolError(n.Bucket.Content) {
-				hasToolError = true
-			}
-			if sessions.BlocksHaveGitActivity(n.Bucket.Content) {
+			if !hasGitActivity && sessions.BlocksHaveGitActivity(n.Bucket.Content) {
 				hasGitActivity = true
 			}
+			toolResultCount += sessions.CountToolResults(n.Bucket.Content)
+			toolErrorCount += sessions.CountToolResultErrors(n.Bucket.Content)
 		}
 		leaf := req.Nodes[len(req.Nodes)-1]
-		status := sessions.DetermineStatus(leaf, hasToolError, hasGitActivity)
+		status := sessions.DetermineStatus(leaf, hasGitActivity, toolResultCount, toolErrorCount)
 		if err := qtx.UpdateSessionStatus(ctx, gensqlc.UpdateSessionStatusParams{
-			HasToolError:   hasToolError,
-			HasGitActivity: hasGitActivity,
-			DerivedStatus:  status,
-			ID:             sessionRow.ID,
+			HasGitActivity:  hasGitActivity,
+			ToolResultCount: int32Count(toolResultCount),
+			ToolErrorCount:  int32Count(toolErrorCount),
+			DerivedStatus:   status,
+			ID:              sessionRow.ID,
 		}); err != nil {
 			return storage.IngestTurnResult{}, fmt.Errorf("update session status: %w", err)
 		}
@@ -513,6 +515,19 @@ func uuidString(id pgtype.UUID) string {
 // worker currently stubs CostUSD at 0 (no pricing table is wired in
 // this repo); this function exists so the path is ready when a
 // pricing lookup is added.
+// int32Count clamps a non-negative running count into int32 for the session
+// counter columns. Tool-result counts are realistically tiny; the clamp only
+// guards against a pathological overflow and keeps gosec G115 satisfied.
+func int32Count(n int) int32 {
+	if n < 0 {
+		return 0
+	}
+	if n > math.MaxInt32 {
+		return math.MaxInt32
+	}
+	return int32(n)
+}
+
 func numericFromFloat(v float64) (pgtype.Numeric, error) {
 	if v == 0 {
 		return pgtype.Numeric{Int: big.NewInt(0), Exp: 0, Valid: true}, nil

--- a/pkg/storage/postgres/session_ingest.go
+++ b/pkg/storage/postgres/session_ingest.go
@@ -171,6 +171,39 @@ func (d *Driver) IngestTurn(ctx context.Context, req storage.IngestTurnRequest) 
 			return storage.IngestTurnResult{}, fmt.Errorf("update session counters: %w", err)
 		}
 		countersUpdated = true
+
+		// Recompute the session's chain-aware status. has_tool_error and
+		// has_git_activity are sticky across every turn and stem of the
+		// session, so OR this turn's signals into the row's prior state
+		// (sessionRow reflects the pre-turn values via UpsertSession's
+		// RETURNING). derived_status mirrors pkg/sessions.DetermineStatus
+		// over the accumulated flags and this turn's leaf — req.Nodes is
+		// validated root->leaf, so the last node is the leaf.
+		hasToolError, hasGitActivity := sessionRow.HasToolError, sessionRow.HasGitActivity
+		for _, n := range req.Nodes {
+			if hasToolError && hasGitActivity {
+				break
+			}
+			if n == nil {
+				continue
+			}
+			if sessions.BlocksHaveToolError(n.Bucket.Content) {
+				hasToolError = true
+			}
+			if sessions.BlocksHaveGitActivity(n.Bucket.Content) {
+				hasGitActivity = true
+			}
+		}
+		leaf := req.Nodes[len(req.Nodes)-1]
+		status := sessions.DetermineStatus(leaf, hasToolError, hasGitActivity)
+		if err := qtx.UpdateSessionStatus(ctx, gensqlc.UpdateSessionStatusParams{
+			HasToolError:   hasToolError,
+			HasGitActivity: hasGitActivity,
+			DerivedStatus:  status,
+			ID:             sessionRow.ID,
+		}); err != nil {
+			return storage.IngestTurnResult{}, fmt.Errorf("update session status: %w", err)
+		}
 	}
 
 	if err := tx.Commit(ctx); err != nil {

--- a/pkg/storage/postgres/session_ingest_test.go
+++ b/pkg/storage/postgres/session_ingest_test.go
@@ -134,6 +134,66 @@ var _ = Describe("Driver.IngestTurn", func() {
 		}
 	})
 
+	It("derives status 'completed' for an assistant leaf with a terminal stop_reason", func() {
+		orgID := newTestOrgID()
+		env := &sessions.IngestEnvelope{OrgID: orgID, AuthSubject: "s", HarnessID: "claude", HarnessSessionID: "hs-complete"}
+
+		_, err := ingester.IngestTurn(ctx, storage.IngestTurnRequest{Session: env, Nodes: sessionFixture("done")})
+		Expect(err).NotTo(HaveOccurred())
+
+		var status string
+		var hasErr, hasGit bool
+		pg := driver.(*postgres.Driver)
+		Expect(pg.DB().QueryRow(ctx, `SELECT derived_status, has_tool_error, has_git_activity FROM sessions WHERE org_id=$1 AND harness_id=$2 AND harness_session_id=$3`,
+			mustUUID(orgID), "claude", "hs-complete").Scan(&status, &hasErr, &hasGit)).To(Succeed())
+		Expect(status).To(Equal(sessions.StatusCompleted))
+		Expect(hasErr).To(BeFalse())
+		Expect(hasGit).To(BeFalse())
+	})
+
+	It("derives 'completed' via git activity even when the leaf is a non-terminal tool_result (PCC-515)", func() {
+		orgID := newTestOrgID()
+		env := &sessions.IngestEnvelope{OrgID: orgID, AuthSubject: "s", HarnessID: "claude", HarnessSessionID: "hs-git"}
+
+		user := merkle.NewNode(merkle.Bucket{Type: "message", Role: "user", Content: []llm.ContentBlock{{Type: "text", Text: "ship it"}}}, nil)
+		asst := merkle.NewNode(merkle.Bucket{Type: "message", Role: "assistant", Content: []llm.ContentBlock{{Type: "tool_use", ToolName: "Bash", ToolInput: map[string]any{"command": "git commit -m wip"}}}}, user, merkle.NodeOptions{StopReason: "tool_use"})
+		// Leaf is the tool_result (user role, no terminal stop_reason): the
+		// leaf-only SQL classifier would call this abandoned, while the
+		// chain-aware classifier sees the git commit and returns completed.
+		toolRes := merkle.NewNode(merkle.Bucket{Type: "message", Role: "user", Content: []llm.ContentBlock{{Type: "tool_result", ToolOutput: "ok"}}}, asst)
+
+		_, err := ingester.IngestTurn(ctx, storage.IngestTurnRequest{Session: env, Nodes: []*merkle.Node{user, asst, toolRes}})
+		Expect(err).NotTo(HaveOccurred())
+
+		var status string
+		var hasGit bool
+		pg := driver.(*postgres.Driver)
+		Expect(pg.DB().QueryRow(ctx, `SELECT derived_status, has_git_activity FROM sessions WHERE org_id=$1 AND harness_id=$2 AND harness_session_id=$3`,
+			mustUUID(orgID), "claude", "hs-git").Scan(&status, &hasGit)).To(Succeed())
+		Expect(status).To(Equal(sessions.StatusCompleted))
+		Expect(hasGit).To(BeTrue())
+	})
+
+	It("derives 'failed' when any turn carries a tool_result error", func() {
+		orgID := newTestOrgID()
+		env := &sessions.IngestEnvelope{OrgID: orgID, AuthSubject: "s", HarnessID: "claude", HarnessSessionID: "hs-err"}
+
+		user := merkle.NewNode(merkle.Bucket{Type: "message", Role: "user", Content: []llm.ContentBlock{{Type: "text", Text: "do it"}}}, nil)
+		asst := merkle.NewNode(merkle.Bucket{Type: "message", Role: "assistant", Content: []llm.ContentBlock{{Type: "tool_use", ToolName: "Bash", ToolInput: map[string]any{"command": "ls"}}}}, user, merkle.NodeOptions{StopReason: "tool_use"})
+		toolRes := merkle.NewNode(merkle.Bucket{Type: "message", Role: "user", Content: []llm.ContentBlock{{Type: "tool_result", IsError: true, ToolOutput: "boom"}}}, asst)
+
+		_, err := ingester.IngestTurn(ctx, storage.IngestTurnRequest{Session: env, Nodes: []*merkle.Node{user, asst, toolRes}})
+		Expect(err).NotTo(HaveOccurred())
+
+		var status string
+		var hasErr bool
+		pg := driver.(*postgres.Driver)
+		Expect(pg.DB().QueryRow(ctx, `SELECT derived_status, has_tool_error FROM sessions WHERE org_id=$1 AND harness_id=$2 AND harness_session_id=$3`,
+			mustUUID(orgID), "claude", "hs-err").Scan(&status, &hasErr)).To(Succeed())
+		Expect(status).To(Equal(sessions.StatusFailed))
+		Expect(hasErr).To(BeTrue())
+	})
+
 	It("is idempotent across a retried envelope: one row, one set of counter increments", func() {
 		orgID := newTestOrgID()
 		envelope := &sessions.IngestEnvelope{

--- a/pkg/storage/postgres/session_ingest_test.go
+++ b/pkg/storage/postgres/session_ingest_test.go
@@ -142,12 +142,13 @@ var _ = Describe("Driver.IngestTurn", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		var status string
-		var hasErr, hasGit bool
+		var toolErrors int
+		var hasGit bool
 		pg := driver.(*postgres.Driver)
-		Expect(pg.DB().QueryRow(ctx, `SELECT derived_status, has_tool_error, has_git_activity FROM sessions WHERE org_id=$1 AND harness_id=$2 AND harness_session_id=$3`,
-			mustUUID(orgID), "claude", "hs-complete").Scan(&status, &hasErr, &hasGit)).To(Succeed())
+		Expect(pg.DB().QueryRow(ctx, `SELECT derived_status, tool_error_count, has_git_activity FROM sessions WHERE org_id=$1 AND harness_id=$2 AND harness_session_id=$3`,
+			mustUUID(orgID), "claude", "hs-complete").Scan(&status, &toolErrors, &hasGit)).To(Succeed())
 		Expect(status).To(Equal(sessions.StatusCompleted))
-		Expect(hasErr).To(BeFalse())
+		Expect(toolErrors).To(Equal(0))
 		Expect(hasGit).To(BeFalse())
 	})
 
@@ -174,7 +175,7 @@ var _ = Describe("Driver.IngestTurn", func() {
 		Expect(hasGit).To(BeTrue())
 	})
 
-	It("derives 'failed' when any turn carries a tool_result error", func() {
+	It("derives 'failed' when the session ends on an unrecovered tool_result error", func() {
 		orgID := newTestOrgID()
 		env := &sessions.IngestEnvelope{OrgID: orgID, AuthSubject: "s", HarnessID: "claude", HarnessSessionID: "hs-err"}
 
@@ -186,12 +187,12 @@ var _ = Describe("Driver.IngestTurn", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		var status string
-		var hasErr bool
+		var toolErrors int
 		pg := driver.(*postgres.Driver)
-		Expect(pg.DB().QueryRow(ctx, `SELECT derived_status, has_tool_error FROM sessions WHERE org_id=$1 AND harness_id=$2 AND harness_session_id=$3`,
-			mustUUID(orgID), "claude", "hs-err").Scan(&status, &hasErr)).To(Succeed())
+		Expect(pg.DB().QueryRow(ctx, `SELECT derived_status, tool_error_count FROM sessions WHERE org_id=$1 AND harness_id=$2 AND harness_session_id=$3`,
+			mustUUID(orgID), "claude", "hs-err").Scan(&status, &toolErrors)).To(Succeed())
 		Expect(status).To(Equal(sessions.StatusFailed))
-		Expect(hasErr).To(BeTrue())
+		Expect(toolErrors).To(Equal(1))
 	})
 
 	It("backfills derived_status for session rows that predate the computation", func() {
@@ -203,7 +204,7 @@ var _ = Describe("Driver.IngestTurn", func() {
 		pg := driver.(*postgres.Driver)
 		// Simulate a pre-feature row: blank out the computed status so the
 		// backfill has something to recover.
-		_, err = pg.DB().Exec(ctx, `UPDATE sessions SET derived_status='unknown', has_tool_error=false, has_git_activity=false WHERE org_id=$1 AND harness_id=$2 AND harness_session_id=$3`,
+		_, err = pg.DB().Exec(ctx, `UPDATE sessions SET derived_status='unknown', has_git_activity=false, tool_result_count=0, tool_error_count=0 WHERE org_id=$1 AND harness_id=$2 AND harness_session_id=$3`,
 			mustUUID(orgID), "claude", "hs-backfill")
 		Expect(err).NotTo(HaveOccurred())
 

--- a/pkg/storage/postgres/session_ingest_test.go
+++ b/pkg/storage/postgres/session_ingest_test.go
@@ -194,6 +194,31 @@ var _ = Describe("Driver.IngestTurn", func() {
 		Expect(hasErr).To(BeTrue())
 	})
 
+	It("backfills derived_status for session rows that predate the computation", func() {
+		orgID := newTestOrgID()
+		env := &sessions.IngestEnvelope{OrgID: orgID, AuthSubject: "s", HarnessID: "claude", HarnessSessionID: "hs-backfill"}
+		_, err := ingester.IngestTurn(ctx, storage.IngestTurnRequest{Session: env, Nodes: sessionFixture("backfill me")})
+		Expect(err).NotTo(HaveOccurred())
+
+		pg := driver.(*postgres.Driver)
+		// Simulate a pre-feature row: blank out the computed status so the
+		// backfill has something to recover.
+		_, err = pg.DB().Exec(ctx, `UPDATE sessions SET derived_status='unknown', has_tool_error=false, has_git_activity=false WHERE org_id=$1 AND harness_id=$2 AND harness_session_id=$3`,
+			mustUUID(orgID), "claude", "hs-backfill")
+		Expect(err).NotTo(HaveOccurred())
+
+		bf, ok := driver.(storage.SessionStatusBackfiller)
+		Expect(ok).To(BeTrue(), "postgres driver must satisfy SessionStatusBackfiller")
+		res, err := bf.BackfillSessionStatus(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Updated).To(BeNumerically(">=", 1))
+
+		var status string
+		Expect(pg.DB().QueryRow(ctx, `SELECT derived_status FROM sessions WHERE org_id=$1 AND harness_id=$2 AND harness_session_id=$3`,
+			mustUUID(orgID), "claude", "hs-backfill").Scan(&status)).To(Succeed())
+		Expect(status).To(Equal(sessions.StatusCompleted))
+	})
+
 	It("is idempotent across a retried envelope: one row, one set of counter increments", func() {
 		orgID := newTestOrgID()
 		envelope := &sessions.IngestEnvelope{

--- a/pkg/storage/postgres/session_reads.go
+++ b/pkg/storage/postgres/session_reads.go
@@ -167,6 +167,7 @@ func sessionRecordFromRow(row gensqlc.Session) storage.SessionRecord {
 		TotalInputTokens:  row.TotalInputTokens,
 		TotalOutputTokens: row.TotalOutputTokens,
 		TurnCount:         int(row.TurnCount),
+		DerivedStatus:     row.DerivedStatus,
 	}
 	if row.Name.Valid {
 		s.Name = row.Name.String

--- a/pkg/storage/postgres/session_status_backfill.go
+++ b/pkg/storage/postgres/session_status_backfill.go
@@ -1,0 +1,103 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/papercomputeco/tapes/pkg/sessions"
+	"github.com/papercomputeco/tapes/pkg/storage"
+	"github.com/papercomputeco/tapes/pkg/storage/postgres/gensqlc"
+)
+
+// Compile-time guarantee the Postgres driver offers the status-backfill
+// capability so api can type-assert it without depending on this package.
+var _ storage.SessionStatusBackfiller = (*Driver)(nil)
+
+// BackfillSessionStatus recomputes derived_status (and the sticky
+// has_tool_error / has_git_activity flags) for every session by walking its
+// nodes with the same signal helpers ingest uses (sessions.BlocksHaveToolError
+// / BlocksHaveGitActivity over every node, sessions.DetermineStatus over the
+// chronologically-last node as the leaf). It exists for rows that predate the
+// ingest-time computation; live ingest keeps status current on its own.
+//
+// Idempotent and safe to run online: a concurrent live turn re-runs the same
+// UpdateSessionStatus path, so the worst case is a redundant equal write.
+// Each session's recompute is its own statement; there is no global lock.
+func (d *Driver) BackfillSessionStatus(ctx context.Context) (storage.BackfillSessionStatusResult, error) {
+	if d == nil || d.conn == nil {
+		return storage.BackfillSessionStatusResult{}, errors.New("postgres driver not open")
+	}
+
+	rows, err := d.conn.Query(ctx, `SELECT id FROM sessions`)
+	if err != nil {
+		return storage.BackfillSessionStatusResult{}, fmt.Errorf("list sessions: %w", err)
+	}
+	var ids []pgtype.UUID
+	for rows.Next() {
+		var id pgtype.UUID
+		if err := rows.Scan(&id); err != nil {
+			rows.Close()
+			return storage.BackfillSessionStatusResult{}, fmt.Errorf("scan session id: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return storage.BackfillSessionStatusResult{}, fmt.Errorf("iterate sessions: %w", err)
+	}
+
+	result := storage.BackfillSessionStatusResult{}
+	for _, id := range ids {
+		result.Scanned++
+
+		nodeRows, err := d.q.ListNodesBySession(ctx, id)
+		if err != nil {
+			return result, fmt.Errorf("load session %s nodes: %w", uuidString(id), err)
+		}
+		if len(nodeRows) == 0 {
+			// No nodes attributed yet (e.g. a fork-parent placeholder):
+			// nothing to classify, leave the default 'unknown'.
+			continue
+		}
+		nodes, err := merkleNodesFromRows(nodeRows)
+		if err != nil {
+			return result, fmt.Errorf("rebuild session %s nodes: %w", uuidString(id), err)
+		}
+
+		hasToolError, hasGitActivity := false, false
+		for _, n := range nodes {
+			if hasToolError && hasGitActivity {
+				break
+			}
+			if n == nil {
+				continue
+			}
+			if sessions.BlocksHaveToolError(n.Bucket.Content) {
+				hasToolError = true
+			}
+			if sessions.BlocksHaveGitActivity(n.Bucket.Content) {
+				hasGitActivity = true
+			}
+		}
+		// ListNodesBySession orders by created_at ASC, so the last node is
+		// the most recently captured — the same "latest leaf" the per-turn
+		// ingest path classifies on.
+		leaf := nodes[len(nodes)-1]
+		status := sessions.DetermineStatus(leaf, hasToolError, hasGitActivity)
+
+		if err := d.q.UpdateSessionStatus(ctx, gensqlc.UpdateSessionStatusParams{
+			HasToolError:   hasToolError,
+			HasGitActivity: hasGitActivity,
+			DerivedStatus:  status,
+			ID:             id,
+		}); err != nil {
+			return result, fmt.Errorf("update session %s status: %w", uuidString(id), err)
+		}
+		result.Updated++
+	}
+
+	return result, nil
+}

--- a/pkg/storage/postgres/session_status_backfill.go
+++ b/pkg/storage/postgres/session_status_backfill.go
@@ -16,14 +16,20 @@ import (
 // capability so api can type-assert it without depending on this package.
 var _ storage.SessionStatusBackfiller = (*Driver)(nil)
 
-// BackfillSessionStatus recomputes derived_status (and the sticky
-// has_tool_error / has_git_activity flags) for every session by walking its
-// nodes with the same signal helpers ingest uses (sessions.BlocksHaveToolError
-// / BlocksHaveGitActivity over every node, sessions.DetermineStatus over the
-// chronologically-last node as the leaf). It exists for rows that predate the
-// ingest-time computation; live ingest keeps status current on its own.
+// BackfillSessionStatus recomputes derived_status (plus the sticky
+// has_git_activity flag and tool_result_count / tool_error_count) for sessions
+// still at the default 'unknown' status — the rows that predate the
+// ingest-time computation. It walks each session's nodes with the same signal
+// helpers ingest uses (sessions.CountToolResults / CountToolResultErrors /
+// BlocksHaveGitActivity over every node, sessions.DetermineStatus over the
+// chronologically-last node as the leaf). Live ingest keeps status current on
+// its own.
 //
-// Idempotent and safe to run online: a concurrent live turn re-runs the same
+// Scoping to 'unknown' keeps re-runs cheap and idempotent — already-classified
+// rows are skipped. Re-classifying already-decided rows after a classifier
+// change is intentionally out of scope for this endpoint.
+//
+// Safe to run online: a concurrent live turn re-runs the same
 // UpdateSessionStatus path, so the worst case is a redundant equal write.
 // Each session's recompute is its own statement; there is no global lock.
 func (d *Driver) BackfillSessionStatus(ctx context.Context) (storage.BackfillSessionStatusResult, error) {
@@ -31,7 +37,7 @@ func (d *Driver) BackfillSessionStatus(ctx context.Context) (storage.BackfillSes
 		return storage.BackfillSessionStatusResult{}, errors.New("postgres driver not open")
 	}
 
-	rows, err := d.conn.Query(ctx, `SELECT id FROM sessions`)
+	rows, err := d.conn.Query(ctx, `SELECT id FROM sessions WHERE derived_status = 'unknown'`)
 	if err != nil {
 		return storage.BackfillSessionStatusResult{}, fmt.Errorf("list sessions: %w", err)
 	}
@@ -67,32 +73,33 @@ func (d *Driver) BackfillSessionStatus(ctx context.Context) (storage.BackfillSes
 			return result, fmt.Errorf("rebuild session %s nodes: %w", uuidString(id), err)
 		}
 
-		hasToolError, hasGitActivity := false, false
+		// ListNodesBySession returns every node once, so unlike the ingest
+		// path (which sees the full chain re-sent each turn) we can count
+		// straight over the set.
+		hasGitActivity := false
+		toolResultCount, toolErrorCount := 0, 0
 		for _, n := range nodes {
-			if hasToolError && hasGitActivity {
-				break
-			}
 			if n == nil {
 				continue
 			}
-			if sessions.BlocksHaveToolError(n.Bucket.Content) {
-				hasToolError = true
-			}
-			if sessions.BlocksHaveGitActivity(n.Bucket.Content) {
+			if !hasGitActivity && sessions.BlocksHaveGitActivity(n.Bucket.Content) {
 				hasGitActivity = true
 			}
+			toolResultCount += sessions.CountToolResults(n.Bucket.Content)
+			toolErrorCount += sessions.CountToolResultErrors(n.Bucket.Content)
 		}
 		// ListNodesBySession orders by created_at ASC, so the last node is
 		// the most recently captured — the same "latest leaf" the per-turn
 		// ingest path classifies on.
 		leaf := nodes[len(nodes)-1]
-		status := sessions.DetermineStatus(leaf, hasToolError, hasGitActivity)
+		status := sessions.DetermineStatus(leaf, hasGitActivity, toolResultCount, toolErrorCount)
 
 		if err := d.q.UpdateSessionStatus(ctx, gensqlc.UpdateSessionStatusParams{
-			HasToolError:   hasToolError,
-			HasGitActivity: hasGitActivity,
-			DerivedStatus:  status,
-			ID:             id,
+			HasGitActivity:  hasGitActivity,
+			ToolResultCount: int32Count(toolResultCount),
+			ToolErrorCount:  int32Count(toolErrorCount),
+			DerivedStatus:   status,
+			ID:              id,
 		}); err != nil {
 			return result, fmt.Errorf("update session %s status: %w", uuidString(id), err)
 		}

--- a/pkg/storage/session_ingester.go
+++ b/pkg/storage/session_ingester.go
@@ -114,11 +114,11 @@ type SessionBackfillResult struct {
 }
 
 // SessionStatusBackfiller is an optional Driver capability that recomputes
-// the denormalized derived_status (and the sticky has_tool_error /
-// has_git_activity flags) for sessions whose rows predate the ingest-time
-// status computation. It walks each session's nodes with the same signal
-// helpers ingest uses, so a backfilled store matches what live ingest would
-// have written. Idempotent and safe to run online.
+// the denormalized derived_status (and the sticky has_git_activity flag,
+// tool_result_count, and tool_error_count) for sessions whose rows predate
+// the ingest-time status computation. It walks each session's nodes with the
+// same signal helpers ingest uses, so a backfilled store matches what live
+// ingest would have written. Idempotent and safe to run online.
 type SessionStatusBackfiller interface {
 	BackfillSessionStatus(ctx context.Context) (BackfillSessionStatusResult, error)
 }

--- a/pkg/storage/session_ingester.go
+++ b/pkg/storage/session_ingester.go
@@ -112,3 +112,20 @@ type SessionBackfillResult struct {
 	SessionID   string
 	NodesLinked int
 }
+
+// SessionStatusBackfiller is an optional Driver capability that recomputes
+// the denormalized derived_status (and the sticky has_tool_error /
+// has_git_activity flags) for sessions whose rows predate the ingest-time
+// status computation. It walks each session's nodes with the same signal
+// helpers ingest uses, so a backfilled store matches what live ingest would
+// have written. Idempotent and safe to run online.
+type SessionStatusBackfiller interface {
+	BackfillSessionStatus(ctx context.Context) (BackfillSessionStatusResult, error)
+}
+
+type BackfillSessionStatusResult struct {
+	// Scanned is the number of session rows visited.
+	Scanned int
+	// Updated is the number whose status row was (re)written.
+	Updated int
+}

--- a/pkg/storage/session_record.go
+++ b/pkg/storage/session_record.go
@@ -22,5 +22,9 @@ type SessionRecord struct {
 	TotalOutputTokens int64
 	TotalCostUsd      float64
 	TurnCount         int
-	Preview           string // first user turn text, truncated; empty when unavailable
+	// DerivedStatus is the chain-aware session status (completed / failed /
+	// abandoned / unknown), denormalized at ingest. 'unknown' until the first
+	// turn lands or, for pre-feature rows, until the status backfill runs.
+	DerivedStatus string
+	Preview       string // first user turn text, truncated; empty when unavailable
 }

--- a/pkg/storage/storagetest/conformance.go
+++ b/pkg/storage/storagetest/conformance.go
@@ -163,9 +163,14 @@ func RunListSessionsSpecs(label string, makeDriver DriverFactory) bool {
 			ginkgo.It("CountSessions reports correct totals", func() {
 				stats, err := driver.CountSessions(ctx, storage.ListOpts{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				gomega.Expect(stats.SessionCount).To(gomega.Equal(3)) // 3 leaves
-				gomega.Expect(stats.TurnCount).To(gomega.Equal(4))    // root + 3 leaves
+				gomega.Expect(stats.StemCount).To(gomega.Equal(3)) // 3 leaves
+				gomega.Expect(stats.TurnCount).To(gomega.Equal(4)) // root + 3 leaves
 				gomega.Expect(stats.RootCount).To(gomega.Equal(1))
+				// Nodes were Put directly (no session envelope), so there are
+				// no first-class sessions to count — session-grained metrics
+				// are 0 while StemCount carries the leaf-based total.
+				gomega.Expect(stats.SessionCount).To(gomega.Equal(0))
+				gomega.Expect(stats.CompletedCount).To(gomega.Equal(0))
 			})
 
 			ginkgo.It("CountSessions respects filters", func() {
@@ -175,9 +180,10 @@ func RunListSessionsSpecs(label string, makeDriver DriverFactory) bool {
 				// - 3 nodes have project=tapes (root, leafA, leafC)
 				// - 2 of those are leaves (leafA, leafC)
 				// - 1 of those is a root
-				gomega.Expect(stats.SessionCount).To(gomega.Equal(2))
+				gomega.Expect(stats.StemCount).To(gomega.Equal(2))
 				gomega.Expect(stats.TurnCount).To(gomega.Equal(3))
 				gomega.Expect(stats.RootCount).To(gomega.Equal(1))
+				gomega.Expect(stats.SessionCount).To(gomega.Equal(0))
 			})
 
 			ginkgo.It("rejects an invalid cursor", func() {


### PR DESCRIPTION
## Summary
- `/v1/stats` `session_count` now counts distinct first-class sessions instead of one row per Merkle leaf (which over-counted); adds `stem_count` for the leaf/chain total.
- Adds a per-session `derived_status` (completed / failed / abandoned / unknown), computed at ingest and surfaced on `/v1/sessions`. `completed_count` is now session-grained and chain-aware.
- A session is `failed` only when it ends on an unrecovered tool error or >50% of its tool results errored — a single recovered mid-run error no longer marks it failed.
- One-shot `/v1/admin/backfill/session-status` recomputes status for existing rows.

## Test plan
- [x] `make test` green (unit + Postgres integration + conformance)

Fixes PCC-515
Part of PCC-565
Part of PCC-621