### PR TITLE
🧹 chore: (pricing) add Claude Fable 5 and strip the [1m] context marker

### DIFF
--- a/pkg/sessions/pricing.go
+++ b/pkg/sessions/pricing.go
@@ -10,7 +10,7 @@ import (
 
 // DefaultPricing returns hardcoded pricing per million tokens for supported models.
 //
-// Last verified: 2026-05-29
+// Last verified: 2026-06-09
 // Sources:
 //   - Anthropic: https://platform.claude.com/docs/en/about-claude/pricing
 //   - OpenAI:    https://platform.openai.com/docs/pricing
@@ -23,6 +23,7 @@ import (
 func DefaultPricing() PricingTable {
 	return PricingTable{
 		// Anthropic
+		"claude-fable-5":    {Input: 10.00, Output: 50.00, CacheRead: 1.00, CacheWrite: 12.50},
 		"claude-opus-4.8":   {Input: 5.00, Output: 25.00, CacheRead: 0.50, CacheWrite: 6.25},
 		"claude-opus-4.7":   {Input: 5.00, Output: 25.00, CacheRead: 0.50, CacheWrite: 6.25},
 		"claude-opus-4.6":   {Input: 5.00, Output: 25.00, CacheRead: 0.50, CacheWrite: 6.25},
@@ -131,6 +132,10 @@ func NormalizeModel(model string) string {
 	if normalized == "" {
 		return normalized
 	}
+
+	// Strip the Anthropic 1M-context marker: claude-fable-5[1m] prices
+	// the same as claude-fable-5 (no long-context premium).
+	normalized = strings.TrimSuffix(normalized, "[1m]")
 
 	// Strip Anthropic-style date suffix: -YYYYMMDD (8 consecutive digits)
 	if idx := strings.LastIndex(normalized, "-"); idx != -1 {

--- a/pkg/sessions/summary_test.go
+++ b/pkg/sessions/summary_test.go
@@ -267,6 +267,11 @@ var _ = Describe("NormalizeModel", func() {
 	It("strips the Anthropic 1M-context marker", func() {
 		Expect(sessions.NormalizeModel("claude-fable-5[1m]")).To(Equal("claude-fable-5"))
 		Expect(sessions.NormalizeModel("claude-opus-4-8[1m]")).To(Equal("claude-opus-4.8"))
+		// Dated + marker: Anthropic puts the [1m] marker at the very end
+		// (claude-sonnet-4-5-20250929[1m]), so the marker must be stripped
+		// BEFORE the date suffix — otherwise the trailing "[1m]" hides the
+		// date from the -YYYYMMDD stripper.
+		Expect(sessions.NormalizeModel("claude-sonnet-4-5-20250929[1m]")).To(Equal("claude-sonnet-4.5"))
 	})
 	It("resolves claude-fable-5 pricing in bare and 1M-context form", func() {
 		// claude-fable-5 has no minor version, so the dotted-key round-trip

--- a/pkg/sessions/summary_test.go
+++ b/pkg/sessions/summary_test.go
@@ -264,6 +264,21 @@ var _ = Describe("NormalizeModel", func() {
 	It("strips OpenAI-style date suffix", func() {
 		Expect(sessions.NormalizeModel("gpt-4o-2024-08-06")).To(Equal("gpt-4o"))
 	})
+	It("strips the Anthropic 1M-context marker", func() {
+		Expect(sessions.NormalizeModel("claude-fable-5[1m]")).To(Equal("claude-fable-5"))
+		Expect(sessions.NormalizeModel("claude-opus-4-8[1m]")).To(Equal("claude-opus-4.8"))
+	})
+	It("resolves claude-fable-5 pricing in bare and 1M-context form", func() {
+		// claude-fable-5 has no minor version, so the dotted-key round-trip
+		// loop below skips it — pin its lookup explicitly.
+		pricing := sessions.DefaultPricing()
+		for _, api := range []string{"claude-fable-5", "claude-fable-5[1m]"} {
+			price, ok := sessions.PricingForModel(pricing, api)
+			Expect(ok).To(BeTrue(), "PricingForModel(%q)", api)
+			Expect(price.Input).To(BeNumerically("==", 10.00), "input $/MTok for %q", api)
+			Expect(price.Output).To(BeNumerically("==", 50.00), "output $/MTok for %q", api)
+		}
+	})
 	It("every Anthropic pricing key is reachable from its canonical API form", func() {
 		// Guards against forgetting the matching `-N-M` → `-N.M` rewrite when
 		// adding a new Anthropic row to DefaultPricing. The dated variant


### PR DESCRIPTION
Stacked on #215 (rebase onto main once that merges).

Fable 5 is GA but missing from `DefaultPricing()`, so sessions on `claude-fable-5*` report $0.00 cost.

- Add `claude-fable-5` at $10 input / $50 output / $1.00 cache read / $12.50 5min cache write per MTok (Anthropic published pricing).
- Strip the `[1m]` 1M-context marker in `NormalizeModel` so `claude-fable-5[1m]` / `claude-opus-4-8[1m]` resolve to their base pricing keys (1M context is standard pricing, no premium). Without this, 1M-context traffic also prices at $0.00 today.
- Pin the `claude-fable-5` lookup explicitly in `summary_test.go` since the dotted-key round-trip loop skips keys without a minor version.

Related to PCC-663.

🤖 Generated with [Claude Code](https://claude.com/claude-code)