### PR TITLE
🔧 fix: fail on embedding dimension mismatch and redact DSNs in logs

### DIFF
--- a/cli/sqlite-import/main.go
+++ b/cli/sqlite-import/main.go
@@ -22,6 +22,8 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 	pgvectorgo "github.com/pgvector/pgvector-go"
+
+	"github.com/papercomputeco/tapes/pkg/config"
 )
 
 const (
@@ -103,7 +105,7 @@ func run(ctx context.Context, cfg config) error {
 	cfg.sqlitePath = sqlitePath
 
 	log.Printf("source sqlite: %s", cfg.sqlitePath)
-	log.Printf("target postgres: %s", redactDSN(cfg.postgresDSN))
+	log.Printf("target postgres: %s", config.RedactDSN(cfg.postgresDSN))
 
 	sqlite_vec.Auto()
 
@@ -760,17 +762,6 @@ func expandPath(path string) (string, error) {
 		path = filepath.Join(home, path[2:])
 	}
 	return filepath.Abs(path)
-}
-
-func redactDSN(raw string) string {
-	cfg, err := pgxpool.ParseConfig(raw)
-	if err != nil {
-		return raw
-	}
-	if cfg.ConnConfig.Password != "" {
-		cfg.ConnConfig.Password = "xxxxx"
-	}
-	return cfg.ConnString()
 }
 
 func normalizeParentHash(parent sql.NullString) sql.NullString {

--- a/cmd/tapes/serve/api/api.go
+++ b/cmd/tapes/serve/api/api.go
@@ -167,7 +167,7 @@ func (c *apiCommander) run() error {
 		defer apiConfig.VectorDriver.Close()
 
 		c.logger.Info("vector search enabled",
-			"vector_store_target", c.vectorStoreTarget,
+			"vector_store_target", config.RedactDSN(c.vectorStoreTarget),
 			"embedding_provider", c.embeddingProvider,
 			"embedding_target", c.embeddingTarget,
 			"embedding_model", c.embeddingModel,

--- a/cmd/tapes/serve/ingest/ingest.go
+++ b/cmd/tapes/serve/ingest/ingest.go
@@ -221,7 +221,7 @@ func (c *ingestCommander) run() error {
 		defer cfg.VectorDriver.Close()
 
 		c.logger.Info("vector storage enabled",
-			"vector_store_target", c.vectorStoreTarget,
+			"vector_store_target", config.RedactDSN(c.vectorStoreTarget),
 			"embedding_provider", c.embeddingProvider,
 			"embedding_target", c.embeddingTarget,
 			"embedding_model", c.embeddingModel,

--- a/cmd/tapes/serve/proxy/proxy.go
+++ b/cmd/tapes/serve/proxy/proxy.go
@@ -199,7 +199,7 @@ func (c *proxyCommander) run() error {
 	}
 	defer driver.Close()
 
-	config := proxy.Config{
+	proxyConfig := proxy.Config{
 		ListenAddr:   c.listen,
 		UpstreamURL:  c.upstream,
 		ProviderType: c.providerType,
@@ -208,7 +208,7 @@ func (c *proxyCommander) run() error {
 	}
 
 	if c.vectorStoreTarget != "" {
-		config.Embedder, err = embeddingutils.NewEmbedder(&embeddingutils.NewEmbedderOpts{
+		proxyConfig.Embedder, err = embeddingutils.NewEmbedder(&embeddingutils.NewEmbedderOpts{
 			ProviderType: c.embeddingProvider,
 			TargetURL:    c.embeddingTarget,
 			Model:        c.embeddingModel,
@@ -218,26 +218,26 @@ func (c *proxyCommander) run() error {
 		if err != nil {
 			return fmt.Errorf("creating embedder: %w", err)
 		}
-		defer config.Embedder.Close()
+		defer proxyConfig.Embedder.Close()
 
-		config.VectorDriver, err = pgvector.NewDriver(context.TODO(), &pgvector.Config{
+		proxyConfig.VectorDriver, err = pgvector.NewDriver(context.TODO(), &pgvector.Config{
 			ConnString: c.vectorStoreTarget,
 			Dimensions: c.embeddingDimensions,
 		}, c.logger)
 		if err != nil {
 			return fmt.Errorf("could not create new vector driver: %w", err)
 		}
-		defer config.VectorDriver.Close()
+		defer proxyConfig.VectorDriver.Close()
 
 		c.logger.Info("vector storage enabled",
-			"vector_store_target", c.vectorStoreTarget,
+			"vector_store_target", config.RedactDSN(c.vectorStoreTarget),
 			"embedding_provider", c.embeddingProvider,
 			"embedding_target", c.embeddingTarget,
 			"embedding_model", c.embeddingModel,
 		)
 	}
 
-	p, err := proxy.New(config, driver, c.logger)
+	p, err := proxy.New(proxyConfig, driver, c.logger)
 	if err != nil {
 		return fmt.Errorf("creating proxy: %w", err)
 	}

--- a/cmd/tapes/serve/serve.go
+++ b/cmd/tapes/serve/serve.go
@@ -222,7 +222,7 @@ func (c *ServeCommander) run() error {
 	defer proxyConfig.Embedder.Close()
 
 	c.logger.Info("vector storage enabled",
-		"vector_store_target", c.vectorStoreTarget,
+		"vector_store_target", config.RedactDSN(c.vectorStoreTarget),
 		"embedding_provider", c.embeddingProvider,
 		"embedding_target", c.embeddingTarget,
 		"embedding_model", c.embeddingModel,

--- a/pkg/config/redact.go
+++ b/pkg/config/redact.go
@@ -1,0 +1,39 @@
+package config
+
+import (
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+const redactedPassword = "xxxxx"
+
+var (
+	urlPasswordPattern     = regexp.MustCompile(`(://[^:/?#@]+:)[^@]+@`)
+	keywordPasswordPattern = regexp.MustCompile(`(\bpassword=)[^\s&]+`)
+)
+
+// RedactDSN masks the password in a database connection string so the string
+// can be logged safely. URL DSNs (postgres://user:pass@host/db, including the
+// libpq-style ?password=... query parameter) and keyword/value DSNs
+// (host=... password=...) are supported. Strings without a password are
+// returned unchanged.
+func RedactDSN(dsn string) string {
+	if u, err := url.Parse(dsn); err == nil && u.Scheme != "" {
+		if u.User != nil {
+			if _, ok := u.User.Password(); ok {
+				u.User = url.UserPassword(u.User.Username(), redactedPassword)
+			}
+		}
+		if q := u.Query(); q.Has("password") {
+			q.Set("password", redactedPassword)
+			u.RawQuery = q.Encode()
+		}
+		return u.String()
+	}
+	redacted := dsn
+	if strings.Contains(dsn, "://") {
+		redacted = urlPasswordPattern.ReplaceAllString(redacted, "${1}"+redactedPassword+"@")
+	}
+	return keywordPasswordPattern.ReplaceAllString(redacted, "${1}"+redactedPassword)
+}

--- a/pkg/config/redact_test.go
+++ b/pkg/config/redact_test.go
@@ -1,0 +1,60 @@
+package config_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/papercomputeco/tapes/pkg/config"
+)
+
+var _ = Describe("RedactDSN", func() {
+	It("masks the password in a URL DSN", func() {
+		redacted := config.RedactDSN("postgresql://tapes:s3cr3t@yeazel-db-rw.tenant-cnq93:5432/tapes")
+		Expect(redacted).NotTo(ContainSubstring("s3cr3t"))
+		Expect(redacted).To(ContainSubstring("tapes:xxxxx@yeazel-db-rw.tenant-cnq93:5432/tapes"))
+	})
+
+	It("masks the password in a keyword/value DSN", func() {
+		redacted := config.RedactDSN("host=localhost port=5432 user=tapes password=s3cr3t dbname=tapes")
+		Expect(redacted).NotTo(ContainSubstring("s3cr3t"))
+		Expect(redacted).To(ContainSubstring("password=xxxxx"))
+	})
+
+	It("returns URL DSNs without credentials unchanged", func() {
+		dsn := "postgresql://yeazel-db-rw.tenant-cnq93:5432/tapes"
+		Expect(config.RedactDSN(dsn)).To(Equal(dsn))
+	})
+
+	It("returns URL DSNs with a user but no password unchanged", func() {
+		dsn := "postgresql://tapes@yeazel-db-rw.tenant-cnq93:5432/tapes"
+		Expect(config.RedactDSN(dsn)).To(Equal(dsn))
+	})
+
+	It("masks a password passed as a query parameter", func() {
+		redacted := config.RedactDSN("postgresql://tapes@yeazel-db-rw.tenant-cnq93:5432/tapes?password=s3cr3t&sslmode=require")
+		Expect(redacted).NotTo(ContainSubstring("s3cr3t"))
+		Expect(redacted).To(ContainSubstring("password=xxxxx"))
+		Expect(redacted).To(ContainSubstring("sslmode=require"))
+	})
+
+	It("masks both userinfo and query parameter passwords", func() {
+		redacted := config.RedactDSN("postgresql://tapes:s3cr3t@host:5432/tapes?password=als0secret")
+		Expect(redacted).NotTo(ContainSubstring("s3cr3t"))
+		Expect(redacted).NotTo(ContainSubstring("als0secret"))
+	})
+
+	It("masks URL-shaped strings that do not parse as URLs", func() {
+		redacted := config.RedactDSN("postgresql://tapes:pass with space@host:5432/tapes")
+		Expect(redacted).NotTo(ContainSubstring("pass with space"))
+	})
+
+	It("masks query parameter passwords in URL-shaped strings that do not parse", func() {
+		redacted := config.RedactDSN("postgresql://tapes:pass with space@host:5432/tapes?password=s3cr3t&sslmode=require")
+		Expect(redacted).NotTo(ContainSubstring("s3cr3t"))
+		Expect(redacted).To(ContainSubstring("sslmode=require"))
+	})
+
+	It("returns non-DSN strings unchanged", func() {
+		Expect(config.RedactDSN("not a dsn")).To(Equal("not a dsn"))
+	})
+})

--- a/pkg/vector/pgvector/pgvector.go
+++ b/pkg/vector/pgvector/pgvector.go
@@ -17,6 +17,9 @@ import (
 const (
 	// DefaultTableName is the default table name for storing vector documents.
 	DefaultTableName = "tapes_embeddings"
+
+	// maxVectorDimensions is the upper bound pgvector supports for the vector type.
+	maxVectorDimensions = 16000
 )
 
 // Driver implements vector.Driver using PostgreSQL with the pgvector extension.
@@ -48,6 +51,9 @@ func NewDriver(ctx context.Context, c *Config, log *slog.Logger) (*Driver, error
 
 	if c.Dimensions == 0 {
 		return nil, errors.New("pgvector embedding dimensions cannot be 0, must be configured")
+	}
+	if c.Dimensions > maxVectorDimensions {
+		return nil, fmt.Errorf("pgvector embedding dimensions cannot exceed %d", maxVectorDimensions)
 	}
 
 	tableName := c.TableName
@@ -98,6 +104,29 @@ func (d *Driver) ensureSchema(ctx context.Context) error {
 	}
 	if !hasVector {
 		return errors.New("vector extension is not installed in this database")
+	}
+
+	// CREATE TABLE IF NOT EXISTS keeps an existing table's declared dimension,
+	// after which every insert of differently-sized vectors fails. pgvector
+	// cannot resize a column in place, so an existing table must match the
+	// configured dimensions exactly.
+	var existingDims int32
+	err := d.pool.QueryRow(ctx, `
+		SELECT a.atttypmod
+		FROM pg_attribute a
+		WHERE a.attrelid = to_regclass($1)
+		  AND a.attname = 'embedding'
+	`, table).Scan(&existingDims)
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		// Table does not exist yet; create it below.
+	case err != nil:
+		return fmt.Errorf("checking existing embedding dimensions: %w", err)
+	case existingDims != int32(d.dimensions): // #nosec G115 -- NewDriver bounds dimensions to maxVectorDimensions
+		return fmt.Errorf(
+			"existing table %s stores vector(%d) embeddings but %d dimensions are configured; re-embed into a new table or drop the old one",
+			table, existingDims, d.dimensions,
+		)
 	}
 
 	// Create the embeddings table with a vector column sized to the configured dimensions.

--- a/pkg/vector/pgvector/pgvector_test.go
+++ b/pkg/vector/pgvector/pgvector_test.go
@@ -2,13 +2,45 @@ package pgvector_test
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"time"
 
+	"github.com/jackc/pgx/v5"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	"github.com/papercomputeco/tapes/pkg/vector"
 	"github.com/papercomputeco/tapes/pkg/vector/pgvector"
 )
+
+func testPostgresDSN() (string, error) {
+	dsn := os.Getenv("TEST_POSTGRES_DSN")
+	if dsn == "" {
+		return "", errors.New("TEST_POSTGRES_DSN is not set; run postgres integration tests via `dagger call test` so the Dagger Postgres service is available")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	conn, err := pgx.Connect(ctx, dsn)
+	if err != nil {
+		return "", fmt.Errorf("connect to test postgres: %w", err)
+	}
+	defer conn.Close(context.Background())
+
+	if err := conn.Ping(ctx); err != nil {
+		return "", fmt.Errorf("ping test postgres at TEST_POSTGRES_DSN: %w", err)
+	}
+
+	return dsn, nil
+}
+
+func newTestLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(GinkgoWriter, nil))
+}
 
 var _ = Describe("Driver", func() {
 	Describe("Interface compliance", func() {
@@ -32,6 +64,66 @@ var _ = Describe("Driver", func() {
 			}, nil)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("dimensions cannot be 0"))
+		})
+	})
+
+	Describe("ensureSchema dimension check", func() {
+		const tableName = "pgvector_dim_check_test"
+
+		var dsn string
+
+		BeforeEach(func() {
+			var err error
+			dsn, err = testPostgresDSN()
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		AfterEach(func(ctx SpecContext) {
+			conn, err := pgx.Connect(ctx, dsn)
+			Expect(err).NotTo(HaveOccurred())
+			defer conn.Close(context.Background())
+			_, err = conn.Exec(ctx, "DROP TABLE IF EXISTS "+pgx.Identifier{tableName}.Sanitize())
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("refuses to reuse a table whose dimensions differ from the configuration", func(ctx SpecContext) {
+			logger := newTestLogger()
+
+			driver, err := pgvector.NewDriver(ctx, &pgvector.Config{
+				ConnString: dsn,
+				TableName:  tableName,
+				Dimensions: 3,
+			}, logger)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(driver.Close()).To(Succeed())
+
+			_, err = pgvector.NewDriver(ctx, &pgvector.Config{
+				ConnString: dsn,
+				TableName:  tableName,
+				Dimensions: 4,
+			}, logger)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("stores vector(3) embeddings but 4 dimensions are configured"))
+		})
+
+		It("reuses an existing table when the dimensions match", func(ctx SpecContext) {
+			logger := newTestLogger()
+
+			driver, err := pgvector.NewDriver(ctx, &pgvector.Config{
+				ConnString: dsn,
+				TableName:  tableName,
+				Dimensions: 3,
+			}, logger)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(driver.Close()).To(Succeed())
+
+			driver, err = pgvector.NewDriver(ctx, &pgvector.Config{
+				ConnString: dsn,
+				TableName:  tableName,
+				Dimensions: 3,
+			}, logger)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(driver.Close()).To(Succeed())
 		})
 	})
 })


### PR DESCRIPTION
🧍When I was looking at bumping to new embedding configurations I noticed that the logs had the full DSN in them and the dimensions weren't properly checked so things could fail in unexpected ways when trying to move to the new embedding from an older version. 🧍

**Silent dimension mismatch.** `ensureSchema` uses `CREATE TABLE IF NOT EXISTS`, which keeps an existing table's declared vector dimension. A driver configured for 1024 dims connected to a `vector(1536)` table starts cleanly and logs `dimensions=1024` — then every embedding insert fails. pgvector can't resize columns in place, so the driver now checks the existing column's dimension at startup and fails with the options spelled out (re-embed into a new table, or drop the old one). Dimensions are also bounded to pgvector's 16000 vector-type max at construction.

**Database password in logs.** The "vector storage/search enabled" startup lines logged the raw DSN — tenant DB passwords are sitting in staging pod logs and downstream log stores. A new `config.RedactDSN` masks passwords in URL and keyword/value DSN forms, with a pattern fallback for URL-shaped strings that fail to parse so malformed DSNs can't leak through. `cli/sqlite-import`'s local `redactDSN` was rebuilt on the shared helper — it mutated `pgxpool.Config.ConnConfig.Password` and returned `ConnString()`, which returns the original unmodified string, so it never actually masked anything.

## Test plan

- [x] `dagger call test` — includes new pgvector integration specs (mismatched reopen fails with the new error; matching reopen succeeds) and `RedactDSN` unit specs for both DSN forms and edge cases
- [x] `make test-kafka-e2e`
- [ ] After staging rollout: pod startup log shows `tapes:xxxxx@` in `vector_store_target`

Part of PCC-654.

🤖 Generated with [Claude Code](https://claude.com/claude-code)