### PR TITLE
✨ feat: default cloud embeddings to text-embedding-3-large at 1024 dims

### DIFF
--- a/cmd/tapes/init/init_test.go
+++ b/cmd/tapes/init/init_test.go
@@ -140,8 +140,8 @@ var _ = Describe("Init command execution", func() {
 			Expect(cfg.API.Listen).To(Equal(":8081"))
 			Expect(cfg.Embedding.Provider).To(Equal("openai"))
 			Expect(cfg.Embedding.Target).To(Equal("https://api.openai.com"))
-			Expect(cfg.Embedding.Model).To(Equal("text-embedding-3-small"))
-			Expect(cfg.Embedding.Dimensions).To(Equal(uint(1536)))
+			Expect(cfg.Embedding.Model).To(Equal("text-embedding-3-large"))
+			Expect(cfg.Embedding.Dimensions).To(Equal(uint(1024)))
 		})
 
 		It("creates config.toml with anthropic preset", func() {

--- a/cmd/tapes/serve/api/api.go
+++ b/cmd/tapes/serve/api/api.go
@@ -45,7 +45,7 @@ var apiFlags = config.FlagSet{
 	config.FlagVectorStoreTgt:      {Name: "vector-store-target", ViperKey: "vector_store.target", Description: "pgvector connection string (defaults to storage.postgres_dsn when unset)"},
 	config.FlagEmbeddingProv:       {Name: "embedding-provider", ViperKey: "embedding.provider", Description: "Embedding provider type (e.g., ollama, openai)"},
 	config.FlagEmbeddingTgt:        {Name: "embedding-target", ViperKey: "embedding.target", Description: "Embedding provider URL"},
-	config.FlagEmbeddingModel:      {Name: "embedding-model", ViperKey: "embedding.model", Description: "Embedding model name (e.g., text-embedding-3-small)"},
+	config.FlagEmbeddingModel:      {Name: "embedding-model", ViperKey: "embedding.model", Description: "Embedding model name (e.g., text-embedding-3-large)"},
 	config.FlagEmbeddingDims:       {Name: "embedding-dimensions", ViperKey: "embedding.dimensions", Description: "Embedding dimensionality"},
 }
 

--- a/cmd/tapes/serve/ingest/ingest.go
+++ b/cmd/tapes/serve/ingest/ingest.go
@@ -56,7 +56,7 @@ var ingestFlags = config.FlagSet{
 	config.FlagVectorStoreTgt:         {Name: "vector-store-target", ViperKey: "vector_store.target", Description: "pgvector connection string (defaults to storage.postgres_dsn when unset)"},
 	config.FlagEmbeddingProv:          {Name: "embedding-provider", ViperKey: "embedding.provider", Description: "Embedding provider type (e.g., ollama, openai)"},
 	config.FlagEmbeddingTgt:           {Name: "embedding-target", ViperKey: "embedding.target", Description: "Embedding provider URL"},
-	config.FlagEmbeddingModel:         {Name: "embedding-model", ViperKey: "embedding.model", Description: "Embedding model name (e.g., embeddinggemma, text-embedding-3-small)"},
+	config.FlagEmbeddingModel:         {Name: "embedding-model", ViperKey: "embedding.model", Description: "Embedding model name (e.g., embeddinggemma, text-embedding-3-large)"},
 	config.FlagEmbeddingDims:          {Name: "embedding-dimensions", ViperKey: "embedding.dimensions", Description: "Embedding dimensionality"},
 	config.FlagKafkaBrokers:           {Name: "kafka-brokers", ViperKey: "publisher.kafka.brokers", Description: "Comma separated list of broker ip:port pairs"},
 	config.FlagKafkaClientID:          {Name: "kafka-client-id", ViperKey: "publisher.kafka.client_id", Description: "Optional Kafka client.id"},

--- a/cmd/tapes/serve/proxy/proxy.go
+++ b/cmd/tapes/serve/proxy/proxy.go
@@ -60,7 +60,7 @@ var proxyFlags = config.FlagSet{
 	config.FlagVectorStoreTgt:        {Name: "vector-store-target", ViperKey: "vector_store.target", Description: "pgvector connection string (defaults to storage.postgres_dsn when unset)"},
 	config.FlagEmbeddingProv:         {Name: "embedding-provider", ViperKey: "embedding.provider", Description: "Embedding provider type (e.g., ollama, openai)"},
 	config.FlagEmbeddingTgt:          {Name: "embedding-target", ViperKey: "embedding.target", Description: "Embedding provider URL"},
-	config.FlagEmbeddingModel:        {Name: "embedding-model", ViperKey: "embedding.model", Description: "Embedding model name (e.g., embeddinggemma, text-embedding-3-small)"},
+	config.FlagEmbeddingModel:        {Name: "embedding-model", ViperKey: "embedding.model", Description: "Embedding model name (e.g., embeddinggemma, text-embedding-3-large)"},
 	config.FlagEmbeddingDims:         {Name: "embedding-dimensions", ViperKey: "embedding.dimensions", Description: "Embedding dimensionality"},
 	config.FlagKafkaBrokers:          {Name: "kafka-brokers", ViperKey: "publisher.kafka.brokers", Description: "Comma separated list of broker ip:port pairs"},
 	config.FlagKafkaClientID:         {Name: "kafka-client-id", ViperKey: "publisher.kafka.client_id", Description: "Optional Kafka client.id"},

--- a/cmd/tapes/serve/serve.go
+++ b/cmd/tapes/serve/serve.go
@@ -65,7 +65,7 @@ var ServeFlags = config.FlagSet{
 	config.FlagVectorStoreTgt: {Name: "vector-store-target", ViperKey: "vector_store.target", Description: "pgvector connection string (defaults to storage.postgres_dsn when unset)"},
 	config.FlagEmbeddingProv:  {Name: "embedding-provider", ViperKey: "embedding.provider", Description: "Embedding provider type (e.g., ollama, openai)"},
 	config.FlagEmbeddingTgt:   {Name: "embedding-target", ViperKey: "embedding.target", Description: "Embedding provider URL"},
-	config.FlagEmbeddingModel: {Name: "embedding-model", ViperKey: "embedding.model", Description: "Embedding model name (e.g., embeddinggemma, text-embedding-3-small)"},
+	config.FlagEmbeddingModel: {Name: "embedding-model", ViperKey: "embedding.model", Description: "Embedding model name (e.g., embeddinggemma, text-embedding-3-large)"},
 	config.FlagEmbeddingDims:  {Name: "embedding-dimensions", ViperKey: "embedding.dimensions", Description: "Embedding dimensionality"},
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -549,8 +549,8 @@ var _ = Describe("PresetConfig", func() {
 		Expect(cfg.Client.APITarget).To(Equal("http://localhost:8081"))
 		Expect(cfg.Embedding.Provider).To(Equal("openai"))
 		Expect(cfg.Embedding.Target).To(Equal("https://api.openai.com"))
-		Expect(cfg.Embedding.Model).To(Equal("text-embedding-3-small"))
-		Expect(cfg.Embedding.Dimensions).To(Equal(uint(1536)))
+		Expect(cfg.Embedding.Model).To(Equal("text-embedding-3-large"))
+		Expect(cfg.Embedding.Dimensions).To(Equal(uint(1024)))
 	})
 
 	It("returns anthropic preset with correct defaults", func() {
@@ -604,8 +604,8 @@ var _ = Describe("ResolveEmbeddingConfig", func() {
 		cfg := config.ResolveEmbeddingConfig("openai", "http://localhost:11434", "embeddinggemma", 768)
 		Expect(cfg.Provider).To(Equal("openai"))
 		Expect(cfg.Target).To(Equal("https://api.openai.com"))
-		Expect(cfg.Model).To(Equal("text-embedding-3-small"))
-		Expect(cfg.Dimensions).To(Equal(uint(1536)))
+		Expect(cfg.Model).To(Equal("text-embedding-3-large"))
+		Expect(cfg.Dimensions).To(Equal(uint(1024)))
 	})
 
 	It("preserves explicit OpenAI dimensions", func() {
@@ -618,7 +618,7 @@ var _ = Describe("ResolveEmbeddingConfig", func() {
 		)
 		Expect(cfg.Provider).To(Equal("openai"))
 		Expect(cfg.Target).To(Equal("https://api.openai.com"))
-		Expect(cfg.Model).To(Equal("text-embedding-3-small"))
+		Expect(cfg.Model).To(Equal("text-embedding-3-large"))
 		Expect(cfg.Dimensions).To(Equal(uint(768)))
 	})
 

--- a/pkg/config/embedding_defaults.go
+++ b/pkg/config/embedding_defaults.go
@@ -4,8 +4,8 @@ import "strings"
 
 const (
 	defaultOpenAIEmbeddingTarget     = "https://api.openai.com"
-	defaultOpenAIEmbeddingModel      = "text-embedding-3-small"
-	defaultOpenAIEmbeddingDimensions = 1536
+	defaultOpenAIEmbeddingModel      = "text-embedding-3-large"
+	defaultOpenAIEmbeddingDimensions = 1024
 
 	legacyOllamaEmbeddingModel = "nomic-embed-text"
 )

--- a/pkg/embeddings/openai/openai.go
+++ b/pkg/embeddings/openai/openai.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	// DefaultEmbeddingModel is OpenAI's default Tapes embedding model.
-	DefaultEmbeddingModel = "text-embedding-3-small"
+	DefaultEmbeddingModel = "text-embedding-3-large"
 
 	// DefaultBaseURL is the OpenAI API base URL.
 	DefaultBaseURL = "https://api.openai.com/v1"


### PR DESCRIPTION
RFD 00005 settled the cloud embedding choice: OpenAI `text-embedding-3-large` shortened to 1024 dimensions, stored as pgvector `vector(1024)` with HNSW cosine indexing. This adopts that choice for the OpenAI provider defaults.

- `ResolveEmbeddingConfig` OpenAI defaults move from `text-embedding-3-small` / 1536 to `text-embedding-3-large` / 1024, keeping the stronger model family while staying well under pgvector's 2000-dimension HNSW index limit.
- `openai.DefaultEmbeddingModel` and the `--embedding-model` flag help examples follow.
- Explicitly configured models and dimensions are unaffected — only inherited OpenAI provider defaults change. The passthrough tests covering explicit values are intentionally untouched.

Rollout note: existing `tapes_embeddings` tables were created at `vector(1536)` and pgvector column dimensions cannot change in place. The coordinated cloud rollout (tracked on the ticket) drops and recreates the tables; `ensureSchema` recreates them at `vector(1024)` on startup.

## Test plan

- [x] `dagger call test` (full suite incl. Postgres integration tests)
- [x] `make test-kafka-e2e`

Part of PCC-654.

🤖 Generated with [Claude Code](https://claude.com/claude-code)