### PR TITLE
✨ feat: prefer a native Ollama install over Docker in tapes local

### DIFF
--- a/cmd/tapes/local/local.go
+++ b/cmd/tapes/local/local.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"os/exec"
 	"path"
@@ -39,6 +40,7 @@ type localCommander struct {
 	ollamaPort    int
 	postgresImage string
 	ollamaImage   string
+	dockerOllama  bool
 }
 
 func NewLocalCmd() *cobra.Command {
@@ -58,6 +60,11 @@ This starts:
   - Postgres for tapes storage + pgvector + pg_duckdb
   - Ollama for local inference/embeddings
 
+When Ollama is already installed on the host, the existing install is used
+instead of a Docker container — native Ollama has direct GPU access, which a
+containerized Ollama does not on macOS. Pass --docker-ollama to force the
+container anyway.
+
 Examples:
   tapes local
   tapes local up
@@ -75,6 +82,7 @@ Examples:
 	cmd.Flags().IntVar(&cmder.ollamaPort, "ollama-port", cmder.ollamaPort, "Host port to bind Ollama to")
 	cmd.Flags().StringVar(&cmder.postgresImage, "postgres-image", cmder.postgresImage, "Docker image to use for Postgres")
 	cmd.Flags().StringVar(&cmder.ollamaImage, "ollama-image", cmder.ollamaImage, "Docker image to use for Ollama")
+	cmd.Flags().BoolVar(&cmder.dockerOllama, "docker-ollama", cmder.dockerOllama, "Run Ollama in Docker even if a native install is present")
 
 	cmd.AddCommand(&cobra.Command{
 		Use:   "up",
@@ -131,8 +139,24 @@ func (c *localCommander) runUp() error {
 	if err := ensureDockerImage(c.postgresImage, "Postgres"); err != nil {
 		return err
 	}
-	if err := ensureDockerImage(c.ollamaImage, "Ollama"); err != nil {
+
+	containerRunning, _, err := containerState(ollamaContainer)
+	if err != nil {
 		return err
+	}
+	nativeURL := fmt.Sprintf("http://127.0.0.1:%d", c.ollamaPort)
+	_, lookErr := exec.LookPath("ollama")
+	plan := planOllama(
+		c.dockerOllama,
+		containerRunning,
+		!containerRunning && ollamaServing(nativeURL),
+		lookErr == nil,
+	)
+
+	if plan.useDocker {
+		if err := ensureDockerImage(c.ollamaImage, "Ollama"); err != nil {
+			return err
+		}
 	}
 	postgresDir, err := ensureLocalPostgresDir(c.configDir)
 	if err != nil {
@@ -144,17 +168,30 @@ func (c *localCommander) runUp() error {
 	if err := ensurePostgresContainer(c); err != nil {
 		return err
 	}
-	if err := ensureOllamaContainer(c); err != nil {
-		return err
-	}
 	if err := cliui.Step(os.Stdout, "Waiting for Postgres", waitForPostgresReady); err != nil {
 		return err
 	}
-	if err := cliui.Step(os.Stdout, "Waiting for Ollama", waitForOllamaReady); err != nil {
-		return err
-	}
-	if err := ensureOllamaModel(ollamaEmbeddingModel); err != nil {
-		return err
+
+	ollamaURL := nativeURL
+	switch {
+	case plan.useDocker:
+		ollamaURL = fmt.Sprintf("http://localhost:%d", c.ollamaPort)
+		if err := ensureOllamaContainer(c); err != nil {
+			return err
+		}
+		if err := cliui.Step(os.Stdout, "Waiting for Ollama", waitForOllamaReady); err != nil {
+			return err
+		}
+		if err := ensureOllamaModel(ollamaEmbeddingModel); err != nil {
+			return err
+		}
+	case plan.needsStart:
+		fmt.Printf("  %s %s\n", cliui.WarnStyle.Render("●"), cliui.StepStyle.Render("Ollama is installed but not running — start it (ollama serve, or the Ollama app) and pull the embedding model: ollama pull "+ollamaEmbeddingModel))
+	default:
+		fmt.Printf("  %s %s\n", cliui.SuccessMark, cliui.StepStyle.Render("Using existing Ollama at "+nativeURL))
+		if err := ensureNativeOllamaModel(ollamaEmbeddingModel); err != nil {
+			return err
+		}
 	}
 
 	dsn := fmt.Sprintf("postgres://%s:%s@localhost:%d/%s?sslmode=disable", postgresUser, postgresPass, c.postgresPort, postgresDB)
@@ -162,19 +199,67 @@ func (c *localCommander) runUp() error {
 	fmt.Printf("\n%s\n", cliui.HeaderStyle.Render("Started local services"))
 	fmt.Printf("  %s %s\n", cliui.KeyStyle.Render("Postgres:"), cliui.ValueStyle.Render(dsn))
 	fmt.Printf("  %s %s\n", cliui.KeyStyle.Render("Data dir:"), cliui.ValueStyle.Render(postgresDir))
-	fmt.Printf("  %s %s\n\n", cliui.KeyStyle.Render("Ollama:  "), cliui.ValueStyle.Render(fmt.Sprintf("http://localhost:%d", c.ollamaPort)))
+	fmt.Printf("  %s %s\n\n", cliui.KeyStyle.Render("Ollama:  "), cliui.ValueStyle.Render(ollamaURL))
 	fmt.Printf("%s\n", cliui.HeaderStyle.Render("Suggested config"))
 	fmt.Printf("  tapes config set storage.postgres_dsn %q\n", dsn)
 	fmt.Printf("  tapes config set vector_store.provider %q\n", "pgvector")
 	fmt.Printf("  tapes config set vector_store.target %q\n", dsn)
-	fmt.Printf("  tapes config set proxy.upstream %q\n", fmt.Sprintf("http://localhost:%d", c.ollamaPort))
+	fmt.Printf("  tapes config set proxy.upstream %q\n", ollamaURL)
 	fmt.Printf("  tapes config set embedding.provider %q\n", "ollama")
-	fmt.Printf("  tapes config set embedding.target %q\n", fmt.Sprintf("http://localhost:%d", c.ollamaPort))
+	fmt.Printf("  tapes config set embedding.target %q\n", ollamaURL)
 	fmt.Printf("  tapes config set embedding.model %q\n\n", defaultEmbeddingModel)
 	fmt.Printf("Next steps:\n")
 	fmt.Printf("  1. Run: tapes serve --postgres %q\n", dsn)
-	fmt.Printf("  2. Optionally pull chat/completion models with: docker exec -it %s ollama pull qwen3-coder:30b\n\n", ollamaContainer)
+	if plan.useDocker {
+		fmt.Printf("  2. Optionally pull chat/completion models with: docker exec -it %s ollama pull qwen3-coder:30b\n\n", ollamaContainer)
+	} else {
+		fmt.Printf("  2. Optionally pull chat/completion models with: ollama pull qwen3-coder:30b\n\n")
+	}
 	return nil
+}
+
+// ollamaPlan describes how `tapes local up` satisfies the Ollama dependency.
+type ollamaPlan struct {
+	// useDocker provisions (or keeps) the tapes-local-ollama container.
+	useDocker bool
+	// needsStart is set when a native install was found but nothing answers
+	// on the port; the user has to start the server themselves.
+	needsStart bool
+}
+
+// planOllama prefers an Ollama already on the host over the Docker container.
+// Native Ollama has direct GPU access, which a container does not on macOS.
+// A container published on the same port also binds the wildcard addresses
+// and shadows a loopback-only native server for clients that resolve
+// localhost to ::1, so provisioning one next to a native install produces
+// silently split traffic.
+func planOllama(forceDocker, containerRunning, serving, installed bool) ollamaPlan {
+	switch {
+	case forceDocker || containerRunning:
+		return ollamaPlan{useDocker: true}
+	case serving:
+		return ollamaPlan{}
+	case installed:
+		return ollamaPlan{needsStart: true}
+	default:
+		return ollamaPlan{useDocker: true}
+	}
+}
+
+// ollamaServing reports whether an Ollama API answers at url.
+func ollamaServing(url string) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url+"/api/version", nil)
+	if err != nil {
+		return false
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode == http.StatusOK
 }
 
 func (c *localCommander) runDown() error {
@@ -203,6 +288,12 @@ func (c *localCommander) runStatus() error {
 		}
 		status := strings.TrimSpace(out)
 		if status == "" {
+			if name == ollamaContainer {
+				if nativeURL := fmt.Sprintf("http://127.0.0.1:%d", c.ollamaPort); ollamaServing(nativeURL) {
+					fmt.Printf("  %s %s %s\n", cliui.SuccessMark, cliui.NameStyle.Render("ollama (native)"), cliui.ValueStyle.Render(nativeURL))
+					continue
+				}
+			}
 			fmt.Printf("  %s %s %s\n", cliui.DimStyle.Render("●"), cliui.NameStyle.Render(name), cliui.DimStyle.Render("not created"))
 			continue
 		}
@@ -343,6 +434,17 @@ func waitForOllamaReady() error {
 func ensureOllamaModel(model string) error {
 	fmt.Printf("  %s %s\n", cliui.WarnStyle.Render("↓"), cliui.StepStyle.Render("Pulling Ollama model "+model))
 	return runDocker("exec", ollamaContainer, "ollama", "pull", model)
+}
+
+func ensureNativeOllamaModel(model string) error {
+	fmt.Printf("  %s %s\n", cliui.WarnStyle.Render("↓"), cliui.StepStyle.Render("Pulling Ollama model "+model))
+	cmd := exec.CommandContext(context.Background(), "ollama", "pull", model)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("ollama pull %s: %w", model, err)
+	}
+	return nil
 }
 
 func resolveLocalTapesDir(configDir string) (string, error) {

--- a/cmd/tapes/local/local_test.go
+++ b/cmd/tapes/local/local_test.go
@@ -1,6 +1,8 @@
 package localcmder
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 
@@ -62,6 +64,59 @@ var _ = Describe("local", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(Equal(filepath.Join(overrideDir, postgresDirName)))
 			Expect(result).To(BeADirectory())
+		})
+	})
+
+	Describe("planOllama", func() {
+		It("uses a native server that is already answering", func() {
+			plan := planOllama(false, false, true, true)
+			Expect(plan.useDocker).To(BeFalse())
+			Expect(plan.needsStart).To(BeFalse())
+		})
+
+		It("asks the user to start a native install that is not serving", func() {
+			plan := planOllama(false, false, false, true)
+			Expect(plan.useDocker).To(BeFalse())
+			Expect(plan.needsStart).To(BeTrue())
+		})
+
+		It("falls back to Docker when no native install exists", func() {
+			plan := planOllama(false, false, false, false)
+			Expect(plan.useDocker).To(BeTrue())
+		})
+
+		It("keeps an already-running container", func() {
+			plan := planOllama(false, true, false, true)
+			Expect(plan.useDocker).To(BeTrue())
+		})
+
+		It("honors --docker-ollama over a native install", func() {
+			plan := planOllama(true, false, true, true)
+			Expect(plan.useDocker).To(BeTrue())
+		})
+	})
+
+	Describe("ollamaServing", func() {
+		It("reports true for a server answering /api/version", func() {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/api/version" {
+					w.WriteHeader(http.StatusOK)
+					return
+				}
+				w.WriteHeader(http.StatusNotFound)
+			}))
+			DeferCleanup(srv.Close)
+
+			Expect(ollamaServing(srv.URL)).To(BeTrue())
+		})
+
+		It("reports false when nothing is listening", func() {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+			srv.Close()
+
+			Expect(ollamaServing(srv.URL)).To(BeFalse())
 		})
 	})
 })


### PR DESCRIPTION
## Summary

- `tapes local up` now detects an existing native Ollama and uses it instead of provisioning the `tapes-local-ollama` container. Docker remains the fallback when no native install exists; `--docker-ollama` forces the old behavior.
- Motivation: the container has no GPU access on macOS, so embeddings run CPU-only — observed in practice as ~600% sustained CPU with embeds taking 4s–2min each (vs milliseconds on Metal), and a 37k-node embedding backlog that would take days to drain.
- The container also *shadows* a native install: a published port binds the wildcard addresses, so clients that resolve `localhost` to `::1` silently land in the container even while a loopback-only native server is running. The suggested config now prints an explicit `http://127.0.0.1:<port>` target so this can't recur.

## How it works

`runUp` gathers three facts — is the `tapes-local-ollama` container already running, is something answering `/api/version` on the port, is an `ollama` binary on `PATH` — and feeds them to a pure `planOllama` function. The embedding model is pulled through whichever path was chosen (native `ollama pull` vs `docker exec`). `tapes local status` reports `ollama (native)` when the container doesn't exist but a native server is serving.

## Behavior matrix

| Scenario | Before | After |
|---|---|---|
| Native Ollama serving on the port | container created, shadows native | native used, model pulled natively |
| Ollama installed but not running | container created, shadows it later | prompt to start it; no container |
| No Ollama on the host | container created | container created (unchanged) |
| `tapes-local-ollama` already running | kept | kept (unchanged) |
| `--docker-ollama` | n/a | container forced |

## Test plan

- [x] `dagger check` green locally (golangci-lint, generate check, `go test`)
- [x] Unit tests for `planOllama` decision table and `ollamaServing` probe
- [x] Manual: `local up` on a machine with native Ollama serving — skipped the container, pulled `embeddinggemma` natively, printed `127.0.0.1` suggested config; `local status` shows `ollama (native)`
- [ ] Manual: fallback path on a machine with no Ollama install
- [ ] Manual: `--docker-ollama` override

Fixes PCC-684