### PR TITLE
🔧 fix: compute per-session cost at read time (related to PCC-686)

### DIFF
--- a/api/sessions_cost_test.go
+++ b/api/sessions_cost_test.go
@@ -1,0 +1,60 @@
+package api
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/papercomputeco/tapes/pkg/llm"
+	"github.com/papercomputeco/tapes/pkg/merkle"
+	"github.com/papercomputeco/tapes/pkg/sessions"
+)
+
+// assistantCostNode builds a standalone assistant node carrying a model and
+// token usage — the only fields sessionCostFromNodes reads.
+func assistantCostNode(model string, in, out, cacheCreate, cacheRead int) *merkle.Node {
+	bucket := v1TestBucket("assistant", "ok", model, "anthropic", "")
+	return merkle.NewNode(bucket, nil, merkle.NodeOptions{
+		Usage: &llm.Usage{
+			PromptTokens:             in,
+			CompletionTokens:         out,
+			CacheCreationInputTokens: cacheCreate,
+			CacheReadInputTokens:     cacheRead,
+		},
+	})
+}
+
+var _ = Describe("sessionCostFromNodes", func() {
+	pricing := sessions.DefaultPricing()
+
+	It("folds a single priced model's tokens into USD", func() {
+		// claude-sonnet-4.6: $3/M in, $15/M out. 1M in + 1M out = $18.
+		nodes := []*merkle.Node{
+			assistantCostNode("claude-sonnet-4.6", 600_000, 400_000, 0, 0),
+			assistantCostNode("claude-sonnet-4.6", 400_000, 600_000, 0, 0),
+		}
+		Expect(sessionCostFromNodes(nodes, pricing)).To(BeNumerically("~", 18.0, 0.0001))
+	})
+
+	It("sums cost across multiple models", func() {
+		// sonnet 1M in → $3; haiku-4.5 ($1/M in, $5/M out) 1M out → $5; total $8.
+		nodes := []*merkle.Node{
+			assistantCostNode("claude-sonnet-4.6", 1_000_000, 0, 0, 0),
+			assistantCostNode("claude-haiku-4.5", 0, 1_000_000, 0, 0),
+		}
+		Expect(sessionCostFromNodes(nodes, pricing)).To(BeNumerically("~", 8.0, 0.0001))
+	})
+
+	It("ignores nodes without usage and unpriceable models", func() {
+		userBucket := v1TestBucket("user", "hi", "", "", "")
+		nodes := []*merkle.Node{
+			merkle.NewNode(userBucket, nil),                                        // no usage → 0
+			assistantCostNode("totally-unknown-model", 1_000_000, 1_000_000, 0, 0), // unpriced → 0
+			assistantCostNode("claude-sonnet-4.6", 1_000_000, 0, 0, 0),             // $3
+		}
+		Expect(sessionCostFromNodes(nodes, pricing)).To(BeNumerically("~", 3.0, 0.0001))
+	})
+
+	It("is zero for no nodes", func() {
+		Expect(sessionCostFromNodes(nil, pricing)).To(Equal(0.0))
+	})
+})

--- a/api/sessions_handlers.go
+++ b/api/sessions_handlers.go
@@ -25,6 +25,10 @@ type sessionsReader interface {
 	ListSessionRecords(ctx context.Context, orgID string, limit int, cursorTs *time.Time, cursorID *string) ([]storage.SessionRecord, error)
 	GetSessionRecord(ctx context.Context, orgID, id string) (*storage.SessionRecord, error)
 	ListNodesBySession(ctx context.Context, sessionID string) ([]*merkle.Node, error)
+	// SessionTokensByModel returns a per-(session, model) token rollup for the
+	// given sessions, used to fold each row's USD cost at read time (the stored
+	// total_cost_usd column is stubbed at 0 by the ingest worker).
+	SessionTokensByModel(ctx context.Context, sessionIDs []string) (map[string]map[string]storage.ModelTokenStats, error)
 }
 
 const (
@@ -199,6 +203,25 @@ func (s *Server) handleListSessions(c *fiber.Ctx) error {
 	items := make([]SessionItem, len(sessions))
 	for i, sess := range sessions {
 		items[i] = sessionItemFromStorage(sess)
+	}
+
+	// Fold each row's cost from a per-model token rollup, the same way
+	// /v1/stats and the detail endpoint do. The stored total_cost_usd is
+	// stubbed at 0 by the ingest worker. A rollup failure is non-fatal: the
+	// list still renders with the stored (0) cost rather than 500-ing.
+	ids := make([]string, len(items))
+	for i := range items {
+		ids[i] = items[i].ID
+	}
+	if tokensByModel, err := reader.SessionTokensByModel(c.Context(), ids); err != nil {
+		s.logger.Warn("session tokens by model", "error", err)
+	} else {
+		pricing := s.pricingTable()
+		for i := range items {
+			if perModel, ok := tokensByModel[items[i].ID]; ok {
+				items[i].TotalCostUsd = totalCostFromPerModel(perModel, pricing)
+			}
+		}
 	}
 
 	return c.JSON(SessionListResponse{
@@ -413,8 +436,16 @@ func (s *Server) handleGetSession(c *fiber.Ctx) error {
 		turns[i] = turnFromNode(n)
 	}
 
+	item := sessionItemFromStorage(*sess)
+	// The stored total_cost_usd is stubbed at 0 by the ingest worker (no
+	// pricing lookup is wired into the proxy), so recompute it at read time
+	// from the session's nodes — the same per-model token fold /v1/stats
+	// uses. Folds over every node in the session (not just the selected
+	// stem) so the cost is stable regardless of ?stem / ?root.
+	item.TotalCostUsd = sessionCostFromNodes(nodes, s.pricingTable())
+
 	return c.JSON(SessionDetailResponse{
-		Session: sessionItemFromStorage(*sess),
+		Session: item,
 		Turns:   turns,
 		Stems:   stems,
 	})

--- a/api/v1_handlers.go
+++ b/api/v1_handlers.go
@@ -256,10 +256,7 @@ func (s *Server) handleStats(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusInternalServerError).JSON(llm.ErrorResponse{Error: "failed to compute stats"})
 	}
 
-	pricing := s.config.Pricing
-	if pricing == nil {
-		pricing = sessions.DefaultPricing()
-	}
+	pricing := s.pricingTable()
 
 	return c.JSON(StatsResponse{
 		SessionCount:    stats.SessionCount,
@@ -273,6 +270,47 @@ func (s *Server) handleStats(c *fiber.Ctx) error {
 		TotalDurationNs: stats.TotalDurationNs,
 		ToolCalls:       stats.ToolCalls,
 	})
+}
+
+// pricingTable returns the configured model pricing table, falling back to
+// the built-in default when the server has no override. Shared by every
+// handler that folds tokens into a USD cost (/v1/stats, /v1/stems, and the
+// per-session cost on /v1/sessions/:id) so they price identically.
+func (s *Server) pricingTable() sessions.PricingTable {
+	if s.config.Pricing != nil {
+		return s.config.Pricing
+	}
+	return sessions.DefaultPricing()
+}
+
+// sessionCostFromNodes folds a session's full node set into a USD cost the
+// same way /v1/stats does: bucket tokens per model, then price each bucket
+// via the pricing table. Reusing totalCostFromPerModel keeps a single
+// session's cost and the aggregate stats cost from ever diverging. Nodes
+// without usage or a priceable model contribute zero.
+//
+// This is the read-time source of truth for a session's cost. The ingest
+// worker stubs the stored total_cost_usd column at 0 (no pricing lookup is
+// wired into the proxy — see proxy/worker/pool.go), so the handler recomputes
+// it here rather than trusting the column.
+func sessionCostFromNodes(nodes []*merkle.Node, pricing sessions.PricingTable) float64 {
+	perModel := make(map[string]storage.ModelTokenStats)
+	for _, n := range nodes {
+		if n == nil || n.Usage == nil {
+			continue
+		}
+		model := n.Bucket.Model
+		if model == "" {
+			continue
+		}
+		t := perModel[model]
+		t.InputTokens += int64(n.Usage.PromptTokens)
+		t.OutputTokens += int64(n.Usage.CompletionTokens)
+		t.CacheCreationTokens += int64(n.Usage.CacheCreationInputTokens)
+		t.CacheReadTokens += int64(n.Usage.CacheReadInputTokens)
+		perModel[model] = t
+	}
+	return totalCostFromPerModel(perModel, pricing)
 }
 
 // totalCostFromPerModel folds the driver's per-model token rollup into a

--- a/api/v1_summary_handler.go
+++ b/api/v1_summary_handler.go
@@ -43,10 +43,7 @@ func (s *Server) handleListStems(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusInternalServerError).JSON(llm.ErrorResponse{Error: "failed to list stems"})
 	}
 
-	pricing := s.config.Pricing
-	if pricing == nil {
-		pricing = sessions.DefaultPricing()
-	}
+	pricing := s.pricingTable()
 
 	// Batch-walk the ancestry of every leaf on the page in a single call.
 	// The naive per-leaf AncestryChain loop issues O(N × depth) queries,

--- a/pkg/storage/postgres/session_reads.go
+++ b/pkg/storage/postgres/session_reads.go
@@ -157,6 +157,64 @@ func (d *Driver) ListNodesBySession(ctx context.Context, sessionID string) ([]*m
 	return merkleNodesFromRows(rows)
 }
 
+// SessionTokensByModel returns, for each requested session, a per-model token
+// rollup (summed prompt / completion / cache tokens across the session's
+// nodes). The API layer folds these into a USD cost so model pricing stays in
+// one place (pkg/sessions), exactly like /v1/stats. Sessions with no priceable
+// nodes are simply absent from the returned map.
+//
+// One grouped query covers the whole page — same ANY($1::uuid[]) batching as
+// getSessionPreviews — so the list endpoint stays a fixed number of queries
+// regardless of page size.
+func (d *Driver) SessionTokensByModel(
+	ctx context.Context,
+	sessionIDs []string,
+) (map[string]map[string]storage.ModelTokenStats, error) {
+	out := make(map[string]map[string]storage.ModelTokenStats, len(sessionIDs))
+	if len(sessionIDs) == 0 {
+		return out, nil
+	}
+
+	rows, err := d.conn.Query(ctx, `
+SELECT session_id::text,
+       model,
+       COALESCE(SUM(prompt_tokens), 0)::bigint                AS input_tokens,
+       COALESCE(SUM(completion_tokens), 0)::bigint            AS output_tokens,
+       COALESCE(SUM(cache_creation_input_tokens), 0)::bigint  AS cache_creation_tokens,
+       COALESCE(SUM(cache_read_input_tokens), 0)::bigint      AS cache_read_tokens
+FROM nodes
+WHERE session_id = ANY($1::uuid[])
+  AND model IS NOT NULL AND model <> ''
+GROUP BY session_id, model
+`, sessionIDs)
+	if err != nil {
+		return nil, fmt.Errorf("session tokens by model: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var sessionID, model string
+		var stats storage.ModelTokenStats
+		if err := rows.Scan(
+			&sessionID,
+			&model,
+			&stats.InputTokens,
+			&stats.OutputTokens,
+			&stats.CacheCreationTokens,
+			&stats.CacheReadTokens,
+		); err != nil {
+			return nil, fmt.Errorf("session tokens by model: scan: %w", err)
+		}
+		perModel := out[sessionID]
+		if perModel == nil {
+			perModel = make(map[string]storage.ModelTokenStats)
+			out[sessionID] = perModel
+		}
+		perModel[model] = stats
+	}
+	return out, rows.Err()
+}
+
 // sessionRecordFromRow converts a sqlc-generated Session row to
 // the storage-level SessionRecord type.
 func sessionRecordFromRow(row gensqlc.Session) storage.SessionRecord {


### PR DESCRIPTION
## What

Per-session `total_cost_usd` was always `$0.00` in the console (the session-detail sidebar **and** the sessions table) even though tokens were recorded correctly. That field is a stored column the ingest worker stubs at `0` — no pricing lookup is wired into the proxy (`proxy/worker/pool.go` → `CostUSD: 0, // pricing lookup not wired in this repo`).

This computes per-session cost **at read time** from per-model token rollups via the pricing table — the same approach `/v1/stats` already uses (PCC-452) — instead of trusting the stubbed column.

## Changes

- **`GET /v1/sessions/:id`** (detail / sidebar) — `sessionCostFromNodes` folds the session's nodes into a per-model token map and prices it. Folds over every node in the session, so the cost is stable regardless of `?stem` / `?root`.
- **`GET /v1/sessions`** (list / table) — `SessionTokensByModel` returns a per-`(session, model)` token rollup in one grouped query per page (`ANY($1::uuid[])`, mirroring `getSessionPreviews`); the handler folds each row's cost. A rollup failure is non-fatal — the list falls back to the stored value rather than 500-ing.
- Shared **`s.pricingTable()`** helper; `/v1/stats` and `/v1/stems` now use it too, so all three price identically.
- New Ginkgo specs for `sessionCostFromNodes`.

No API shape change (`total_cost_usd` was always a field); works retroactively for existing sessions.

## Testing

- `make format`, `go build ./...` (`GOEXPERIMENT=jsonv2`), and 60/60 `api` Ginkgo specs pass.
- Verified end-to-end against a local clearing: list + detail report real cost (e.g. `$18.74`) where they previously showed `$0`, and detail/list agree on the same session.
- `SessionTokensByModel` (Postgres) has no local unit test (needs a DB via Dagger); verified against the clearing. Happy to add a postgres integration spec if preferred.

## Notes

Production serves `/v1/sessions` via the tapes-api sidecar (this same Go binary), proxied by paper-cli — so this change ships the fix to production; no paper-cli change is needed.

related to PCC-686

🤖 Generated with [Claude Code](https://claude.com/claude-code)
