### PR TITLE
✨ feat: (api) resolve sessions by harness identity and filter by captured user

### DIFF
--- a/api/sessions_handlers.go
+++ b/api/sessions_handlers.go
@@ -22,7 +22,7 @@ import (
 // (the sessions-table-backed surface at /v1/sessions). The Postgres driver
 // implements it; the handler returns 501 for drivers that don't.
 type sessionsReader interface {
-	ListSessionRecords(ctx context.Context, orgID string, limit int, cursorTs *time.Time, cursorID *string) ([]storage.SessionRecord, error)
+	ListSessionRecords(ctx context.Context, orgID string, authSubject string, limit int, cursorTs *time.Time, cursorID *string) ([]storage.SessionRecord, error)
 	GetSessionRecord(ctx context.Context, orgID, id string) (*storage.SessionRecord, error)
 	GetSessionRecordByHarness(ctx context.Context, orgID string, harnessID string, harnessSessionID string) (*storage.SessionRecord, error)
 	ListNodesBySession(ctx context.Context, sessionID string) ([]*merkle.Node, error)
@@ -53,6 +53,10 @@ type SessionItem struct {
 	DerivedStatus     string         `json:"derived_status"`
 	HarnessMetadata   map[string]any `json:"harness_metadata,omitempty"`
 	Preview           string         `json:"preview,omitempty"`
+	// AuthSubject is the gateway-stamped JWT subject (WorkOS user id)
+	// captured at ingest; empty for rows captured before the edge began
+	// stamping it.
+	AuthSubject string `json:"auth_subject,omitempty"`
 }
 
 // SessionListResponse is the response envelope for GET /v1/sessions.
@@ -100,6 +104,7 @@ func sessionItemFromStorage(s storage.SessionRecord) SessionItem {
 		DerivedStatus:     s.DerivedStatus,
 		HarnessMetadata:   s.HarnessMetadata,
 		Preview:           s.Preview,
+		AuthSubject:       s.AuthSubject,
 	}
 }
 
@@ -147,6 +152,7 @@ func decodeSessionsCursor(token string) (sessionsCursor, error) {
 //	@Param			cursor				query		string	false	"Opaque pagination cursor returned by a previous response"
 //	@Param			harness_id			query		string	false	"Filter to the single session with this harness id (exact match; requires harness_session_id, incompatible with cursor; limit is ignored when the filter is active)"
 //	@Param			harness_session_id	query		string	false	"Filter to the single session with this harness session id (exact match; requires harness_id, incompatible with cursor; limit is ignored when the filter is active)"
+//	@Param			auth_subject		query		string	false	"Filter the paged list to sessions captured for this gateway-stamped JWT subject (exact match; ignored on the harness filter path)"
 //	@Success		200					{object}	SessionListResponse
 //	@Failure		400					{object}	llm.ErrorResponse	"Invalid query parameters, a lone harness filter param, or cursor combined with the harness filter"
 //	@Failure		500					{object}	llm.ErrorResponse	"Failed to list sessions"
@@ -194,7 +200,11 @@ func (s *Server) handleListSessions(c *fiber.Ctx) error {
 
 	orgID := orgIDFromCtx(c)
 	// Fetch one extra item to detect whether a next page exists.
-	sessions, err := reader.ListSessionRecords(c.Context(), orgID, limit+1, cursorTs, cursorID)
+	// Trusted to the same degree as X-Tapes-Org-Id: client-asserted
+	// today, with the cloud edge able to stamp it server-side from the
+	// validated JWT once claim mapping is enabled on the read route.
+	authSubject := c.Query("auth_subject")
+	sessions, err := reader.ListSessionRecords(c.Context(), orgID, authSubject, limit+1, cursorTs, cursorID)
 	if err != nil {
 		s.logger.Error("list sessions", "error", err)
 		return c.Status(fiber.StatusInternalServerError).JSON(llm.ErrorResponse{Error: "failed to list sessions"})

--- a/api/sessions_handlers.go
+++ b/api/sessions_handlers.go
@@ -24,6 +24,7 @@ import (
 type sessionsReader interface {
 	ListSessionRecords(ctx context.Context, orgID string, limit int, cursorTs *time.Time, cursorID *string) ([]storage.SessionRecord, error)
 	GetSessionRecord(ctx context.Context, orgID, id string) (*storage.SessionRecord, error)
+	GetSessionRecordByHarness(ctx context.Context, orgID string, harnessID string, harnessSessionID string) (*storage.SessionRecord, error)
 	ListNodesBySession(ctx context.Context, sessionID string) ([]*merkle.Node, error)
 }
 
@@ -142,17 +143,30 @@ func decodeSessionsCursor(token string) (sessionsCursor, error) {
 //	@Description	Returns one row per harness session from the sessions table, newest first (last_seen_at desc), cursor-paginated. This is the product session view; the Merkle leaf-chain view lives at /v1/stems.
 //	@Tags			sessions
 //	@Produce		json
-//	@Param			limit	query		int		false	"Maximum number of sessions to return (default 50, max 200)"	minimum(1)
-//	@Param			cursor	query		string	false	"Opaque pagination cursor returned by a previous response"
-//	@Success		200		{object}	SessionListResponse
-//	@Failure		400		{object}	llm.ErrorResponse	"Invalid query parameters"
-//	@Failure		500		{object}	llm.ErrorResponse	"Failed to list sessions"
-//	@Failure		501		{object}	llm.ErrorResponse	"Sessions not supported by this backend"
+//	@Param			limit				query		int		false	"Maximum number of sessions to return (default 50, max 200)"	minimum(1)
+//	@Param			cursor				query		string	false	"Opaque pagination cursor returned by a previous response"
+//	@Param			harness_id			query		string	false	"Filter to the single session with this harness id (exact match; requires harness_session_id, incompatible with cursor; limit is ignored when the filter is active)"
+//	@Param			harness_session_id	query		string	false	"Filter to the single session with this harness session id (exact match; requires harness_id, incompatible with cursor; limit is ignored when the filter is active)"
+//	@Success		200					{object}	SessionListResponse
+//	@Failure		400					{object}	llm.ErrorResponse	"Invalid query parameters, a lone harness filter param, or cursor combined with the harness filter"
+//	@Failure		500					{object}	llm.ErrorResponse	"Failed to list sessions"
+//	@Failure		501					{object}	llm.ErrorResponse	"Sessions not supported by this backend"
 //	@Router			/v1/sessions [get]
 func (s *Server) handleListSessions(c *fiber.Ctx) error {
 	reader, ok := s.driver.(sessionsReader)
 	if !ok {
 		return c.Status(fiber.StatusNotImplemented).JSON(llm.ErrorResponse{Error: "sessions not supported by this backend"})
+	}
+
+	// The harness natural-key filter is a point lookup that bypasses the
+	// paged-list path entirely. Route to it whenever either param is
+	// non-empty — an empty value is treated as absent, since ingest
+	// guarantees no stored row carries an empty harness id, so an empty
+	// value could never address a row anyway. Both-or-neither validation
+	// (and cursor incompatibility) happens in the filter handler; requests
+	// without the params take the existing path untouched.
+	if c.Query("harness_id") != "" || c.Query("harness_session_id") != "" {
+		return s.listSessionsByHarness(c, reader)
 	}
 
 	limit := defaultSessionsLimit
@@ -205,6 +219,43 @@ func (s *Server) handleListSessions(c *fiber.Ctx) error {
 		Items:      items,
 		NextCursor: nextCursor,
 	})
+}
+
+// listSessionsByHarness handles GET /v1/sessions when the harness
+// natural-key filter params are present. It validates that harness_id and
+// harness_session_id are supplied both-or-neither (400 on a lone param),
+// rejects cursor combined with the filter (400), then performs a single
+// org-scoped exact-match lookup via GetSessionRecordByHarness and returns
+// the standard SessionListResponse envelope with 0 or 1 items and no
+// next_cursor.
+func (s *Server) listSessionsByHarness(c *fiber.Ctx, reader sessionsReader) error {
+	harnessID := c.Query("harness_id")
+	harnessSessionID := c.Query("harness_session_id")
+	if harnessID == "" || harnessSessionID == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(llm.ErrorResponse{
+			Error: "harness_id and harness_session_id must be supplied together",
+		})
+	}
+	if c.Query("cursor") != "" {
+		return c.Status(fiber.StatusBadRequest).JSON(llm.ErrorResponse{
+			Error: "cursor cannot be combined with the harness filter",
+		})
+	}
+
+	orgID := orgIDFromCtx(c)
+	sess, err := reader.GetSessionRecordByHarness(c.Context(), orgID, harnessID, harnessSessionID)
+	if err != nil {
+		s.logger.Error("get session by harness", "error", err)
+		return c.Status(fiber.StatusInternalServerError).JSON(llm.ErrorResponse{Error: "failed to list sessions"})
+	}
+
+	// A nil record is a normal no-match: the list envelope's empty items
+	// form expresses it (never 404 — that's the :id endpoint's vocabulary).
+	items := []SessionItem{}
+	if sess != nil {
+		items = append(items, sessionItemFromStorage(*sess))
+	}
+	return c.JSON(SessionListResponse{Items: items})
 }
 
 // sessionStems returns one StemSummary per root in nodes, sorted by length

--- a/api/sessions_handlers_test.go
+++ b/api/sessions_handlers_test.go
@@ -1,0 +1,325 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/papercomputeco/tapes/pkg/llm"
+	tapeslogger "github.com/papercomputeco/tapes/pkg/logger"
+	"github.com/papercomputeco/tapes/pkg/merkle"
+	"github.com/papercomputeco/tapes/pkg/storage"
+	"github.com/papercomputeco/tapes/pkg/storage/inmemory"
+)
+
+// sessionsStubDriver wraps a real storage.Driver and implements the
+// unexported sessionsReader capability interface with canned responses,
+// recording the arguments it receives so specs can assert org threading and
+// that validation short-circuits before any storage call. It follows the
+// identityDriver pattern from v1_session_identity_test.go.
+type sessionsStubDriver struct {
+	storage.Driver
+
+	// ListSessionRecords stubbing.
+	listRecords  []storage.SessionRecord
+	listErr      error
+	listCalls    int
+	lastListOrg  string
+	lastLimit    int
+	lastCursorTs *time.Time
+	lastCursorID *string
+
+	// GetSessionRecordByHarness stubbing.
+	harnessRecord        *storage.SessionRecord
+	harnessErr           error
+	harnessCalls         int
+	lastOrgID            string
+	lastHarnessID        string
+	lastHarnessSessionID string
+}
+
+func (d *sessionsStubDriver) ListSessionRecords(_ context.Context, orgID string, limit int, cursorTs *time.Time, cursorID *string) ([]storage.SessionRecord, error) {
+	d.listCalls++
+	d.lastListOrg = orgID
+	d.lastLimit = limit
+	d.lastCursorTs = cursorTs
+	d.lastCursorID = cursorID
+	return d.listRecords, d.listErr
+}
+
+func (d *sessionsStubDriver) GetSessionRecord(_ context.Context, _, _ string) (*storage.SessionRecord, error) {
+	return nil, nil
+}
+
+func (d *sessionsStubDriver) GetSessionRecordByHarness(_ context.Context, orgID, harnessID, harnessSessionID string) (*storage.SessionRecord, error) {
+	d.harnessCalls++
+	d.lastOrgID = orgID
+	d.lastHarnessID = harnessID
+	d.lastHarnessSessionID = harnessSessionID
+	return d.harnessRecord, d.harnessErr
+}
+
+func (d *sessionsStubDriver) ListNodesBySession(_ context.Context, _ string) ([]*merkle.Node, error) {
+	return nil, nil
+}
+
+// getSessionList issues GET path against the server, optionally with the
+// X-Tapes-Org-Id header (empty org sends no header), and decodes the body as
+// a SessionListResponse on 200 or an llm.ErrorResponse otherwise.
+func getSessionList(server *Server, path, org string) (SessionListResponse, llm.ErrorResponse, int) {
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, path, nil)
+	Expect(err).NotTo(HaveOccurred())
+	if org != "" {
+		req.Header.Set(orgIDHeader, org)
+	}
+	resp, err := server.app.Test(req)
+	Expect(err).NotTo(HaveOccurred())
+	defer resp.Body.Close()
+	raw, err := io.ReadAll(resp.Body)
+	Expect(err).NotTo(HaveOccurred())
+
+	var body SessionListResponse
+	var errBody llm.ErrorResponse
+	if resp.StatusCode == fiber.StatusOK {
+		Expect(json.Unmarshal(raw, &body)).To(Succeed())
+	} else {
+		Expect(json.Unmarshal(raw, &errBody)).To(Succeed())
+	}
+	return body, errBody, resp.StatusCode
+}
+
+var _ = Describe("harness natural-key filter on GET /v1/sessions", func() {
+	var record storage.SessionRecord
+
+	newSessionsServer := func(driver storage.Driver) *Server {
+		server, err := NewServer(Config{ListenAddr: ":0"}, driver, tapeslogger.NewNoop())
+		Expect(err).NotTo(HaveOccurred())
+		return server
+	}
+
+	BeforeEach(func() {
+		started := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+		ended := started.Add(10 * time.Minute)
+		record = storage.SessionRecord{
+			ID:                "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+			HarnessID:         "claude",
+			HarnessSessionID:  "sess-xyz",
+			Name:              "menu work",
+			Cwd:               "/home/dev/project",
+			HarnessVersion:    "1.2.3",
+			StartedAt:         started,
+			LastSeenAt:        ended,
+			EndedAt:           &ended,
+			TurnCount:         4,
+			TotalInputTokens:  100,
+			TotalOutputTokens: 200,
+			TotalCostUsd:      0.42,
+			DerivedStatus:     "completed",
+			Preview:           "first user turn",
+		}
+	})
+
+	It("returns a 200 single-item SessionListResponse when both harness params match", func() {
+		drv := &sessionsStubDriver{Driver: inmemory.NewDriver(), harnessRecord: &record}
+		server := newSessionsServer(drv)
+
+		body, _, status := getSessionList(server, "/v1/sessions?harness_id=claude&harness_session_id=sess-xyz", "")
+		Expect(status).To(Equal(fiber.StatusOK))
+		Expect(body.Items).To(HaveLen(1))
+		Expect(body.Items[0].ID).To(Equal(record.ID))
+		Expect(body.Items[0].HarnessID).To(Equal("claude"))
+		Expect(body.Items[0].HarnessSessionID).To(Equal("sess-xyz"))
+		Expect(drv.harnessCalls).To(Equal(1), "the filter must hit the natural-key lookup exactly once")
+		// The params are passed through verbatim — exact match, as stored.
+		Expect(drv.lastHarnessID).To(Equal("claude"))
+		Expect(drv.lastHarnessSessionID).To(Equal("sess-xyz"))
+		Expect(drv.listCalls).To(BeZero(), "the paged-list path must be skipped when filtering")
+	})
+
+	It("returns 200 with empty items when the harness filter matches no session", func() {
+		drv := &sessionsStubDriver{Driver: inmemory.NewDriver(), harnessRecord: nil}
+		server := newSessionsServer(drv)
+
+		body, _, status := getSessionList(server, "/v1/sessions?harness_id=claude&harness_session_id=sess-missing", "")
+		Expect(status).To(Equal(fiber.StatusOK), "a nil record is a normal no-match, never 404/500")
+		Expect(body.Items).NotTo(BeNil(), "no match must serialize as an empty items list, not null")
+		Expect(body.Items).To(BeEmpty())
+		Expect(body.NextCursor).To(BeEmpty())
+		Expect(drv.harnessCalls).To(Equal(1))
+	})
+
+	It("treats empty harness params as absent and serves the unfiltered list", func() {
+		// Both params present but empty must take the unfiltered paged-list
+		// path, not the filter (and not a 400): the router keys on non-empty
+		// values, and ingest guarantees no stored row carries an empty
+		// harness id, so an empty value could never address a row anyway.
+		drv := &sessionsStubDriver{
+			Driver:        inmemory.NewDriver(),
+			listRecords:   []storage.SessionRecord{record},
+			harnessRecord: &record,
+		}
+		server := newSessionsServer(drv)
+
+		body, _, status := getSessionList(server, "/v1/sessions?harness_id=&harness_session_id=", "")
+		Expect(status).To(Equal(fiber.StatusOK))
+		Expect(drv.harnessCalls).To(BeZero(), "empty params must not reach the natural-key lookup")
+		Expect(drv.listCalls).To(Equal(1), "empty params must fall through to the paged list")
+		Expect(body.Items).To(HaveLen(1))
+		Expect(body.Items[0].ID).To(Equal(record.ID))
+	})
+
+	It("returns 400 when only harness_id is supplied", func() {
+		drv := &sessionsStubDriver{Driver: inmemory.NewDriver(), harnessRecord: &record}
+		server := newSessionsServer(drv)
+
+		_, errBody, status := getSessionList(server, "/v1/sessions?harness_id=claude", "")
+		Expect(status).To(Equal(fiber.StatusBadRequest))
+		// The error must name the both-or-neither rule so the caller can tell
+		// the filter was rejected, not silently dropped.
+		Expect(errBody.Error).To(ContainSubstring("harness_id"))
+		Expect(errBody.Error).To(ContainSubstring("harness_session_id"))
+		Expect(drv.harnessCalls).To(BeZero(), "validation must precede any storage call")
+		Expect(drv.listCalls).To(BeZero(), "a lone param must not fall through to the unfiltered list")
+	})
+
+	It("returns 400 when only harness_session_id is supplied", func() {
+		drv := &sessionsStubDriver{Driver: inmemory.NewDriver(), harnessRecord: &record}
+		server := newSessionsServer(drv)
+
+		_, errBody, status := getSessionList(server, "/v1/sessions?harness_session_id=sess-xyz", "")
+		Expect(status).To(Equal(fiber.StatusBadRequest))
+		Expect(errBody.Error).To(ContainSubstring("harness_id"))
+		Expect(errBody.Error).To(ContainSubstring("harness_session_id"))
+		Expect(drv.harnessCalls).To(BeZero(), "validation must precede any storage call")
+		Expect(drv.listCalls).To(BeZero(), "a lone param must not fall through to the unfiltered list")
+	})
+
+	It("threads the X-Tapes-Org-Id org through to the harness lookup", func() {
+		drv := &sessionsStubDriver{Driver: inmemory.NewDriver(), harnessRecord: &record}
+		server := newSessionsServer(drv)
+
+		org := "11111111-1111-1111-1111-111111111111"
+		_, _, status := getSessionList(server, "/v1/sessions?harness_id=claude&harness_session_id=sess-xyz", org)
+		Expect(status).To(Equal(fiber.StatusOK))
+		Expect(drv.lastOrgID).To(Equal(org), "the lookup must be scoped to the requested tenant")
+
+		// Without the header the middleware falls back to the nil-org
+		// sentinel, which must still be threaded down to the lookup.
+		_, _, status = getSessionList(server, "/v1/sessions?harness_id=claude&harness_session_id=sess-xyz", "")
+		Expect(status).To(Equal(fiber.StatusOK))
+		Expect(drv.lastOrgID).To(Equal(nilOrgID))
+	})
+
+	It("keeps the unfiltered paged list behavior when no harness params are supplied", func() {
+		older := record
+		older.ID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+		older.LastSeenAt = record.LastSeenAt.Add(-time.Minute)
+		oldest := record
+		oldest.ID = "cccccccc-cccc-cccc-cccc-cccccccccccc"
+		oldest.LastSeenAt = record.LastSeenAt.Add(-2 * time.Minute)
+
+		// Three records back from storage against limit=2 means a next page
+		// exists and the third row is trimmed.
+		drv := &sessionsStubDriver{
+			Driver:      inmemory.NewDriver(),
+			listRecords: []storage.SessionRecord{record, older, oldest},
+		}
+		server := newSessionsServer(drv)
+
+		cursorTs := time.Date(2026, 6, 2, 0, 0, 0, 0, time.UTC)
+		cursor := encodeSessionsCursor(sessionsCursor{LastSeenAt: cursorTs, ID: record.ID})
+
+		body, _, status := getSessionList(server, "/v1/sessions?limit=2&cursor="+cursor, "")
+		Expect(status).To(Equal(fiber.StatusOK))
+		Expect(drv.harnessCalls).To(BeZero(), "the harness lookup must never run on the unfiltered path")
+		Expect(drv.listCalls).To(Equal(1))
+		Expect(drv.lastLimit).To(Equal(3), "the handler fetches limit+1 to detect the next page")
+		Expect(drv.lastCursorTs).NotTo(BeNil())
+		Expect(drv.lastCursorTs.Equal(cursorTs)).To(BeTrue())
+		Expect(drv.lastCursorID).NotTo(BeNil())
+		Expect(*drv.lastCursorID).To(Equal(record.ID))
+
+		Expect(body.Items).To(HaveLen(2))
+		Expect(body.Items[0].ID).To(Equal(record.ID))
+		Expect(body.Items[1].ID).To(Equal(older.ID))
+		Expect(body.NextCursor).NotTo(BeEmpty())
+		next, err := decodeSessionsCursor(body.NextCursor)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(next.ID).To(Equal(older.ID))
+		Expect(next.LastSeenAt.Equal(older.LastSeenAt)).To(BeTrue())
+	})
+
+	It("ignores limit on the harness filter path", func() {
+		// The point lookup returns at most one row, so limit — even a
+		// malformed one that would 400 on the paged-list path — is ignored
+		// rather than validated when the filter is active.
+		drv := &sessionsStubDriver{Driver: inmemory.NewDriver(), harnessRecord: &record}
+		server := newSessionsServer(drv)
+
+		body, _, status := getSessionList(server, "/v1/sessions?limit=banana&harness_id=claude&harness_session_id=sess-xyz", "")
+		Expect(status).To(Equal(fiber.StatusOK))
+		Expect(body.Items).To(HaveLen(1))
+		Expect(body.Items[0].ID).To(Equal(record.ID))
+		Expect(drv.harnessCalls).To(Equal(1))
+		Expect(drv.listCalls).To(BeZero())
+	})
+
+	It("returns 400 when cursor is combined with the harness filter", func() {
+		drv := &sessionsStubDriver{Driver: inmemory.NewDriver(), harnessRecord: &record}
+		server := newSessionsServer(drv)
+
+		// A well-formed cursor: the rejection is about combining pagination
+		// with a point lookup, not about cursor decoding.
+		cursor := encodeSessionsCursor(sessionsCursor{LastSeenAt: record.LastSeenAt, ID: record.ID})
+
+		_, errBody, status := getSessionList(server, "/v1/sessions?harness_id=claude&harness_session_id=sess-xyz&cursor="+cursor, "")
+		Expect(status).To(Equal(fiber.StatusBadRequest))
+		Expect(errBody.Error).To(ContainSubstring("cursor"))
+		Expect(drv.harnessCalls).To(BeZero(), "validation must precede any storage call")
+		Expect(drv.listCalls).To(BeZero())
+	})
+
+	It("omits next_cursor and populates the filtered item like a list row", func() {
+		// The same record is served by both the paged-list path and the
+		// harness lookup so the two response rows can be compared field by
+		// field — the filtered item must be built exactly like a list row,
+		// preview included.
+		drv := &sessionsStubDriver{
+			Driver:        inmemory.NewDriver(),
+			listRecords:   []storage.SessionRecord{record},
+			harnessRecord: &record,
+		}
+		server := newSessionsServer(drv)
+
+		listBody, _, listStatus := getSessionList(server, "/v1/sessions", "")
+		Expect(listStatus).To(Equal(fiber.StatusOK))
+		Expect(listBody.Items).To(HaveLen(1))
+
+		filtered, _, status := getSessionList(server, "/v1/sessions?harness_id=claude&harness_session_id=sess-xyz", "")
+		Expect(status).To(Equal(fiber.StatusOK))
+		Expect(filtered.NextCursor).To(BeEmpty(), "a point lookup has no next page")
+		Expect(filtered.Items).To(HaveLen(1))
+		Expect(filtered.Items[0]).To(Equal(listBody.Items[0]))
+		Expect(filtered.Items[0].Preview).To(Equal(record.Preview), "the filtered row must carry preview like a list row")
+	})
+
+	It("returns 501 when the driver does not implement sessionsReader regardless of filter params", func() {
+		base := inmemory.NewDriver()
+		_, hasReader := storage.Driver(base).(sessionsReader)
+		Expect(hasReader).To(BeFalse(), "precondition: the bare inmemory driver must not implement sessionsReader")
+
+		server := newSessionsServer(base)
+
+		_, _, status := getSessionList(server, "/v1/sessions?harness_id=claude&harness_session_id=sess-xyz", "")
+		Expect(status).To(Equal(fiber.StatusNotImplemented))
+
+		_, _, status = getSessionList(server, "/v1/sessions", "")
+		Expect(status).To(Equal(fiber.StatusNotImplemented))
+	})
+})

--- a/api/sessions_handlers_test.go
+++ b/api/sessions_handlers_test.go
@@ -27,13 +27,14 @@ type sessionsStubDriver struct {
 	storage.Driver
 
 	// ListSessionRecords stubbing.
-	listRecords  []storage.SessionRecord
-	listErr      error
-	listCalls    int
-	lastListOrg  string
-	lastLimit    int
-	lastCursorTs *time.Time
-	lastCursorID *string
+	listRecords     []storage.SessionRecord
+	listErr         error
+	listCalls       int
+	lastListOrg     string
+	lastAuthSubject string
+	lastLimit       int
+	lastCursorTs    *time.Time
+	lastCursorID    *string
 
 	// GetSessionRecordByHarness stubbing.
 	harnessRecord        *storage.SessionRecord
@@ -44,9 +45,10 @@ type sessionsStubDriver struct {
 	lastHarnessSessionID string
 }
 
-func (d *sessionsStubDriver) ListSessionRecords(_ context.Context, orgID string, limit int, cursorTs *time.Time, cursorID *string) ([]storage.SessionRecord, error) {
+func (d *sessionsStubDriver) ListSessionRecords(_ context.Context, orgID string, authSubject string, limit int, cursorTs *time.Time, cursorID *string) ([]storage.SessionRecord, error) {
 	d.listCalls++
 	d.lastListOrg = orgID
+	d.lastAuthSubject = authSubject
 	d.lastLimit = limit
 	d.lastCursorTs = cursorTs
 	d.lastCursorID = cursorID
@@ -214,6 +216,44 @@ var _ = Describe("harness natural-key filter on GET /v1/sessions", func() {
 		_, _, status = getSessionList(server, "/v1/sessions?harness_id=claude&harness_session_id=sess-xyz", "")
 		Expect(status).To(Equal(fiber.StatusOK))
 		Expect(drv.lastOrgID).To(Equal(nilOrgID))
+	})
+
+	It("threads auth_subject through to the paged list and echoes it on items", func() {
+		// Given a stored record attributed to a user
+		attributed := record
+		attributed.AuthSubject = "user_01HXYZ"
+		drv := &sessionsStubDriver{
+			Driver:      inmemory.NewDriver(),
+			listRecords: []storage.SessionRecord{attributed},
+		}
+		server := newSessionsServer(drv)
+
+		// When listing with the auth_subject filter
+		body, _, status := getSessionList(server, "/v1/sessions?auth_subject=user_01HXYZ", "")
+
+		// Then the subject reaches storage verbatim and the item
+		// carries it back
+		Expect(status).To(Equal(fiber.StatusOK))
+		Expect(drv.listCalls).To(Equal(1))
+		Expect(drv.lastAuthSubject).To(Equal("user_01HXYZ"))
+		Expect(body.Items).To(HaveLen(1))
+		Expect(body.Items[0].AuthSubject).To(Equal("user_01HXYZ"))
+	})
+
+	It("lists every user's sessions when auth_subject is absent", func() {
+		// Given storage rows
+		drv := &sessionsStubDriver{
+			Driver:      inmemory.NewDriver(),
+			listRecords: []storage.SessionRecord{record},
+		}
+		server := newSessionsServer(drv)
+
+		// When listing without the filter
+		_, _, status := getSessionList(server, "/v1/sessions", "")
+
+		// Then storage sees the empty (no-filter) subject
+		Expect(status).To(Equal(fiber.StatusOK))
+		Expect(drv.lastAuthSubject).To(BeEmpty())
 	})
 
 	It("keeps the unfiltered paged list behavior when no harness params are supplied", func() {

--- a/cmd/tapes/sync/sync.go
+++ b/cmd/tapes/sync/sync.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/user"
 	"path/filepath"
 	"strings"
 
@@ -54,7 +55,7 @@ func NewSyncCmd() *cobra.Command {
 	cmd.Flags().BoolVarP(&cmder.verbose, "verbose", "v", false, "Show per-node match details")
 	cmd.Flags().BoolVar(&cmder.sessions, "sessions", false, "Also backfill Claude session rows and link legacy nodes")
 	cmd.Flags().StringVar(&cmder.orgID, "org-id", "", "Organization UUID to use for backfilled sessions")
-	cmd.Flags().StringVar(&cmder.authSubject, "auth-subject", "", "Auth subject to use for backfilled sessions")
+	cmd.Flags().StringVar(&cmder.authSubject, "auth-subject", localUserSubject(), "Auth subject to attribute backfilled sessions to (defaults to the local username)")
 
 	return cmd
 }
@@ -123,4 +124,18 @@ func (c *syncCommander) resolveClaudeDir() string {
 	}
 
 	return filepath.Join(home, ".claude", "projects")
+}
+
+// localUserSubject is the default attribution subject for locally-run
+// backfills: the OS username of whoever is running tapes. Local
+// captures have no gateway-validated JWT to derive a subject from, so
+// the closest honest identity is the local user. This default lives at
+// the CLI flag — never inside pkg/backfill — because the same package
+// also runs server-side behind the admin endpoint, where the process
+// owner's username would mis-attribute every row.
+func localUserSubject() string {
+	if u, err := user.Current(); err == nil && u.Username != "" {
+		return u.Username
+	}
+	return os.Getenv("USER")
 }

--- a/cmd/tapes/sync/sync_test.go
+++ b/cmd/tapes/sync/sync_test.go
@@ -16,6 +16,18 @@ var _ = Describe("NewSyncCmd", func() {
 		Expect(cmd.Hidden).To(BeTrue())
 	})
 
+	It("defaults auth-subject to the local username", func() {
+		// Local backfills have no gateway-validated JWT to derive a
+		// subject from; the closest honest identity is whoever is
+		// running tapes. Explicit --auth-subject still overrides.
+		cmd := NewSyncCmd()
+		flag := cmd.Flags().Lookup("auth-subject")
+		Expect(flag).NotTo(BeNil())
+		Expect(flag.DefValue).To(Equal(localUserSubject()))
+		Expect(localUserSubject()).NotTo(BeEmpty(),
+			"test environments always have an OS user or $USER")
+	})
+
 	It("has the expected flags", func() {
 		cmd := NewSyncCmd()
 

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -201,6 +201,18 @@ const docTemplate = `{
                         "description": "Opaque pagination cursor returned by a previous response",
                         "name": "cursor",
                         "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter to the single session with this harness id (exact match; requires harness_session_id, incompatible with cursor; limit is ignored when the filter is active)",
+                        "name": "harness_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter to the single session with this harness session id (exact match; requires harness_id, incompatible with cursor; limit is ignored when the filter is active)",
+                        "name": "harness_session_id",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -211,7 +223,7 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Invalid query parameters",
+                        "description": "Invalid query parameters, a lone harness filter param, or cursor combined with the harness filter",
                         "schema": {
                             "$ref": "#/definitions/github_com_papercomputeco_tapes_pkg_llm.ErrorResponse"
                         }
@@ -739,6 +751,9 @@ const docTemplate = `{
                 "cwd": {
                     "type": "string"
                 },
+                "derived_status": {
+                    "type": "string"
+                },
                 "ended_at": {
                     "type": "string"
                 },
@@ -817,6 +832,9 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "session_count": {
+                    "type": "integer"
+                },
+                "stem_count": {
                     "type": "integer"
                 },
                 "tool_calls": {
@@ -1053,6 +1071,13 @@ const docTemplate = `{
         "github_com_papercomputeco_tapes_pkg_llm.ContentBlock": {
             "type": "object",
             "properties": {
+                "content": {
+                    "description": "Content (type=\"web_search_tool_result\" and other server-tool results) -\nthe raw result payload Anthropic returns inline on the block, captured\nverbatim as JSON so the variable result-object shapes survive without\nimposing a schema. ToolResultID links it to the paired server_tool_use.",
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
                 "image_base64": {
                     "description": "Base64-encoded image data",
                     "type": "string"

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -213,6 +213,12 @@ const docTemplate = `{
                         "description": "Filter to the single session with this harness session id (exact match; requires harness_id, incompatible with cursor; limit is ignored when the filter is active)",
                         "name": "harness_session_id",
                         "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter the paged list to sessions captured for this gateway-stamped JWT subject (exact match; ignored on the harness filter path)",
+                        "name": "auth_subject",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -748,6 +754,10 @@ const docTemplate = `{
         "api.SessionItem": {
             "type": "object",
             "properties": {
+                "auth_subject": {
+                    "description": "AuthSubject is the gateway-stamped JWT subject (WorkOS user id)\ncaptured at ingest; empty for rows captured before the edge began\nstamping it.",
+                    "type": "string"
+                },
                 "cwd": {
                     "type": "string"
                 },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -209,6 +209,12 @@
                         "description": "Filter to the single session with this harness session id (exact match; requires harness_id, incompatible with cursor; limit is ignored when the filter is active)",
                         "name": "harness_session_id",
                         "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter the paged list to sessions captured for this gateway-stamped JWT subject (exact match; ignored on the harness filter path)",
+                        "name": "auth_subject",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -744,6 +750,10 @@
         "api.SessionItem": {
             "type": "object",
             "properties": {
+                "auth_subject": {
+                    "description": "AuthSubject is the gateway-stamped JWT subject (WorkOS user id)\ncaptured at ingest; empty for rows captured before the edge began\nstamping it.",
+                    "type": "string"
+                },
                 "cwd": {
                     "type": "string"
                 },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -197,6 +197,18 @@
                         "description": "Opaque pagination cursor returned by a previous response",
                         "name": "cursor",
                         "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter to the single session with this harness id (exact match; requires harness_session_id, incompatible with cursor; limit is ignored when the filter is active)",
+                        "name": "harness_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter to the single session with this harness session id (exact match; requires harness_id, incompatible with cursor; limit is ignored when the filter is active)",
+                        "name": "harness_session_id",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -207,7 +219,7 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid query parameters",
+                        "description": "Invalid query parameters, a lone harness filter param, or cursor combined with the harness filter",
                         "schema": {
                             "$ref": "#/definitions/github_com_papercomputeco_tapes_pkg_llm.ErrorResponse"
                         }
@@ -735,6 +747,9 @@
                 "cwd": {
                     "type": "string"
                 },
+                "derived_status": {
+                    "type": "string"
+                },
                 "ended_at": {
                     "type": "string"
                 },
@@ -813,6 +828,9 @@
                     "type": "integer"
                 },
                 "session_count": {
+                    "type": "integer"
+                },
+                "stem_count": {
                     "type": "integer"
                 },
                 "tool_calls": {
@@ -1049,6 +1067,13 @@
         "github_com_papercomputeco_tapes_pkg_llm.ContentBlock": {
             "type": "object",
             "properties": {
+                "content": {
+                    "description": "Content (type=\"web_search_tool_result\" and other server-tool results) -\nthe raw result payload Anthropic returns inline on the block, captured\nverbatim as JSON so the variable result-object shapes survive without\nimposing a schema. ToolResultID links it to the paired server_tool_use.",
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
                 "image_base64": {
                     "description": "Base64-encoded image data",
                     "type": "string"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -112,6 +112,12 @@ definitions:
     type: object
   api.SessionItem:
     properties:
+      auth_subject:
+        description: |-
+          AuthSubject is the gateway-stamped JWT subject (WorkOS user id)
+          captured at ingest; empty for rows captured before the edge began
+          stamping it.
+        type: string
       cwd:
         type: string
       derived_status:
@@ -650,6 +656,11 @@ paths:
           the filter is active)
         in: query
         name: harness_session_id
+        type: string
+      - description: Filter the paged list to sessions captured for this gateway-stamped
+          JWT subject (exact match; ignored on the harness filter path)
+        in: query
+        name: auth_subject
         type: string
       produces:
       - application/json

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -114,6 +114,8 @@ definitions:
     properties:
       cwd:
         type: string
+      derived_status:
+        type: string
       ended_at:
         type: string
       harness_id:
@@ -166,6 +168,8 @@ definitions:
       root_count:
         type: integer
       session_count:
+        type: integer
+      stem_count:
         type: integer
       tool_calls:
         type: integer
@@ -338,6 +342,15 @@ definitions:
     type: object
   github_com_papercomputeco_tapes_pkg_llm.ContentBlock:
     properties:
+      content:
+        description: |-
+          Content (type="web_search_tool_result" and other server-tool results) -
+          the raw result payload Anthropic returns inline on the block, captured
+          verbatim as JSON so the variable result-object shapes survive without
+          imposing a schema. ToolResultID links it to the paired server_tool_use.
+        items:
+          type: integer
+        type: array
       image_base64:
         description: Base64-encoded image data
         type: string
@@ -626,6 +639,18 @@ paths:
         in: query
         name: cursor
         type: string
+      - description: Filter to the single session with this harness id (exact match;
+          requires harness_session_id, incompatible with cursor; limit is ignored
+          when the filter is active)
+        in: query
+        name: harness_id
+        type: string
+      - description: Filter to the single session with this harness session id (exact
+          match; requires harness_id, incompatible with cursor; limit is ignored when
+          the filter is active)
+        in: query
+        name: harness_session_id
+        type: string
       produces:
       - application/json
       responses:
@@ -634,7 +659,8 @@ paths:
           schema:
             $ref: '#/definitions/api.SessionListResponse'
         "400":
-          description: Invalid query parameters
+          description: Invalid query parameters, a lone harness filter param, or cursor
+            combined with the harness filter
           schema:
             $ref: '#/definitions/github_com_papercomputeco_tapes_pkg_llm.ErrorResponse'
         "500":

--- a/pkg/storage/postgres/gensqlc/sessions.sql.go
+++ b/pkg/storage/postgres/gensqlc/sessions.sql.go
@@ -205,26 +205,35 @@ const listSessionRecords = `-- name: ListSessionRecords :many
 SELECT id, org_id, auth_subject, harness_id, harness_session_id, name, cwd, harness_version, parent_session_id, started_at, last_seen_at, ended_at, harness_metadata, total_input_tokens, total_output_tokens, total_cost_usd, turn_count, derived_status, has_git_activity, tool_result_count, tool_error_count FROM sessions
 WHERE org_id = $1
   AND (
-    $2::timestamptz IS NULL
-    OR last_seen_at < $2::timestamptz
-    OR (last_seen_at = $2::timestamptz AND id < $3::uuid)
+    $2::text IS NULL
+    OR auth_subject = $2::text
+  )
+  AND (
+    $3::timestamptz IS NULL
+    OR last_seen_at < $3::timestamptz
+    OR (last_seen_at = $3::timestamptz AND id < $4::uuid)
   )
 ORDER BY last_seen_at DESC, id DESC
-LIMIT $4
+LIMIT $5
 `
 
 type ListSessionRecordsParams struct {
-	OrgID    pgtype.UUID
-	CursorTs pgtype.Timestamptz
-	CursorID pgtype.UUID
-	Lim      int32
+	OrgID       pgtype.UUID
+	AuthSubject pgtype.Text
+	CursorTs    pgtype.Timestamptz
+	CursorID    pgtype.UUID
+	Lim         int32
 }
 
 // Paginated list of sessions for an org ordered newest-first (last_seen_at DESC, id DESC).
-// Pass NULL cursor values to start from the beginning.
+// Pass NULL cursor values to start from the beginning. Pass a NULL
+// auth_subject to list every user's sessions; a non-NULL value is an
+// exact match against the gateway-stamped JWT subject captured at
+// ingest (sessions_auth_subject_idx).
 func (q *Queries) ListSessionRecords(ctx context.Context, arg ListSessionRecordsParams) ([]Session, error) {
 	rows, err := q.db.Query(ctx, listSessionRecords,
 		arg.OrgID,
+		arg.AuthSubject,
 		arg.CursorTs,
 		arg.CursorID,
 		arg.Lim,

--- a/pkg/storage/postgres/postgres.go
+++ b/pkg/storage/postgres/postgres.go
@@ -9,6 +9,7 @@ import (
 	"maps"
 	"math"
 	"net/url"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -355,9 +356,9 @@ func (d *Driver) LoadDag(ctx context.Context, hash string) (*merkle.Dag, error) 
 		return nil, fmt.Errorf("node %s not found", hash)
 	}
 
-	for i := len(ancestry) - 1; i >= 0; i-- {
-		if _, err := dag.AddNode(ancestry[i]); err != nil {
-			return nil, fmt.Errorf("adding ancestor node %s: %w", ancestry[i].Hash, err)
+	for _, v := range slices.Backward(ancestry) {
+		if _, err := dag.AddNode(v); err != nil {
+			return nil, fmt.Errorf("adding ancestor node %s: %w", v.Hash, err)
 		}
 	}
 

--- a/pkg/storage/postgres/queries/sessions.sql
+++ b/pkg/storage/postgres/queries/sessions.sql
@@ -122,9 +122,16 @@ UPDATE sessions
 
 -- name: ListSessionRecords :many
 -- Paginated list of sessions for an org ordered newest-first (last_seen_at DESC, id DESC).
--- Pass NULL cursor values to start from the beginning.
+-- Pass NULL cursor values to start from the beginning. Pass a NULL
+-- auth_subject to list every user's sessions; a non-NULL value is an
+-- exact match against the gateway-stamped JWT subject captured at
+-- ingest (sessions_auth_subject_idx).
 SELECT * FROM sessions
 WHERE org_id = sqlc.arg(org_id)
+  AND (
+    sqlc.narg(auth_subject)::text IS NULL
+    OR auth_subject = sqlc.narg(auth_subject)::text
+  )
   AND (
     sqlc.narg(cursor_ts)::timestamptz IS NULL
     OR last_seen_at < sqlc.narg(cursor_ts)::timestamptz

--- a/pkg/storage/postgres/session_reads.go
+++ b/pkg/storage/postgres/session_reads.go
@@ -20,10 +20,14 @@ import (
 )
 
 // ListSessionRecords returns a page of sessions for an org ordered by
-// last_seen_at DESC. Pass nil cursorTs/cursorID to start from the beginning.
+// last_seen_at DESC. Pass nil cursorTs/cursorID to start from the
+// beginning. A non-empty authSubject narrows the page to sessions
+// captured for that gateway-stamped JWT subject (exact match on the
+// indexed column); empty lists every user's sessions.
 func (d *Driver) ListSessionRecords(
 	ctx context.Context,
 	orgID string,
+	authSubject string,
 	limit int,
 	cursorTs *time.Time,
 	cursorID *string,
@@ -47,10 +51,16 @@ func (d *Driver) ListSessionRecords(
 		idPg = pgtype.UUID{Bytes: parsed, Valid: true}
 	}
 
+	var subjectPg pgtype.Text
+	if authSubject != "" {
+		subjectPg = pgtype.Text{String: authSubject, Valid: true}
+	}
+
 	rows, err := d.q.ListSessionRecords(ctx, gensqlc.ListSessionRecordsParams{
-		OrgID:    oid,
-		CursorTs: tsPg,
-		CursorID: idPg,
+		OrgID:       oid,
+		AuthSubject: subjectPg,
+		CursorTs:    tsPg,
+		CursorID:    idPg,
 		// The int32 conversion cannot overflow: limit is bounded above by
 		// the API handler's maxSessionsLimit.
 		Lim: int32(limit), //nolint:gosec // bounded above by the API handler (maxSessionsLimit)
@@ -212,6 +222,7 @@ func sessionRecordFromRow(row gensqlc.Session) storage.SessionRecord {
 		TotalOutputTokens: row.TotalOutputTokens,
 		TurnCount:         int(row.TurnCount),
 		DerivedStatus:     row.DerivedStatus,
+		AuthSubject:       row.AuthSubject,
 	}
 	if row.Name.Valid {
 		s.Name = row.Name.String

--- a/pkg/storage/postgres/session_reads.go
+++ b/pkg/storage/postgres/session_reads.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -50,7 +51,9 @@ func (d *Driver) ListSessionRecords(
 		OrgID:    oid,
 		CursorTs: tsPg,
 		CursorID: idPg,
-		Lim:      int32(limit), //nolint:gosec // bounded above by the API handler (maxSessionsLimit)
+		// The int32 conversion cannot overflow: limit is bounded above by
+		// the API handler's maxSessionsLimit.
+		Lim: int32(limit), //nolint:gosec // bounded above by the API handler (maxSessionsLimit)
 	})
 	if err != nil {
 		return nil, fmt.Errorf("list session records: %w", err)
@@ -61,17 +64,27 @@ func (d *Driver) ListSessionRecords(
 		out[i] = sessionRecordFromRow(row)
 	}
 
-	previews, err := d.getSessionPreviews(ctx, out)
-	if err == nil {
-		for i := range out {
-			out[i].Preview = previews[out[i].ID]
-		}
-	}
+	d.attachPreviews(ctx, out)
 
 	return out, nil
 }
 
 const sessionPreviewMaxRunes = 120
+
+// attachPreviews populates Preview on each record in place from a single
+// batched preview query. It owns the best-effort policy for session reads:
+// previews are decoration, so a fetch failure is logged and the records are
+// returned without previews rather than failing the read.
+func (d *Driver) attachPreviews(ctx context.Context, records []storage.SessionRecord) {
+	previews, err := d.getSessionPreviews(ctx, records)
+	if err != nil {
+		slog.WarnContext(ctx, "attach session previews", "error", err)
+		return
+	}
+	for i := range records {
+		records[i].Preview = previews[records[i].ID]
+	}
+}
 
 // getSessionPreviews fetches the first user-role node text for each session in
 // the supplied list, in a single query. Returns a map of session UUID string →
@@ -141,6 +154,37 @@ func (d *Driver) GetSessionRecord(ctx context.Context, orgID, id string) (*stora
 	}
 	s := sessionRecordFromRow(row)
 	return &s, nil
+}
+
+// GetSessionRecordByHarness returns the single session matching the
+// org-scoped natural key (org_id, harness_id, harness_session_id), or nil
+// if no row matches. The lookup is an exact-match point read on the
+// sessions_harness_uq unique index, mirroring the GetSessionRecord
+// nil-on-no-rows contract.
+func (d *Driver) GetSessionRecordByHarness(
+	ctx context.Context,
+	orgID string,
+	harnessID string,
+	harnessSessionID string,
+) (*storage.SessionRecord, error) {
+	oid, err := orgIDFromString(orgID)
+	if err != nil {
+		return nil, fmt.Errorf("get session record by harness: %w", err)
+	}
+	row, err := d.q.GetSessionByNaturalKey(ctx, gensqlc.GetSessionByNaturalKeyParams{
+		OrgID:            oid,
+		HarnessID:        harnessID,
+		HarnessSessionID: harnessSessionID,
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("get session record by harness: %w", err)
+	}
+	recs := []storage.SessionRecord{sessionRecordFromRow(row)}
+	d.attachPreviews(ctx, recs)
+	return &recs[0], nil
 }
 
 // ListNodesBySession returns all nodes attributed to a session ordered by

--- a/pkg/storage/postgres/session_reads_test.go
+++ b/pkg/storage/postgres/session_reads_test.go
@@ -1,0 +1,151 @@
+package postgres_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/papercomputeco/tapes/pkg/sessions"
+	"github.com/papercomputeco/tapes/pkg/storage"
+	"github.com/papercomputeco/tapes/pkg/storage/postgres"
+)
+
+var _ = Describe("Driver.GetSessionRecordByHarness", func() {
+	var (
+		driver   storage.Driver
+		pgDriver *postgres.Driver
+		ingester storage.SessionIngester
+		ctx      context.Context
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		dsn, err := testPostgresDSN()
+		Expect(err).NotTo(HaveOccurred())
+
+		driver, err = postgres.NewDriver(ctx, dsn)
+		Expect(err).NotTo(HaveOccurred())
+
+		var ok bool
+		pgDriver, ok = driver.(*postgres.Driver)
+		Expect(ok).To(BeTrue())
+		_, err = pgDriver.DB().Exec(ctx, "TRUNCATE TABLE nodes")
+		Expect(err).NotTo(HaveOccurred())
+		_, err = pgDriver.DB().Exec(ctx, "TRUNCATE TABLE sessions CASCADE")
+		Expect(err).NotTo(HaveOccurred())
+
+		ingester, ok = driver.(storage.SessionIngester)
+		Expect(ok).To(BeTrue(), "postgres driver must satisfy SessionIngester")
+	})
+
+	AfterEach(func() {
+		if driver != nil {
+			driver.Close()
+		}
+	})
+
+	// seedSession ingests a 2-node turn for the given org and harness
+	// identity, returning the tapes-minted session UUID. The text seeds
+	// the user message so it becomes the session's preview.
+	seedSession := func(orgID, harnessID, harnessSessionID, text string) string {
+		res, err := ingester.IngestTurn(ctx, storage.IngestTurnRequest{
+			Session: &sessions.IngestEnvelope{
+				OrgID:            orgID,
+				AuthSubject:      "subject-reads",
+				HarnessID:        harnessID,
+				HarnessSessionID: harnessSessionID,
+			},
+			Nodes:        sessionFixture(text),
+			InputTokens:  12,
+			OutputTokens: 8,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.SessionID).NotTo(BeEmpty())
+		return res.SessionID
+	}
+
+	It("returns the matching record with preview for an exact org-scoped natural key", func() {
+		orgID := newTestOrgID()
+		sessionID := seedSession(orgID, "claude", "harness-exact", "preview text for exact match")
+
+		rec, err := pgDriver.GetSessionRecordByHarness(ctx, orgID, "claude", "harness-exact")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rec).NotTo(BeNil())
+
+		Expect(rec.ID).To(Equal(sessionID))
+		Expect(rec.HarnessID).To(Equal("claude"))
+		Expect(rec.HarnessSessionID).To(Equal("harness-exact"))
+		Expect(rec.TurnCount).To(Equal(1))
+		Expect(rec.TotalInputTokens).To(Equal(int64(12)))
+		Expect(rec.TotalOutputTokens).To(Equal(int64(8)))
+		Expect(rec.Preview).To(Equal("preview text for exact match"))
+
+		// Parity with the list path: the single filtered row must
+		// carry the same field population as a ListSessionRecords row,
+		// including Preview attached via getSessionPreviews.
+		listed, err := pgDriver.ListSessionRecords(ctx, orgID, 10, nil, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(listed).To(HaveLen(1))
+		Expect(listed[0].ID).To(Equal(rec.ID))
+		Expect(listed[0].Preview).To(Equal(rec.Preview))
+	})
+
+	It("returns nil without error when no row matches the natural key", func() {
+		orgID := newTestOrgID()
+		// Seed an unrelated session so the miss exercises the index
+		// against real rows rather than an empty table.
+		seedSession(orgID, "claude", "harness-present", "some other session")
+
+		rec, err := pgDriver.GetSessionRecordByHarness(ctx, orgID, "claude", "harness-absent")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rec).To(BeNil())
+	})
+
+	It("does not return a session with the same harness identity under a different org", func() {
+		orgA := newTestOrgID()
+		orgB := newTestOrgID()
+
+		// Identical (harness_id, harness_session_id) pair seeded under
+		// two different orgs; the unique index is only unique per-org.
+		idA := seedSession(orgA, "claude", "shared-harness-session", "org A turn")
+		idB := seedSession(orgB, "claude", "shared-harness-session", "org B turn")
+		Expect(idA).NotTo(Equal(idB))
+
+		rec, err := pgDriver.GetSessionRecordByHarness(ctx, orgA, "claude", "shared-harness-session")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rec).NotTo(BeNil())
+		Expect(rec.ID).To(Equal(idA))
+		Expect(rec.ID).NotTo(Equal(idB), "org B's session UUID must never surface for org A")
+		Expect(rec.Preview).To(Equal("org A turn"))
+	})
+
+	It("does not match case-folded, trimmed, or prefix variants of the harness ids", func() {
+		orgID := newTestOrgID()
+		seedSession(orgID, "Claude-Code", "Sess-ABC-123", "variant matching")
+
+		// Sanity anchor: the exact stored triple hits.
+		rec, err := pgDriver.GetSessionRecordByHarness(ctx, orgID, "Claude-Code", "Sess-ABC-123")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rec).NotTo(BeNil())
+
+		variants := []struct {
+			desc             string
+			harnessID        string
+			harnessSessionID string
+		}{
+			{"case-folded harness_id", "claude-code", "Sess-ABC-123"},
+			{"case-folded harness_session_id", "Claude-Code", "sess-abc-123"},
+			{"case-folded both", "CLAUDE-CODE", "SESS-ABC-123"},
+			{"whitespace-padded harness_id", " Claude-Code ", "Sess-ABC-123"},
+			{"whitespace-padded harness_session_id", "Claude-Code", " Sess-ABC-123 "},
+			{"prefix of harness_id", "Claude", "Sess-ABC-123"},
+			{"prefix of harness_session_id", "Claude-Code", "Sess-ABC"},
+		}
+		for _, v := range variants {
+			rec, err := pgDriver.GetSessionRecordByHarness(ctx, orgID, v.harnessID, v.harnessSessionID)
+			Expect(err).NotTo(HaveOccurred(), v.desc)
+			Expect(rec).To(BeNil(), "%s must not match the stored natural key", v.desc)
+		}
+	})
+})

--- a/pkg/storage/postgres/session_reads_test.go
+++ b/pkg/storage/postgres/session_reads_test.go
@@ -84,7 +84,7 @@ var _ = Describe("Driver.GetSessionRecordByHarness", func() {
 		// Parity with the list path: the single filtered row must
 		// carry the same field population as a ListSessionRecords row,
 		// including Preview attached via getSessionPreviews.
-		listed, err := pgDriver.ListSessionRecords(ctx, orgID, 10, nil, nil)
+		listed, err := pgDriver.ListSessionRecords(ctx, orgID, "", 10, nil, nil)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(listed).To(HaveLen(1))
 		Expect(listed[0].ID).To(Equal(rec.ID))
@@ -118,6 +118,42 @@ var _ = Describe("Driver.GetSessionRecordByHarness", func() {
 		Expect(rec.ID).To(Equal(idA))
 		Expect(rec.ID).NotTo(Equal(idB), "org B's session UUID must never surface for org A")
 		Expect(rec.Preview).To(Equal("org A turn"))
+	})
+
+	It("filters the paged list by auth_subject within an org", func() {
+		// Given two sessions in one org captured for different users
+		orgID := newTestOrgID()
+		seedFor := func(subject, harnessSession, text string) string {
+			res, err := ingester.IngestTurn(ctx, storage.IngestTurnRequest{
+				Session: &sessions.IngestEnvelope{
+					OrgID:            orgID,
+					AuthSubject:      subject,
+					HarnessID:        "claude",
+					HarnessSessionID: harnessSession,
+				},
+				Nodes:        sessionFixture(text),
+				InputTokens:  12,
+				OutputTokens: 8,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			return res.SessionID
+		}
+		idAlice := seedFor("user_alice", "sess-alice", "alice turn")
+		_ = seedFor("user_bob", "sess-bob", "bob turn")
+
+		// When listing with alice's subject
+		mine, err := pgDriver.ListSessionRecords(ctx, orgID, "user_alice", 10, nil, nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Then only alice's session returns, carrying the subject
+		Expect(mine).To(HaveLen(1))
+		Expect(mine[0].ID).To(Equal(idAlice))
+		Expect(mine[0].AuthSubject).To(Equal("user_alice"))
+
+		// And the unfiltered list still returns both users' sessions
+		all, err := pgDriver.ListSessionRecords(ctx, orgID, "", 10, nil, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(all).To(HaveLen(2))
 	})
 
 	It("does not match case-folded, trimmed, or prefix variants of the harness ids", func() {

--- a/pkg/storage/session_record.go
+++ b/pkg/storage/session_record.go
@@ -27,4 +27,8 @@ type SessionRecord struct {
 	// turn lands or, for pre-feature rows, until the status backfill runs.
 	DerivedStatus string
 	Preview       string // first user turn text, truncated; empty when unavailable
+	// AuthSubject is the gateway-stamped JWT subject (the WorkOS user id)
+	// captured at ingest. Empty for rows captured before the edge began
+	// stamping the x-paper-auth-subject header.
+	AuthSubject string
 }


### PR DESCRIPTION
🧍I mingled a few things here but these boil down to the pieces needed to enable a rich menu experience on the paper menu. These are mostly here to let the menu scope things properly for the minimal view it offers. 🧍

## Summary

- `GET /v1/sessions` gains two opt-in narrows: an exact-match `harness_id` + `harness_session_id` point lookup (resolves a locally-known harness session id to the tapes-minted session UUID in one indexed read — the bridge tray/console deep links need), and an `auth_subject` filter over the paged list (the "my sessions" select).
- `auth_subject` — captured at ingest since the original session-tracking schema and newly stamped by the gateway (papercomputeco/tko#74) — is now surfaced on `SessionItem` (`omitempty`; invisible for pre-attribution rows).
- `tapes sync` local backfills default attribution to the local OS username. Flag-level only: `pkg/backfill` also runs server-side behind the admin endpoint, where a package-level OS-user default would mis-attribute every row.
- Preview-fetch failures are logged via a shared `attachPreviews` helper instead of silently swallowed at two call sites.

## Behavior matrix

Every pre-existing request shape returns byte-identical responses; the unfiltered list path is textually unchanged.

| Request | Before | After |
|---|---|---|
| list / `limit` / `cursor` | paged list | identical |
| both harness params | params ignored → list | point lookup, 0-or-1 items, no cursor |
| lone harness param | params ignored → list | 400 (both-or-neither) |
| harness filter + `cursor` | params ignored → list | 400 (point lookup cannot paginate) |
| `auth_subject=X` | param ignored → list | list narrowed to X (indexed exact match) |
| empty-valued harness params | list | list (pinned by spec; ingest guarantees no row carries empty ids) |
| `limit` + harness filter | list | ignored, stated in swagger (PCC-676 tracks tightening) |

One disclosure: the endpoint previously tolerated unknown query params; `harness_id`, `harness_session_id`, and `auth_subject` are now reserved names with validation semantics. The `auth_subject` param is trusted to the same degree as `X-Tapes-Org-Id` — client-asserted today, server-derivable from the gateway-stamped header once the read route consumes it.

## Test plan

- [x] Full suite incl. live-Postgres integration specs: cross-org isolation, exact-match variant rejection, subject filtering with two users in one org — green
- [x] Handler unit specs pin every row of the behavior matrix
- [x] gofmt clean; golangci-lint zero new findings
- [x] Live clearing E2E: harness lookup resolves a captured session's cloud UUID; subject-scoped list returns only the signed-in user's sessions
- [ ] CI kafka-e2e (dagger; not run locally — no kafka-adjacent changes)

Part of PCC-455. Related to PCC-569.