### PR TITLE
✨ feat: capture OpenAI Responses (Codex) turns

### DIFF
--- a/pkg/capture/anthropic_state.go
+++ b/pkg/capture/anthropic_state.go
@@ -304,7 +304,7 @@ func (s *turnState) finalize() *llm.ChatResponse {
 	if !s.seenMessageStop && s.errorType == "" {
 		extra["incomplete"] = true
 		if s.stopReason == "" {
-			s.stopReason = "incomplete"
+			s.stopReason = stopReasonIncomplete
 		}
 	}
 

--- a/pkg/capture/openai_responses.go
+++ b/pkg/capture/openai_responses.go
@@ -1,0 +1,352 @@
+package capture
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/papercomputeco/tapes/pkg/llm"
+	"github.com/papercomputeco/tapes/pkg/sse"
+)
+
+// ProviderOpenAI is the canonical provider-name string consumers use to key
+// the OpenAI Responses reducer in their dispatch maps.
+const ProviderOpenAI = "openai"
+
+// stopReasonIncomplete is the canonical stop reason for turns that ended
+// before natural completion, shared across reducers.
+const stopReasonIncomplete = "incomplete"
+
+// openaiResponsesReducer turns a single OpenAI Responses API turn — streamed
+// SSE or one-shot JSON — into a canonical *llm.ChatResponse.
+//
+// The streaming shape is friendlier than Anthropic's: the terminal
+// `response.completed` / `response.incomplete` / `response.failed` event
+// carries the complete Response object (output items, status, usage), so the
+// happy path reduces that single payload with the same mapping as the
+// one-shot form instead of replaying every delta. Deltas are accumulated
+// only as a fallback so a stream torn down before its terminal event still
+// captures the partial text rather than a hole.
+type openaiResponsesReducer struct{}
+
+// NewOpenAIResponsesReducer returns an OpenAI Responses reducer. The value
+// is stateless at the package level; per-turn state lives inside Reduce.
+func NewOpenAIResponsesReducer() Reducer {
+	return &openaiResponsesReducer{}
+}
+
+// Reduce implements Reducer.
+func (r *openaiResponsesReducer) Reduce(ctx context.Context, _, respBody io.Reader, contentType string) (*llm.ChatResponse, error) {
+	if respBody == nil {
+		return nil, errors.New("openai responses reducer: nil response body")
+	}
+
+	lower := strings.ToLower(contentType)
+	switch {
+	case strings.Contains(lower, "event-stream"), strings.Contains(lower, "ndjson"):
+		return r.reduceStream(ctx, respBody)
+	case strings.Contains(lower, "json"):
+		return r.reduceOneShot(respBody)
+	default:
+		// chatgpt.com/backend-api/codex omits Content-Type entirely on
+		// its SSE responses, so an absent or unknown type sniffs the
+		// body: SSE frames open with an "event:" or "data:" field name.
+		br := bufio.NewReader(respBody)
+		prefix, _ := br.Peek(sseSniffLen)
+		if looksLikeSSE(prefix) {
+			return r.reduceStream(ctx, br)
+		}
+		return r.reduceOneShot(br)
+	}
+}
+
+// sseSniffLen covers leading whitespace plus the longest field name the
+// sniffer matches ("event:").
+const sseSniffLen = 16
+
+func looksLikeSSE(prefix []byte) bool {
+	trimmed := bytes.TrimLeft(prefix, " \t\r\n")
+	return bytes.HasPrefix(trimmed, []byte("event:")) || bytes.HasPrefix(trimmed, []byte("data:"))
+}
+
+func (r *openaiResponsesReducer) reduceOneShot(body io.Reader) (*llm.ChatResponse, error) {
+	raw, err := io.ReadAll(body)
+	if err != nil {
+		return nil, fmt.Errorf("openai responses reducer: read oneshot body: %w", err)
+	}
+
+	var resp responsesObject
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return nil, fmt.Errorf("openai responses reducer: parse oneshot body: %w", err)
+	}
+	if resp.Object != "response" {
+		return nil, fmt.Errorf("openai responses reducer: unexpected object %q", resp.Object)
+	}
+
+	return responsesObjectToChat(&resp), nil
+}
+
+// streamEnvelope is the data payload of one Responses SSE event. Terminal
+// events nest the full Response object under `response`; delta events carry
+// the delta text directly.
+type streamEnvelope struct {
+	Type     string           `json:"type"`
+	Response *responsesObject `json:"response"`
+	Delta    string           `json:"delta"`
+	Item     json.RawMessage  `json:"item"`
+}
+
+func (r *openaiResponsesReducer) reduceStream(ctx context.Context, body io.Reader) (*llm.ChatResponse, error) {
+	// Completed output items accumulate from response.output_item.done
+	// frames: api.openai.com echoes the full item list again on the
+	// terminal event, but chatgpt.com/backend-api/codex sends the
+	// terminal event with an EMPTY output array, so the accumulated
+	// items are the only complete record there. Text deltas are a
+	// second-line fallback for streams torn down mid-item.
+	var (
+		items     []json.RawMessage
+		deltaText strings.Builder
+		created   *responsesObject
+	)
+
+	tr := sse.NewTeeReader(body, io.Discard)
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
+		ev, err := tr.Next()
+		if err != nil {
+			return partialResponse(created, items, deltaText.String(), err.Error()), nil
+		}
+		if ev == nil {
+			break
+		}
+
+		var env streamEnvelope
+		if jsonErr := json.Unmarshal([]byte(ev.Data), &env); jsonErr != nil {
+			continue
+		}
+
+		switch env.Type {
+		case "response.completed", "response.incomplete", "response.failed":
+			if env.Response == nil {
+				// A terminal envelope without a response object is a
+				// malformed frame, not an early-truncated stream — give
+				// it a distinct reason so the two failure shapes stay
+				// separable in capture diagnostics.
+				reason := fmt.Sprintf("terminal event %s carried no response object", env.Type)
+				return partialResponse(created, items, deltaText.String(), reason), nil
+			}
+			if len(env.Response.Output) == 0 {
+				env.Response.Output = items
+			}
+			return responsesObjectToChat(env.Response), nil
+		case "response.created":
+			created = env.Response
+		case "response.output_item.done":
+			if len(env.Item) > 0 {
+				items = append(items, env.Item)
+			}
+		case "response.output_text.delta":
+			deltaText.WriteString(env.Delta)
+		}
+	}
+
+	return partialResponse(created, items, deltaText.String(), "stream ended before terminal response event"), nil
+}
+
+// partialResponse preserves whatever a truncated stream yielded, flagged via
+// Extra so operators see the partial turn instead of silence. Completed
+// output items are the best record; loose text deltas cover a stream cut
+// mid-item.
+func partialResponse(created *responsesObject, items []json.RawMessage, text, reason string) *llm.ChatResponse {
+	content := responsesOutputContent(items)
+	if len(content) == 0 && text != "" {
+		content = append(content, llm.ContentBlock{Type: "text", Text: text})
+	}
+
+	resp := &llm.ChatResponse{
+		Message: llm.Message{
+			Role:    "assistant",
+			Content: content,
+		},
+		Extra: map[string]any{"partial": true, "reducer_error": reason},
+	}
+	if created != nil {
+		resp.Model = created.Model
+		if created.CreatedAt > 0 {
+			resp.CreatedAt = time.Unix(created.CreatedAt, 0).UTC()
+		}
+	}
+	return resp
+}
+
+// responsesObject is the subset of the Responses API Response object tapes
+// maps onto llm.ChatResponse.
+type responsesObject struct {
+	ID                string            `json:"id"`
+	Object            string            `json:"object"`
+	CreatedAt         int64             `json:"created_at"`
+	Status            string            `json:"status"`
+	Model             string            `json:"model"`
+	Output            []json.RawMessage `json:"output"`
+	Usage             *responsesUsage   `json:"usage"`
+	IncompleteDetails *struct {
+		Reason string `json:"reason"`
+	} `json:"incomplete_details"`
+}
+
+type responsesUsage struct {
+	InputTokens        int `json:"input_tokens"`
+	OutputTokens       int `json:"output_tokens"`
+	TotalTokens        int `json:"total_tokens"`
+	InputTokensDetails *struct {
+		CachedTokens int `json:"cached_tokens"`
+	} `json:"input_tokens_details"`
+}
+
+// responsesOutputItem is the union of output item shapes (message,
+// function_call, reasoning, hosted-tool calls).
+type responsesOutputItem struct {
+	Type    string `json:"type"`
+	Role    string `json:"role"`
+	Content []struct {
+		Type    string `json:"type"`
+		Text    string `json:"text"`
+		Refusal string `json:"refusal"`
+	} `json:"content"`
+
+	// function_call
+	CallID    string `json:"call_id"`
+	Name      string `json:"name"`
+	Arguments string `json:"arguments"`
+
+	// reasoning
+	Summary []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	} `json:"summary"`
+	EncryptedContent string `json:"encrypted_content"`
+}
+
+// responsesOutputContent maps Responses output items to canonical content
+// blocks. Shared by full-object reduction and partial captures so a stream
+// torn down before its terminal event maps items identically.
+func responsesOutputContent(output []json.RawMessage) []llm.ContentBlock {
+	content := make([]llm.ContentBlock, 0, len(output))
+	for _, raw := range output {
+		var item responsesOutputItem
+		if err := json.Unmarshal(raw, &item); err != nil {
+			content = append(content, llm.ContentBlock{Type: "unparsed", Content: raw})
+			continue
+		}
+
+		switch item.Type {
+		case "message":
+			for _, part := range item.Content {
+				switch part.Type {
+				case "output_text":
+					content = append(content, llm.ContentBlock{Type: "text", Text: part.Text})
+				case "refusal":
+					content = append(content, llm.ContentBlock{Type: "refusal", Text: part.Refusal})
+				default:
+					content = append(content, llm.ContentBlock{Type: part.Type, Text: part.Text})
+				}
+			}
+		case "function_call":
+			cb := llm.ContentBlock{
+				Type:      "tool_use",
+				ToolUseID: item.CallID,
+				ToolName:  item.Name,
+			}
+			if item.Arguments != "" {
+				var input map[string]any
+				if err := json.Unmarshal([]byte(item.Arguments), &input); err == nil {
+					cb.ToolInput = input
+				} else {
+					cb.Content = raw
+				}
+			}
+			content = append(content, cb)
+		case "reasoning":
+			var b strings.Builder
+			for _, part := range item.Summary {
+				if b.Len() > 0 && part.Text != "" {
+					b.WriteString("\n")
+				}
+				b.WriteString(part.Text)
+			}
+			content = append(content, llm.ContentBlock{
+				Type:              "thinking",
+				Thinking:          b.String(),
+				ThinkingSignature: item.EncryptedContent,
+			})
+		default:
+			// Hosted tool calls (web_search_call, code_interpreter_call,
+			// ...) and future item types survive verbatim.
+			content = append(content, llm.ContentBlock{Type: item.Type, Content: raw})
+		}
+	}
+	return content
+}
+
+// responsesObjectToChat maps a full Response object to the canonical chat
+// response shape shared with the Chat Completions path.
+func responsesObjectToChat(resp *responsesObject) *llm.ChatResponse {
+	content := responsesOutputContent(resp.Output)
+
+	out := &llm.ChatResponse{
+		Model: resp.Model,
+		Message: llm.Message{
+			Role:    "assistant",
+			Content: content,
+		},
+		Done:       true,
+		StopReason: responsesStopReason(resp),
+		Extra: map[string]any{
+			"id":     resp.ID,
+			"object": resp.Object,
+			"status": resp.Status,
+		},
+	}
+	if resp.CreatedAt > 0 {
+		out.CreatedAt = time.Unix(resp.CreatedAt, 0).UTC()
+	}
+	if resp.Usage != nil {
+		usage := &llm.Usage{
+			PromptTokens:     resp.Usage.InputTokens,
+			CompletionTokens: resp.Usage.OutputTokens,
+			TotalTokens:      resp.Usage.TotalTokens,
+		}
+		if resp.Usage.InputTokensDetails != nil {
+			usage.CacheReadInputTokens = resp.Usage.InputTokensDetails.CachedTokens
+		}
+		out.Usage = usage
+	}
+	return out
+}
+
+// responsesStopReason maps Response status to the canonical stop-reason
+// vocabulary: completed turns say "stop" (Chat Completions parity);
+// incomplete turns surface the API's own reason (e.g. "max_output_tokens");
+// anything else carries the status verbatim.
+func responsesStopReason(resp *responsesObject) string {
+	switch resp.Status {
+	case "completed":
+		return "stop"
+	case stopReasonIncomplete:
+		if resp.IncompleteDetails != nil && resp.IncompleteDetails.Reason != "" {
+			return resp.IncompleteDetails.Reason
+		}
+		return stopReasonIncomplete
+	default:
+		return resp.Status
+	}
+}

--- a/pkg/capture/openai_responses_test.go
+++ b/pkg/capture/openai_responses_test.go
@@ -1,0 +1,168 @@
+package capture_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/papercomputeco/tapes/pkg/capture"
+)
+
+// The oneshot.json and stream.sse fixtures are real api.openai.com Responses
+// wire captures recorded through the papermeetcodex clearing (gpt-4o-mini),
+// not hand-written approximations.
+var _ = Describe("OpenAI Responses reducer", func() {
+	var r capture.Reducer
+	ctx := context.Background()
+
+	BeforeEach(func() {
+		r = capture.NewOpenAIResponsesReducer()
+	})
+
+	readFixture := func(name string) []byte {
+		data, err := os.ReadFile(filepath.Join("testdata", "openai_responses", name))
+		Expect(err).NotTo(HaveOccurred())
+		return data
+	}
+
+	Describe("one-shot JSON", func() {
+		It("reduces a completed response", func() {
+			resp, err := r.Reduce(ctx, nil, bytes.NewReader(readFixture("oneshot.json")), "application/json")
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(resp.Model).To(Equal("gpt-4o-mini-2024-07-18"))
+			Expect(resp.Done).To(BeTrue())
+			Expect(resp.StopReason).To(Equal("stop"))
+			Expect(resp.Message.Role).To(Equal("assistant"))
+			Expect(resp.Message.GetText()).To(Equal("paper-codex-ok"))
+			Expect(resp.Usage).NotTo(BeNil())
+			Expect(resp.Usage.PromptTokens).To(Equal(16))
+			Expect(resp.Usage.CompletionTokens).To(Equal(6))
+			Expect(resp.Usage.TotalTokens).To(Equal(22))
+			Expect(resp.Extra).To(HaveKeyWithValue("status", "completed"))
+			Expect(resp.CreatedAt.IsZero()).To(BeFalse())
+		})
+
+		It("rejects a non-response object", func() {
+			_, err := r.Reduce(ctx, nil, strings.NewReader(`{"object":"chat.completion"}`), "application/json")
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("maps function_call output items to tool_use blocks", func() {
+			body := `{
+				"object": "response", "id": "resp_x", "status": "completed",
+				"model": "gpt-5.5", "created_at": 1781218506,
+				"output": [
+					{"type": "reasoning", "summary": [{"type": "summary_text", "text": "think"}], "encrypted_content": "blob"},
+					{"type": "function_call", "call_id": "call_1", "name": "shell", "arguments": "{\"command\":[\"ls\"]}"}
+				]
+			}`
+			resp, err := r.Reduce(ctx, nil, strings.NewReader(body), "application/json")
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(resp.Message.Content).To(HaveLen(2))
+			Expect(resp.Message.Content[0].Type).To(Equal("thinking"))
+			Expect(resp.Message.Content[0].Thinking).To(Equal("think"))
+			Expect(resp.Message.Content[0].ThinkingSignature).To(Equal("blob"))
+			Expect(resp.Message.Content[1].Type).To(Equal("tool_use"))
+			Expect(resp.Message.Content[1].ToolUseID).To(Equal("call_1"))
+			Expect(resp.Message.Content[1].ToolName).To(Equal("shell"))
+			Expect(resp.Message.Content[1].ToolInput).To(HaveKey("command"))
+		})
+
+		It("surfaces incomplete_details as the stop reason", func() {
+			body := `{
+				"object": "response", "id": "resp_x", "status": "incomplete",
+				"model": "gpt-5.5",
+				"incomplete_details": {"reason": "max_output_tokens"},
+				"output": []
+			}`
+			resp, err := r.Reduce(ctx, nil, strings.NewReader(body), "application/json")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.StopReason).To(Equal("max_output_tokens"))
+		})
+	})
+
+	Describe("streaming SSE", func() {
+		It("reduces the terminal response.completed event", func() {
+			resp, err := r.Reduce(ctx, nil, bytes.NewReader(readFixture("stream.sse")), "text/event-stream; charset=utf-8")
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(resp.Model).To(Equal("gpt-4o-mini-2024-07-18"))
+			Expect(resp.Done).To(BeTrue())
+			Expect(resp.StopReason).To(Equal("stop"))
+			Expect(resp.Message.GetText()).To(Equal("paper-codex-sse-ok"))
+			Expect(resp.Usage).NotTo(BeNil())
+			Expect(resp.Usage.PromptTokens).To(Equal(18))
+			Expect(resp.Usage.CompletionTokens).To(Equal(8))
+			Expect(resp.Usage.TotalTokens).To(Equal(26))
+		})
+
+		It("preserves accumulated deltas when the stream is truncated", func() {
+			full := readFixture("stream.sse")
+			cut := bytes.Index(full, []byte("event: response.completed"))
+			Expect(cut).To(BeNumerically(">", 0))
+
+			resp, err := r.Reduce(ctx, nil, bytes.NewReader(full[:cut]), "text/event-stream")
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(resp.Done).To(BeFalse())
+			Expect(resp.Message.GetText()).To(Equal("paper-codex-sse-ok"))
+			Expect(resp.Extra).To(HaveKeyWithValue("partial", true))
+			// Model comes from the response.created event even without
+			// a terminal frame.
+			Expect(resp.Model).To(Equal("gpt-4o-mini-2024-07-18"))
+		})
+
+		It("accumulates output items when the terminal event has empty output", func() {
+			// Real chatgpt.com/backend-api/codex wire capture: that
+			// backend sends response.completed with "output": [] and
+			// only emits items via response.output_item.done.
+			resp, err := r.Reduce(ctx, nil, bytes.NewReader(readFixture("chatgpt_stream.sse")), "")
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(resp.Done).To(BeTrue())
+			Expect(resp.StopReason).To(Equal("stop"))
+			Expect(resp.Model).To(Equal("gpt-5.5"))
+			Expect(resp.Message.GetText()).To(Equal("chatgpt-probe-ok"))
+			Expect(resp.Usage).NotTo(BeNil())
+			Expect(resp.Usage.PromptTokens).To(Equal(26))
+			Expect(resp.Usage.CompletionTokens).To(Equal(21))
+		})
+
+		It("sniffs SSE when the upstream omits Content-Type", func() {
+			// chatgpt.com/backend-api/codex sends no Content-Type header
+			// at all on its event stream.
+			resp, err := r.Reduce(ctx, nil, bytes.NewReader(readFixture("stream.sse")), "")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.Done).To(BeTrue())
+			Expect(resp.Message.GetText()).To(Equal("paper-codex-sse-ok"))
+		})
+
+		It("sniffs one-shot JSON when the upstream omits Content-Type", func() {
+			resp, err := r.Reduce(ctx, nil, bytes.NewReader(readFixture("oneshot.json")), "")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.Message.GetText()).To(Equal("paper-codex-ok"))
+		})
+
+		It("flags a terminal event without a response object distinctly", func() {
+			body := "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":null}\n\n"
+			resp, err := r.Reduce(ctx, nil, strings.NewReader(body), "text/event-stream")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.Extra).To(HaveKeyWithValue("partial", true))
+			Expect(resp.Extra["reducer_error"]).To(ContainSubstring("carried no response object"))
+		})
+
+		It("flags an empty stream as partial instead of erroring", func() {
+			resp, err := r.Reduce(ctx, nil, strings.NewReader(""), "text/event-stream")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.Extra).To(HaveKeyWithValue("partial", true))
+			Expect(resp.Message.Content).To(BeEmpty())
+		})
+	})
+})

--- a/pkg/capture/testdata/openai_responses/chatgpt_stream.sse
+++ b/pkg/capture/testdata/openai_responses/chatgpt_stream.sse
@@ -1,0 +1,48 @@
+event: response.created
+data: {"type":"response.created","response":{"id":"resp_0439f6129bd8a840016a2b457a0774819ba629cf2ae61cba10","object":"response","created_at":1781220730,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":"You are a helpful assistant.","max_output_tokens":null,"max_tool_calls":null,"model":"gpt-5.5","moderation":null,"output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"f8bfa631-fb92-4be5-86da-cb9914a58391","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"medium","summary":null},"safety_identifier":"user-2k7Kh3Oh1ylURCNfiXRiK70C","service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":0}
+
+event: response.in_progress
+data: {"type":"response.in_progress","response":{"id":"resp_0439f6129bd8a840016a2b457a0774819ba629cf2ae61cba10","object":"response","created_at":1781220730,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":"You are a helpful assistant.","max_output_tokens":null,"max_tool_calls":null,"model":"gpt-5.5","moderation":null,"output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"f8bfa631-fb92-4be5-86da-cb9914a58391","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"medium","summary":null},"safety_identifier":"user-2k7Kh3Oh1ylURCNfiXRiK70C","service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":1}
+
+event: response.output_item.added
+data: {"type":"response.output_item.added","item":{"id":"rs_0439f6129bd8a840016a2b457a9930819ba298189bcf81954d","type":"reasoning","content":[],"summary":[]},"output_index":0,"sequence_number":2}
+
+event: response.output_item.done
+data: {"type":"response.output_item.done","item":{"id":"rs_0439f6129bd8a840016a2b457a9930819ba298189bcf81954d","type":"reasoning","content":[],"summary":[]},"output_index":0,"sequence_number":3}
+
+event: response.output_item.added
+data: {"type":"response.output_item.added","item":{"id":"msg_0439f6129bd8a840016a2b457ace14819b8016db8f8e530fc8","type":"message","status":"in_progress","content":[],"phase":"final_answer","role":"assistant"},"output_index":1,"sequence_number":4}
+
+event: response.content_part.added
+data: {"type":"response.content_part.added","content_index":0,"item_id":"msg_0439f6129bd8a840016a2b457ace14819b8016db8f8e530fc8","output_index":1,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""},"sequence_number":5}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":"chat","item_id":"msg_0439f6129bd8a840016a2b457ace14819b8016db8f8e530fc8","logprobs":[],"obfuscation":"aa4pIuoAa1x6","output_index":1,"sequence_number":6}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":"g","item_id":"msg_0439f6129bd8a840016a2b457ace14819b8016db8f8e530fc8","logprobs":[],"obfuscation":"Unqpdg86HetlMu3","output_index":1,"sequence_number":7}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":"pt","item_id":"msg_0439f6129bd8a840016a2b457ace14819b8016db8f8e530fc8","logprobs":[],"obfuscation":"gcoJJnFeHro0E9","output_index":1,"sequence_number":8}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":"-pro","item_id":"msg_0439f6129bd8a840016a2b457ace14819b8016db8f8e530fc8","logprobs":[],"obfuscation":"pkbci91lQpE3","output_index":1,"sequence_number":9}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":"be","item_id":"msg_0439f6129bd8a840016a2b457ace14819b8016db8f8e530fc8","logprobs":[],"obfuscation":"E9PB9hqr6pMIqp","output_index":1,"sequence_number":10}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":"-ok","item_id":"msg_0439f6129bd8a840016a2b457ace14819b8016db8f8e530fc8","logprobs":[],"obfuscation":"Dynv1o6k6Xm6W","output_index":1,"sequence_number":11}
+
+event: response.output_text.done
+data: {"type":"response.output_text.done","content_index":0,"item_id":"msg_0439f6129bd8a840016a2b457ace14819b8016db8f8e530fc8","logprobs":[],"output_index":1,"sequence_number":12,"text":"chatgpt-probe-ok"}
+
+event: response.content_part.done
+data: {"type":"response.content_part.done","content_index":0,"item_id":"msg_0439f6129bd8a840016a2b457ace14819b8016db8f8e530fc8","output_index":1,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"chatgpt-probe-ok"},"sequence_number":13}
+
+event: response.output_item.done
+data: {"type":"response.output_item.done","item":{"id":"msg_0439f6129bd8a840016a2b457ace14819b8016db8f8e530fc8","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"chatgpt-probe-ok"}],"phase":"final_answer","role":"assistant"},"output_index":1,"sequence_number":14}
+
+event: response.completed
+data: {"type":"response.completed","response":{"id":"resp_0439f6129bd8a840016a2b457a0774819ba629cf2ae61cba10","object":"response","created_at":1781220730,"status":"completed","background":false,"completed_at":1781220730,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":"You are a helpful assistant.","max_output_tokens":null,"max_tool_calls":null,"model":"gpt-5.5","moderation":null,"output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"f8bfa631-fb92-4be5-86da-cb9914a58391","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"medium","summary":null},"safety_identifier":"user-2k7Kh3Oh1ylURCNfiXRiK70C","service_tier":"default","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":{"input_tokens":26,"input_tokens_details":{"cached_tokens":0},"output_tokens":21,"output_tokens_details":{"reasoning_tokens":9},"total_tokens":47},"user":null,"metadata":{}},"sequence_number":15}
+

--- a/pkg/capture/testdata/openai_responses/oneshot.json
+++ b/pkg/capture/testdata/openai_responses/oneshot.json
@@ -1,0 +1,73 @@
+{
+  "id": "resp_0d447a724b353270006a2b3cbb2e2881989e548b7fd191e59d",
+  "object": "response",
+  "created_at": 1781218491,
+  "status": "completed",
+  "background": false,
+  "billing": {
+    "payer": "developer"
+  },
+  "completed_at": 1781218492,
+  "error": null,
+  "frequency_penalty": 0.0,
+  "incomplete_details": null,
+  "instructions": null,
+  "max_output_tokens": null,
+  "max_tool_calls": null,
+  "model": "gpt-4o-mini-2024-07-18",
+  "moderation": null,
+  "output": [
+    {
+      "id": "msg_0d447a724b353270006a2b3cbc49208198a1226e84abdab652",
+      "type": "message",
+      "status": "completed",
+      "content": [
+        {
+          "type": "output_text",
+          "annotations": [],
+          "logprobs": [],
+          "text": "paper-codex-ok"
+        }
+      ],
+      "role": "assistant"
+    }
+  ],
+  "parallel_tool_calls": true,
+  "presence_penalty": 0.0,
+  "previous_response_id": null,
+  "prompt_cache_key": null,
+  "prompt_cache_retention": "in_memory",
+  "reasoning": {
+    "context": null,
+    "effort": null,
+    "summary": null
+  },
+  "safety_identifier": null,
+  "service_tier": "default",
+  "store": true,
+  "temperature": 1.0,
+  "text": {
+    "format": {
+      "type": "text"
+    },
+    "verbosity": "medium"
+  },
+  "tool_choice": "auto",
+  "tools": [],
+  "top_logprobs": 0,
+  "top_p": 1.0,
+  "truncation": "disabled",
+  "usage": {
+    "input_tokens": 16,
+    "input_tokens_details": {
+      "cached_tokens": 0
+    },
+    "output_tokens": 6,
+    "output_tokens_details": {
+      "reasoning_tokens": 0
+    },
+    "total_tokens": 22
+  },
+  "user": null,
+  "metadata": {}
+}

--- a/pkg/capture/testdata/openai_responses/stream.sse
+++ b/pkg/capture/testdata/openai_responses/stream.sse
@@ -1,0 +1,45 @@
+event: response.created
+data: {"type":"response.created","response":{"id":"resp_01432258600f7c15006a2b3cca8f00819aa3844016990df817","object":"response","created_at":1781218506,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-mini-2024-07-18","moderation":null,"output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"in_memory","reasoning":{"context":null,"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":0}
+
+event: response.in_progress
+data: {"type":"response.in_progress","response":{"id":"resp_01432258600f7c15006a2b3cca8f00819aa3844016990df817","object":"response","created_at":1781218506,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-mini-2024-07-18","moderation":null,"output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"in_memory","reasoning":{"context":null,"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":1}
+
+event: response.output_item.added
+data: {"type":"response.output_item.added","item":{"id":"msg_01432258600f7c15006a2b3ccb103c819a849227fe4c5ee757","type":"message","status":"in_progress","content":[],"role":"assistant"},"output_index":0,"sequence_number":2}
+
+event: response.content_part.added
+data: {"type":"response.content_part.added","content_index":0,"item_id":"msg_01432258600f7c15006a2b3ccb103c819a849227fe4c5ee757","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""},"sequence_number":3}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":"paper","item_id":"msg_01432258600f7c15006a2b3ccb103c819a849227fe4c5ee757","logprobs":[],"obfuscation":"qSk1aLuJoed","output_index":0,"sequence_number":4}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":"-c","item_id":"msg_01432258600f7c15006a2b3ccb103c819a849227fe4c5ee757","logprobs":[],"obfuscation":"4vS2vONszu6CC6","output_index":0,"sequence_number":5}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":"od","item_id":"msg_01432258600f7c15006a2b3ccb103c819a849227fe4c5ee757","logprobs":[],"obfuscation":"1LVQn75MFUlUxF","output_index":0,"sequence_number":6}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":"ex","item_id":"msg_01432258600f7c15006a2b3ccb103c819a849227fe4c5ee757","logprobs":[],"obfuscation":"navSA0fhxlnkKA","output_index":0,"sequence_number":7}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":"-s","item_id":"msg_01432258600f7c15006a2b3ccb103c819a849227fe4c5ee757","logprobs":[],"obfuscation":"YhQ4IvLglIWvBa","output_index":0,"sequence_number":8}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":"se","item_id":"msg_01432258600f7c15006a2b3ccb103c819a849227fe4c5ee757","logprobs":[],"obfuscation":"LRD7Eq26ObEsiB","output_index":0,"sequence_number":9}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","content_index":0,"delta":"-ok","item_id":"msg_01432258600f7c15006a2b3ccb103c819a849227fe4c5ee757","logprobs":[],"obfuscation":"sRgpabsQD7Z6d","output_index":0,"sequence_number":10}
+
+event: response.output_text.done
+data: {"type":"response.output_text.done","content_index":0,"item_id":"msg_01432258600f7c15006a2b3ccb103c819a849227fe4c5ee757","logprobs":[],"output_index":0,"sequence_number":11,"text":"paper-codex-sse-ok"}
+
+event: response.content_part.done
+data: {"type":"response.content_part.done","content_index":0,"item_id":"msg_01432258600f7c15006a2b3ccb103c819a849227fe4c5ee757","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"paper-codex-sse-ok"},"sequence_number":12}
+
+event: response.output_item.done
+data: {"type":"response.output_item.done","item":{"id":"msg_01432258600f7c15006a2b3ccb103c819a849227fe4c5ee757","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"paper-codex-sse-ok"}],"role":"assistant"},"output_index":0,"sequence_number":13}
+
+event: response.completed
+data: {"type":"response.completed","response":{"id":"resp_01432258600f7c15006a2b3cca8f00819aa3844016990df817","object":"response","created_at":1781218506,"status":"completed","background":false,"completed_at":1781218507,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-mini-2024-07-18","moderation":null,"output":[{"id":"msg_01432258600f7c15006a2b3ccb103c819a849227fe4c5ee757","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"paper-codex-sse-ok"}],"role":"assistant"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"in_memory","reasoning":{"context":null,"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":18,"input_tokens_details":{"cached_tokens":0},"output_tokens":8,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":26},"user":null,"metadata":{}},"sequence_number":14}
+

--- a/pkg/llm/provider/openai/openai.go
+++ b/pkg/llm/provider/openai/openai.go
@@ -23,6 +23,12 @@ func (o *Provider) DefaultStreaming() bool {
 }
 
 func (o *Provider) ParseRequest(payload []byte) (*llm.ChatRequest, error) {
+	// Responses API requests (Codex et al.) carry `input` instead of
+	// `messages` and need their own item mapping.
+	if isResponsesRequest(payload) {
+		return parseResponsesRequest(payload)
+	}
+
 	var req openaiRequest
 	if err := json.Unmarshal(payload, &req); err != nil {
 		return nil, err

--- a/pkg/llm/provider/openai/responses.go
+++ b/pkg/llm/provider/openai/responses.go
@@ -1,0 +1,264 @@
+package openai
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/papercomputeco/tapes/pkg/llm"
+)
+
+// OpenAI Responses API support. Codex and other Responses-first harnesses
+// POST /v1/responses with an `input` item list instead of Chat Completions'
+// `messages`, so the provider sniffs the request shape and parses each with
+// its own mapping into the canonical llm.ChatRequest.
+
+// responsesRequest is the subset of the Responses API request body tapes
+// maps onto llm.ChatRequest. `input` is either a bare string or an array of
+// items; items are kept raw and decoded per type.
+type responsesRequest struct {
+	Model           string          `json:"model"`
+	Input           json.RawMessage `json:"input"`
+	Instructions    string          `json:"instructions,omitempty"`
+	MaxOutputTokens *int            `json:"max_output_tokens,omitempty"`
+	Temperature     *float64        `json:"temperature,omitempty"`
+	TopP            *float64        `json:"top_p,omitempty"`
+	Stream          *bool           `json:"stream,omitempty"`
+	Reasoning       map[string]any  `json:"reasoning,omitempty"`
+	PreviousID      string          `json:"previous_response_id,omitempty"`
+}
+
+// responsesItem is the union of the Responses input/output item shapes tapes
+// understands. Codex omits `"type":"message"` on plain role/content items,
+// so a missing type with a role present is treated as a message.
+type responsesItem struct {
+	Type    string          `json:"type"`
+	Role    string          `json:"role"`
+	Content json.RawMessage `json:"content"`
+
+	// function_call / function_call_output
+	CallID    string          `json:"call_id"`
+	Name      string          `json:"name"`
+	Arguments string          `json:"arguments"`
+	Output    json.RawMessage `json:"output"`
+
+	// reasoning
+	Summary          []responsesContentPart `json:"summary"`
+	EncryptedContent string                 `json:"encrypted_content"`
+}
+
+// responsesContentPart is one entry of a message item's content array
+// (input_text / output_text / summary_text / refusal / input_image, ...).
+type responsesContentPart struct {
+	Type     string `json:"type"`
+	Text     string `json:"text"`
+	Refusal  string `json:"refusal"`
+	ImageURL string `json:"image_url"`
+}
+
+// isResponsesRequest reports whether the payload is a Responses API request
+// rather than Chat Completions: Responses carries `input`, never `messages`.
+func isResponsesRequest(payload []byte) bool {
+	var probe struct {
+		Messages json.RawMessage `json:"messages"`
+		Input    json.RawMessage `json:"input"`
+	}
+	if err := json.Unmarshal(payload, &probe); err != nil {
+		return false
+	}
+	return jsonFieldPresent(probe.Input) && !jsonFieldPresent(probe.Messages)
+}
+
+// jsonFieldPresent reports whether a raw field carried a real value: a
+// missing key decodes to an empty RawMessage, but an explicit JSON null
+// keeps the literal `null` bytes and must count as absent too — routing
+// `{"input": null}` to the Responses parser would fabricate an empty
+// user message out of nothing.
+func jsonFieldPresent(raw json.RawMessage) bool {
+	return len(raw) > 0 && !bytes.Equal(raw, []byte("null"))
+}
+
+// parseResponsesRequest maps a Responses API request to llm.ChatRequest.
+// Instructions become the system prompt; input items become messages with
+// the same role conventions as the Chat Completions mapping (tool calls on
+// assistant messages, tool outputs on role "tool").
+func parseResponsesRequest(payload []byte) (*llm.ChatRequest, error) {
+	var req responsesRequest
+	if err := json.Unmarshal(payload, &req); err != nil {
+		return nil, err
+	}
+
+	var messages []llm.Message
+	if len(req.Input) > 0 {
+		var inputText string
+		if err := json.Unmarshal(req.Input, &inputText); err == nil {
+			messages = []llm.Message{llm.NewTextMessage("user", inputText)}
+		} else {
+			var items []json.RawMessage
+			if err := json.Unmarshal(req.Input, &items); err != nil {
+				return nil, fmt.Errorf("responses input is neither string nor item array: %w", err)
+			}
+			messages = make([]llm.Message, 0, len(items))
+			for _, raw := range items {
+				msg, ok := responsesItemToMessage(raw)
+				if ok {
+					messages = append(messages, msg)
+				}
+			}
+		}
+	}
+
+	result := &llm.ChatRequest{
+		Model:       req.Model,
+		Messages:    messages,
+		System:      req.Instructions,
+		MaxTokens:   req.MaxOutputTokens,
+		Temperature: req.Temperature,
+		TopP:        req.TopP,
+		Stream:      req.Stream,
+		RawRequest:  payload,
+	}
+
+	extra := map[string]any{"endpoint": "responses"}
+	if len(req.Reasoning) > 0 {
+		extra["reasoning"] = req.Reasoning
+	}
+	if req.PreviousID != "" {
+		extra["previous_response_id"] = req.PreviousID
+	}
+	result.Extra = extra
+
+	return result, nil
+}
+
+// responsesItemToMessage maps one Responses item to a canonical message.
+// Unknown item types are preserved as a single raw-content block rather than
+// dropped, so novel Codex tool shapes survive capture verbatim.
+func responsesItemToMessage(raw json.RawMessage) (llm.Message, bool) {
+	var item responsesItem
+	if err := json.Unmarshal(raw, &item); err != nil {
+		return llm.Message{}, false
+	}
+
+	switch {
+	case item.Type == "message" || (item.Type == "" && item.Role != ""):
+		return llm.Message{
+			Role:    item.Role,
+			Content: responsesContentBlocks(item.Content),
+		}, true
+
+	case item.Type == "function_call":
+		return llm.Message{
+			Role:    "assistant",
+			Content: []llm.ContentBlock{functionCallBlock(item, raw)},
+		}, true
+
+	case item.Type == "function_call_output":
+		return llm.Message{
+			Role: "tool",
+			Content: []llm.ContentBlock{{
+				Type:         "tool_result",
+				ToolResultID: item.CallID,
+				ToolOutput:   rawToText(item.Output),
+			}},
+		}, true
+
+	case item.Type == "reasoning":
+		return llm.Message{
+			Role:    "assistant",
+			Content: []llm.ContentBlock{reasoningBlock(item)},
+		}, true
+
+	default:
+		return llm.Message{
+			Role:    "assistant",
+			Content: []llm.ContentBlock{{Type: item.Type, Content: raw}},
+		}, true
+	}
+}
+
+// responsesContentBlocks maps a message item's content — bare string or
+// part array — to canonical content blocks.
+func responsesContentBlocks(raw json.RawMessage) []llm.ContentBlock {
+	if len(raw) == 0 {
+		return []llm.ContentBlock{}
+	}
+
+	var text string
+	if err := json.Unmarshal(raw, &text); err == nil {
+		return []llm.ContentBlock{{Type: "text", Text: text}}
+	}
+
+	var parts []responsesContentPart
+	if err := json.Unmarshal(raw, &parts); err != nil {
+		return []llm.ContentBlock{{Type: "text", Content: raw}}
+	}
+
+	blocks := make([]llm.ContentBlock, 0, len(parts))
+	for _, part := range parts {
+		switch part.Type {
+		case "input_text", "output_text", "summary_text":
+			blocks = append(blocks, llm.ContentBlock{Type: "text", Text: part.Text})
+		case "refusal":
+			blocks = append(blocks, llm.ContentBlock{Type: "refusal", Text: part.Refusal})
+		case "input_image":
+			blocks = append(blocks, llm.ContentBlock{Type: "image", ImageURL: part.ImageURL})
+		default:
+			blocks = append(blocks, llm.ContentBlock{Type: part.Type, Text: part.Text})
+		}
+	}
+	return blocks
+}
+
+// functionCallBlock maps a function_call item to a tool_use block. The
+// Responses wire carries arguments as a JSON string; when it does not parse
+// as an object the raw item is preserved on Content so nothing is lost.
+func functionCallBlock(item responsesItem, raw json.RawMessage) llm.ContentBlock {
+	cb := llm.ContentBlock{
+		Type:      "tool_use",
+		ToolUseID: item.CallID,
+		ToolName:  item.Name,
+	}
+	if item.Arguments != "" {
+		var input map[string]any
+		if err := json.Unmarshal([]byte(item.Arguments), &input); err == nil {
+			cb.ToolInput = input
+		} else {
+			cb.Content = raw
+		}
+	}
+	return cb
+}
+
+// reasoningBlock maps a reasoning item to a thinking block. The summary text
+// is the only human-readable part; encrypted_content is the opaque
+// continuation blob, preserved on the signature field like Anthropic's
+// thinking signatures.
+func reasoningBlock(item responsesItem) llm.ContentBlock {
+	var b strings.Builder
+	for _, part := range item.Summary {
+		if b.Len() > 0 && part.Text != "" {
+			b.WriteString("\n")
+		}
+		b.WriteString(part.Text)
+	}
+	return llm.ContentBlock{
+		Type:              "thinking",
+		Thinking:          b.String(),
+		ThinkingSignature: item.EncryptedContent,
+	}
+}
+
+// rawToText renders a function_call_output payload as text: bare strings
+// unquote, structured outputs stay compact JSON.
+func rawToText(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s
+	}
+	return string(raw)
+}

--- a/pkg/llm/provider/openai/responses_test.go
+++ b/pkg/llm/provider/openai/responses_test.go
@@ -1,0 +1,110 @@
+package openai_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/papercomputeco/tapes/pkg/llm/provider/openai"
+)
+
+var _ = Describe("Responses API request parsing", func() {
+	var provider *openai.Provider
+
+	BeforeEach(func() {
+		provider = openai.New()
+	})
+
+	It("parses a Codex-shaped item-list request", func() {
+		payload := []byte(`{
+			"model": "gpt-5.5",
+			"instructions": "You are Codex.",
+			"stream": true,
+			"input": [
+				{"type": "message", "role": "user", "content": [{"type": "input_text", "text": "list files"}]},
+				{"type": "reasoning", "summary": [{"type": "summary_text", "text": "plan"}], "encrypted_content": "blob"},
+				{"type": "function_call", "call_id": "call_1", "name": "shell", "arguments": "{\"command\":[\"ls\"]}"},
+				{"type": "function_call_output", "call_id": "call_1", "output": "README.md"}
+			]
+		}`)
+
+		req, err := provider.ParseRequest(payload)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(req.Model).To(Equal("gpt-5.5"))
+		Expect(req.System).To(Equal("You are Codex."))
+		Expect(req.Stream).NotTo(BeNil())
+		Expect(*req.Stream).To(BeTrue())
+		Expect(req.Extra).To(HaveKeyWithValue("endpoint", "responses"))
+
+		Expect(req.Messages).To(HaveLen(4))
+
+		Expect(req.Messages[0].Role).To(Equal("user"))
+		Expect(req.Messages[0].GetText()).To(Equal("list files"))
+
+		Expect(req.Messages[1].Role).To(Equal("assistant"))
+		Expect(req.Messages[1].Content[0].Type).To(Equal("thinking"))
+		Expect(req.Messages[1].Content[0].Thinking).To(Equal("plan"))
+		Expect(req.Messages[1].Content[0].ThinkingSignature).To(Equal("blob"))
+
+		Expect(req.Messages[2].Role).To(Equal("assistant"))
+		Expect(req.Messages[2].Content[0].Type).To(Equal("tool_use"))
+		Expect(req.Messages[2].Content[0].ToolUseID).To(Equal("call_1"))
+		Expect(req.Messages[2].Content[0].ToolName).To(Equal("shell"))
+		Expect(req.Messages[2].Content[0].ToolInput).To(HaveKey("command"))
+
+		Expect(req.Messages[3].Role).To(Equal("tool"))
+		Expect(req.Messages[3].Content[0].Type).To(Equal("tool_result"))
+		Expect(req.Messages[3].Content[0].ToolResultID).To(Equal("call_1"))
+		Expect(req.Messages[3].Content[0].ToolOutput).To(Equal("README.md"))
+	})
+
+	It("parses a bare-string input as a user message", func() {
+		req, err := provider.ParseRequest([]byte(`{"model": "gpt-5.5", "input": "hello"}`))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(req.Messages).To(HaveLen(1))
+		Expect(req.Messages[0].Role).To(Equal("user"))
+		Expect(req.Messages[0].GetText()).To(Equal("hello"))
+	})
+
+	It("treats typeless role/content items as messages", func() {
+		// Codex omits "type":"message" on plain conversation items.
+		req, err := provider.ParseRequest([]byte(`{
+			"model": "gpt-5.5",
+			"input": [{"role": "user", "content": "hi"}]
+		}`))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(req.Messages).To(HaveLen(1))
+		Expect(req.Messages[0].Role).To(Equal("user"))
+		Expect(req.Messages[0].GetText()).To(Equal("hi"))
+	})
+
+	It("preserves unknown item types as raw content blocks", func() {
+		req, err := provider.ParseRequest([]byte(`{
+			"model": "gpt-5.5",
+			"input": [{"type": "web_search_call", "id": "ws_1"}]
+		}`))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(req.Messages).To(HaveLen(1))
+		Expect(req.Messages[0].Content[0].Type).To(Equal("web_search_call"))
+		Expect(req.Messages[0].Content[0].Content).NotTo(BeEmpty())
+	})
+
+	It("treats an explicit null input as Chat Completions, not Responses", func() {
+		// json.RawMessage keeps the literal `null` bytes; without the
+		// null check this would fabricate an empty user message.
+		req, err := provider.ParseRequest([]byte(`{"model": "gpt-4o", "input": null}`))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(req.Messages).To(BeEmpty())
+		Expect(req.Extra).NotTo(HaveKey("endpoint"))
+	})
+
+	It("still parses Chat Completions requests unchanged", func() {
+		req, err := provider.ParseRequest([]byte(`{
+			"model": "gpt-4o",
+			"messages": [{"role": "user", "content": "hi"}]
+		}`))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(req.Messages).To(HaveLen(1))
+		Expect(req.Extra).NotTo(HaveKey("endpoint"))
+	})
+})

--- a/pkg/sessions/pricing.go
+++ b/pkg/sessions/pricing.go
@@ -10,7 +10,7 @@ import (
 
 // DefaultPricing returns hardcoded pricing per million tokens for supported models.
 //
-// Last verified: 2026-06-09
+// Last verified: 2026-06-12
 // Sources:
 //   - Anthropic: https://platform.claude.com/docs/en/about-claude/pricing
 //   - OpenAI:    https://platform.openai.com/docs/pricing
@@ -50,6 +50,7 @@ func DefaultPricing() PricingTable {
 		"o3":                {Input: 2.00, Output: 8.00, CacheRead: 0.50, CacheWrite: 2.00},
 		"o3-mini":           {Input: 1.10, Output: 4.40, CacheRead: 0.55, CacheWrite: 1.10},
 		"o4-mini":           {Input: 1.10, Output: 4.40, CacheRead: 0.275, CacheWrite: 1.10},
+		"gpt-5.5":           {Input: 5.00, Output: 30.00, CacheRead: 0.50, CacheWrite: 5.00},
 		"gpt-5.4":           {Input: 2.50, Output: 15.00, CacheRead: 0.25, CacheWrite: 2.50},
 		"gpt-5.3-codex":     {Input: 1.75, Output: 14.00, CacheRead: 0.175, CacheWrite: 1.75},
 		"gpt-5.2-codex":     {Input: 1.75, Output: 14.00, CacheRead: 0.175, CacheWrite: 1.75},
@@ -148,6 +149,7 @@ func NormalizeModel(model string) string {
 	// Strip OpenAI-style date suffix: -YYYY-MM-DD
 	normalized = stripOpenAIDateSuffix(normalized)
 
+	normalized = strings.ReplaceAll(normalized, "-5-5", "-5.5")
 	normalized = strings.ReplaceAll(normalized, "-5-4", "-5.4")
 	normalized = strings.ReplaceAll(normalized, "-5-3", "-5.3")
 	normalized = strings.ReplaceAll(normalized, "-5-2", "-5.2")

--- a/pkg/sessions/summary_test.go
+++ b/pkg/sessions/summary_test.go
@@ -263,6 +263,9 @@ var _ = Describe("NormalizeModel", func() {
 	})
 	It("strips OpenAI-style date suffix", func() {
 		Expect(sessions.NormalizeModel("gpt-4o-2024-08-06")).To(Equal("gpt-4o"))
+		// Codex default model id as seen on the Responses wire.
+		Expect(sessions.NormalizeModel("gpt-5.5-2026-04-23")).To(Equal("gpt-5.5"))
+		Expect(sessions.NormalizeModel("gpt-5-5-2026-04-23")).To(Equal("gpt-5.5"))
 	})
 	It("strips the Anthropic 1M-context marker", func() {
 		Expect(sessions.NormalizeModel("claude-fable-5[1m]")).To(Equal("claude-fable-5"))


### PR DESCRIPTION
## Summary
- Adds an OpenAI Responses API capture reducer (`pkg/capture/openai_responses.go`) and request parser (`pkg/llm/provider/openai/responses.go`) so Codex turns reduce to the same canonical `ChatRequest`/`ChatResponse` shapes as Chat Completions and land in the DAG uniformly.
- Reduction prefers the terminal `response.completed/incomplete/failed` event and accumulates `response.output_item.done` items along the way: `chatgpt.com/backend-api/codex` sends the terminal event with an **empty `output` array**, while `api.openai.com` echoes the full item list — both upstreams reduce identically. Streams torn down early keep accumulated items (or text deltas) as a flagged partial capture instead of a hole.
- `chatgpt.com/backend-api/codex` omits the `Content-Type` header entirely on its SSE responses, so an absent/unknown content type sniffs the body for an SSE field name before choosing the stream vs one-shot path.
- Request parsing detects the Responses shape by presence of `input` (Responses never carries `messages`) and maps items with the existing role conventions: `function_call` → assistant `tool_use`, `function_call_output` → tool `tool_result`, `reasoning` → `thinking` with `encrypted_content` preserved on the signature field. Unknown item types survive verbatim as raw-content blocks.
- Prices `gpt-5.5` (Codex's default model, $5.00/$0.50-cached/$30.00 per MTok per OpenAI's pricing page) so captured Codex turns get cost attribution.

## Claude-path safety
- Anthropic reducer and parser behavior is untouched; the only shared-file edit is sharing a stop-reason constant.
- The Chat Completions parser is unchanged behind a cheap shape probe (`input` present + `messages` absent), so existing OpenAI traffic parses exactly as before.

## Validation
- The testdata fixtures are real wire captures (api.openai.com one-shot + SSE, chatgpt.com/backend-api/codex SSE) recorded through a local clearing — not hand-written approximations.
- End-to-end in the clearing: real `codex exec` tool-call turns in both auth modes (API key and ChatGPT plan) captured as structured stems with tool_use/tool_result blocks, usage incl. cache-read tokens, and cost.

## Test plan
- [x] `make check` green (generate, go-mod-tidy, lint, full test suite)
- [x] Staging validation rides the tapes-extproc + TKO rollout

Companion consumer (draft while this is in review): papercomputeco/tapes-extproc#19 — gated on the next tapes release.

Part of PCC-680
