### PR TITLE
✨ feat: version tapes span projection tables

### DIFF
--- a/migrations/1781310000_version_span_projection_tables.down.sql
+++ b/migrations/1781310000_version_span_projection_tables.down.sql
@@ -1,0 +1,25 @@
+ALTER TABLE IF EXISTS spans_20260615 RENAME CONSTRAINT spans_20260615_kind_chk TO spans_kind_chk;
+
+ALTER INDEX IF EXISTS span_links_20260615_session_idx RENAME TO span_links_session_idx;
+ALTER INDEX IF EXISTS span_links_20260615_to_trace_idx RENAME TO span_links_to_trace_idx;
+ALTER INDEX IF EXISTS span_links_20260615_from_trace_idx RENAME TO span_links_from_trace_idx;
+ALTER INDEX IF EXISTS span_links_20260615_pkey RENAME TO span_links_pkey;
+
+ALTER INDEX IF EXISTS spans_20260615_org_kind_started_idx RENAME TO spans_org_kind_started_idx;
+ALTER INDEX IF EXISTS spans_20260615_raw_turn_idx RENAME TO spans_raw_turn_idx;
+ALTER INDEX IF EXISTS spans_20260615_org_call_kind_idx RENAME TO spans_org_call_kind_idx;
+ALTER INDEX IF EXISTS spans_20260615_session_idx RENAME TO spans_session_idx;
+ALTER INDEX IF EXISTS spans_20260615_pkey RENAME TO spans_pkey;
+
+ALTER INDEX IF EXISTS span_turns_20260615_org_started_idx RENAME TO span_turns_org_started_idx;
+ALTER INDEX IF EXISTS span_turns_20260615_session_idx RENAME TO span_turns_session_idx;
+ALTER INDEX IF EXISTS span_turns_20260615_pkey RENAME TO span_turns_pkey;
+
+ALTER TABLE IF EXISTS span_links_20260615 RENAME TO span_links;
+ALTER TABLE IF EXISTS spans_20260615 RENAME TO spans;
+ALTER TABLE IF EXISTS span_turns_20260615 RENAME TO span_turns;
+
+DELETE FROM derived_projection_schemas
+WHERE compatibility_date = DATE '2026-06-15';
+
+DROP TABLE IF EXISTS derived_projection_schemas;

--- a/migrations/1781310000_version_span_projection_tables.up.sql
+++ b/migrations/1781310000_version_span_projection_tables.up.sql
@@ -1,0 +1,48 @@
+-- The span projection is derived data. Keep each schema generation in
+-- date-suffixed physical tables so future projection schemas can coexist
+-- with readable historical rows instead of mutating one live table family.
+
+CREATE TABLE IF NOT EXISTS derived_projection_schemas (
+    compatibility_date DATE PRIMARY KEY,
+    span_turns_table   TEXT NOT NULL,
+    spans_table        TEXT NOT NULL,
+    span_links_table   TEXT NOT NULL,
+    created_at         TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+INSERT INTO derived_projection_schemas (
+    compatibility_date,
+    span_turns_table,
+    spans_table,
+    span_links_table
+) VALUES (
+    DATE '2026-06-15',
+    'span_turns_20260615',
+    'spans_20260615',
+    'span_links_20260615'
+) ON CONFLICT (compatibility_date) DO NOTHING;
+
+ALTER TABLE IF EXISTS span_turns RENAME TO span_turns_20260615;
+ALTER TABLE IF EXISTS spans RENAME TO spans_20260615;
+ALTER TABLE IF EXISTS span_links RENAME TO span_links_20260615;
+
+ALTER INDEX IF EXISTS span_turns_pkey RENAME TO span_turns_20260615_pkey;
+ALTER INDEX IF EXISTS span_turns_session_idx RENAME TO span_turns_20260615_session_idx;
+ALTER INDEX IF EXISTS span_turns_org_started_idx RENAME TO span_turns_20260615_org_started_idx;
+
+ALTER INDEX IF EXISTS spans_pkey RENAME TO spans_20260615_pkey;
+ALTER INDEX IF EXISTS spans_session_idx RENAME TO spans_20260615_session_idx;
+ALTER INDEX IF EXISTS spans_org_call_kind_idx RENAME TO spans_20260615_org_call_kind_idx;
+ALTER INDEX IF EXISTS spans_raw_turn_idx RENAME TO spans_20260615_raw_turn_idx;
+ALTER INDEX IF EXISTS spans_org_kind_started_idx RENAME TO spans_20260615_org_kind_started_idx;
+
+ALTER INDEX IF EXISTS span_links_pkey RENAME TO span_links_20260615_pkey;
+ALTER INDEX IF EXISTS span_links_from_trace_idx RENAME TO span_links_20260615_from_trace_idx;
+ALTER INDEX IF EXISTS span_links_to_trace_idx RENAME TO span_links_20260615_to_trace_idx;
+ALTER INDEX IF EXISTS span_links_session_idx RENAME TO span_links_20260615_session_idx;
+
+ALTER TABLE IF EXISTS spans_20260615 RENAME CONSTRAINT spans_kind_chk TO spans_20260615_kind_chk;
+
+COMMENT ON TABLE span_turns_20260615 IS 'Derived span-turn projection schema version 2026-06-15.';
+COMMENT ON TABLE spans_20260615 IS 'Derived span projection schema version 2026-06-15.';
+COMMENT ON TABLE span_links_20260615 IS 'Derived span-link projection schema version 2026-06-15.';

--- a/pkg/spanembed/store.go
+++ b/pkg/spanembed/store.go
@@ -16,8 +16,8 @@ import (
 
 const (
 	// DefaultTableName is the span-embedding table. It lives in the
-	// same database as the spans projection — candidate selection and
-	// search both join against spans/span_turns.
+	// same database as the versioned spans projection — candidate selection
+	// and search both join against the current physical table family.
 	DefaultTableName = "span_embeddings"
 
 	// maxVectorDimensions is the upper bound pgvector supports for the
@@ -178,7 +178,7 @@ func (s *Store) ListCandidates(ctx context.Context, after Key, limit int) ([]Can
 	query := fmt.Sprintf(`
 		SELECT s.org_id, s.trace_id, s.span_id, s.session_id, s.input, s.output,
 		       COALESCE(e.content_hash, ''), COALESCE(e.model, '')
-		FROM spans s
+		FROM spans_20260615 s
 		LEFT JOIN %s e
 		  ON e.org_id = s.org_id AND e.trace_id = s.trace_id AND e.span_id = s.span_id
 		WHERE s.kind = 'llm' AND s.call_kind = 'main'
@@ -289,7 +289,7 @@ func (s *Store) PruneOrphans(ctx context.Context) (int64, error) {
 		DELETE FROM %s e
 		WHERE (NOT @scoped::boolean OR e.org_id = @scope_org)
 		  AND NOT EXISTS (
-			SELECT 1 FROM spans s
+			SELECT 1 FROM spans_20260615 s
 			WHERE s.org_id = e.org_id AND s.trace_id = e.trace_id AND s.span_id = e.span_id
 			  AND s.kind = 'llm' AND s.call_kind = 'main'
 		)
@@ -325,9 +325,9 @@ func (s *Store) Search(ctx context.Context, orgID string, embedding []float32, t
 		       1 - (e.embedding <=> @embedding) AS score,
 		       t.user_prompt, s.model, s.started_at, s.input, s.output
 		FROM %s e
-		JOIN spans s
+		JOIN spans_20260615 s
 		  ON s.org_id = e.org_id AND s.trace_id = e.trace_id AND s.span_id = e.span_id
-		JOIN span_turns t
+		JOIN span_turns_20260615 t
 		  ON t.org_id = e.org_id AND t.trace_id = e.trace_id
 		WHERE e.org_id = @org
 		ORDER BY e.embedding <=> @embedding

--- a/pkg/spanembed/store_test.go
+++ b/pkg/spanembed/store_test.go
@@ -63,7 +63,7 @@ var _ = Describe("Store", func() {
 		dsn, err = testPostgresDSN()
 		Expect(err).NotTo(HaveOccurred())
 
-		// Open the tapes driver once so migrations (spans, span_turns)
+		// Open the tapes driver once so migrations (spans_20260615, span_turns_20260615)
 		// are applied, then keep a plain pool for the store under test.
 		driver, err := postgres.NewDriver(ctx, dsn)
 		Expect(err).NotTo(HaveOccurred())
@@ -79,23 +79,23 @@ var _ = Describe("Store", func() {
 	AfterEach(func() {
 		_, err := pool.Exec(ctx, "DROP TABLE IF EXISTS "+pgx.Identifier{tableName}.Sanitize())
 		Expect(err).NotTo(HaveOccurred())
-		_, err = pool.Exec(ctx, "DELETE FROM spans WHERE org_id = $1", org)
+		_, err = pool.Exec(ctx, "DELETE FROM spans_20260615 WHERE org_id = $1", org)
 		Expect(err).NotTo(HaveOccurred())
-		_, err = pool.Exec(ctx, "DELETE FROM span_turns WHERE org_id = $1", org)
+		_, err = pool.Exec(ctx, "DELETE FROM span_turns_20260615 WHERE org_id = $1", org)
 		Expect(err).NotTo(HaveOccurred())
 		pool.Close()
 	})
 
 	insertSpan := func(spanID, kind, callKind string, input, output string) {
 		_, err := pool.Exec(ctx, `
-			INSERT INTO span_turns (org_id, trace_id, user_prompt, started_at)
+			INSERT INTO span_turns_20260615 (org_id, trace_id, user_prompt, started_at)
 			VALUES ($1, $2, 'find the turn', now())
 			ON CONFLICT (org_id, trace_id) DO NOTHING
 		`, org, traceA)
 		Expect(err).NotTo(HaveOccurred())
 
 		_, err = pool.Exec(ctx, `
-			INSERT INTO spans (org_id, trace_id, span_id, kind, call_kind, started_at, input, output)
+			INSERT INTO spans_20260615 (org_id, trace_id, span_id, kind, call_kind, started_at, input, output)
 			VALUES ($1, $2, $3, $4, $5, now(), NULLIF($6, '')::jsonb, NULLIF($7, '')::jsonb)
 		`, org, traceA, spanID, kind, callKind, input, output)
 		Expect(err).NotTo(HaveOccurred())
@@ -125,7 +125,7 @@ var _ = Describe("Store", func() {
 	})
 
 	Describe("candidate selection and search round trip", func() {
-		It("lists only main llm spans, upserts by identity, prunes orphans, and searches with turn context", func() {
+		It("lists only main llm spans_20260615, upserts by identity, prunes orphans, and searches with turn context", func() {
 			input := `[{"type":"text","text":"how do I configure retry backoff"}]`
 			output := `[{"type":"text","text":"set max-poll-backoff"}]`
 			insertSpan("llm_main", "llm", "main", input, output)
@@ -170,7 +170,7 @@ var _ = Describe("Store", func() {
 			Expect(hits[0].Score).To(BeNumerically("~", 1.0, 1e-4))
 
 			// Pruning: drop the span, the embedding follows.
-			_, err = pool.Exec(ctx, "DELETE FROM spans WHERE org_id = $1 AND span_id = 'llm_main'", org)
+			_, err = pool.Exec(ctx, "DELETE FROM spans_20260615 WHERE org_id = $1 AND span_id = 'llm_main'", org)
 			Expect(err).NotTo(HaveOccurred())
 			pruned, err := store.PruneOrphans(ctx)
 			Expect(err).NotTo(HaveOccurred())

--- a/pkg/storage/postgres/derive_queue_test.go
+++ b/pkg/storage/postgres/derive_queue_test.go
@@ -149,14 +149,14 @@ var _ = Describe("Derive worker storage (postgres)", func() {
 				).To(Succeed())
 				return n
 			}
-			turns := countRows("span_turns")
-			spanRows := countRows("spans")
+			turns := countRows("span_turns_20260615")
+			spanRows := countRows("spans_20260615")
 			Expect(turns).To(BeNumerically(">", 0), "derive must land span turns")
-			Expect(spanRows).To(BeNumerically(">", turns), "each trace carries spans beyond its root")
+			Expect(spanRows).To(BeNumerically(">", turns), "each trace carries spans_20260615 beyond its root")
 
 			var llmSpans int
 			Expect(driver.DB().QueryRow(ctx,
-				"SELECT COUNT(*) FROM spans WHERE session_id = $1 AND kind = 'llm' AND raw_turn_id IS NOT NULL",
+				"SELECT COUNT(*) FROM spans_20260615 WHERE session_id = $1 AND kind = 'llm' AND raw_turn_id IS NOT NULL",
 				sessionARowID).Scan(&llmSpans)).To(Succeed())
 			Expect(llmSpans).To(Equal(2), "one llm span per wire call, referencing its raw row")
 
@@ -164,8 +164,8 @@ var _ = Describe("Derive worker storage (postgres)", func() {
 			// changes nothing.
 			_, err = driver.RederiveSession(ctx, "", "", harnessID, sessionA)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(countRows("span_turns")).To(Equal(turns))
-			Expect(countRows("spans")).To(Equal(spanRows))
+			Expect(countRows("span_turns_20260615")).To(Equal(turns))
+			Expect(countRows("spans_20260615")).To(Equal(spanRows))
 		})
 
 		It("derives one session, is idempotent, and never touches siblings", func() {

--- a/pkg/storage/postgres/gensqlc/models.go
+++ b/pkg/storage/postgres/gensqlc/models.go
@@ -16,6 +16,14 @@ type DeriveQueue struct {
 	FirstDirtiedAt   pgtype.Timestamptz
 }
 
+type DerivedProjectionSchema struct {
+	CompatibilityDate pgtype.Date
+	SpanTurnsTable    string
+	SpansTable        string
+	SpanLinksTable    string
+	CreatedAt         pgtype.Timestamptz
+}
+
 type Node struct {
 	Hash                     string
 	Bucket                   []byte
@@ -91,7 +99,42 @@ type Session struct {
 	ModelUsage        []byte
 }
 
-type Span struct {
+// Derived span-link projection schema version 2026-06-15.
+type SpanLinks20260615 struct {
+	OrgID       pgtype.UUID
+	FromTraceID string
+	FromSpanID  string
+	FromIo      string
+	ToTraceID   string
+	ToSpanID    string
+	ToIo        string
+	Kind        string
+	SessionID   pgtype.UUID
+}
+
+// Derived span-turn projection schema version 2026-06-15.
+type SpanTurns20260615 struct {
+	OrgID               pgtype.UUID
+	TraceID             string
+	SessionID           pgtype.UUID
+	UserPrompt          string
+	Synthetic           string
+	Status              string
+	StartedAt           pgtype.Timestamptz
+	EndedAt             pgtype.Timestamptz
+	DurationNs          int64
+	TotalInputTokens    int64
+	TotalOutputTokens   int64
+	TotalCostUsd        pgtype.Numeric
+	MainInputTokens     int64
+	MainOutputTokens    int64
+	CacheReadTokens     int64
+	CacheCreationTokens int64
+	ResponsePreview     string
+}
+
+// Derived span projection schema version 2026-06-15.
+type Spans20260615 struct {
 	OrgID        pgtype.UUID
 	TraceID      string
 	SpanID       string
@@ -112,36 +155,4 @@ type Span struct {
 	RawTurnID    pgtype.Int8
 	NodeHash     string
 	Seq          int64
-}
-
-type SpanLink struct {
-	OrgID       pgtype.UUID
-	FromTraceID string
-	FromSpanID  string
-	FromIo      string
-	ToTraceID   string
-	ToSpanID    string
-	ToIo        string
-	Kind        string
-	SessionID   pgtype.UUID
-}
-
-type SpanTurn struct {
-	OrgID               pgtype.UUID
-	TraceID             string
-	SessionID           pgtype.UUID
-	UserPrompt          string
-	Synthetic           string
-	Status              string
-	StartedAt           pgtype.Timestamptz
-	EndedAt             pgtype.Timestamptz
-	DurationNs          int64
-	TotalInputTokens    int64
-	TotalOutputTokens   int64
-	TotalCostUsd        pgtype.Numeric
-	MainInputTokens     int64
-	MainOutputTokens    int64
-	CacheReadTokens     int64
-	CacheCreationTokens int64
-	ResponsePreview     string
 }

--- a/pkg/storage/postgres/gensqlc/spans.sql.go
+++ b/pkg/storage/postgres/gensqlc/spans.sql.go
@@ -16,7 +16,7 @@ WITH matched AS (
     SELECT t.org_id, t.trace_id, t.session_id, t.synthetic, t.duration_ns,
            t.total_input_tokens, t.total_output_tokens,
            t.cache_read_tokens, t.cache_creation_tokens, t.total_cost_usd
-    FROM span_turns t
+    FROM span_turns_20260615 t
     WHERE t.org_id = $1
       AND ($2::timestamptz IS NULL OR t.started_at >= $2::timestamptz)
       AND ($3::timestamptz IS NULL OR t.started_at < $3::timestamptz)
@@ -37,7 +37,7 @@ SELECT
     COALESCE(SUM(cache_read_tokens), 0)::bigint             AS cache_read_tokens,
     COALESCE(SUM(duration_ns), 0)::bigint                   AS total_duration_ns,
     COALESCE(SUM(total_cost_usd), 0)::numeric               AS total_cost_usd,
-    (SELECT COUNT(*) FROM spans sp
+    (SELECT COUNT(*) FROM spans_20260615 sp
      WHERE sp.org_id = $1
        AND sp.kind = 'tool'
        AND ($2::timestamptz IS NULL OR sp.started_at >= $2::timestamptz)
@@ -76,7 +76,7 @@ type AggregateSpanStatsRow struct {
 //	total_duration_ns = SUM of trace durations — agent time, not the
 //	                    wall-clock MAX-MIN window (idle time between
 //	                    turns no longer counts)
-//	tool_calls        = tool spans started in the window
+//	tool_calls        = tool spans_20260615 started in the window
 func (q *Queries) AggregateSpanStats(ctx context.Context, arg AggregateSpanStatsParams) (AggregateSpanStatsRow, error) {
 	row := q.db.QueryRow(ctx, aggregateSpanStats, arg.OrgID, arg.SinceFilter, arg.UntilFilter)
 	var i AggregateSpanStatsRow
@@ -105,7 +105,7 @@ UPDATE sessions SET
     model_usage = NULL,
     derived_title = NULL,
     derived_model = COALESCE((
-        SELECT sp.model FROM spans sp
+        SELECT sp.model FROM spans_20260615 sp
         WHERE sp.session_id = sessions.id
           AND sp.kind = 'llm' AND sp.call_kind = 'main' AND sp.model <> ''
           -- main thread only: subagents run their own (often cheaper)
@@ -123,7 +123,7 @@ FROM (
            SUM(st.total_output_tokens) AS output_tokens,
            COUNT(st.trace_id)          AS turns
     FROM sessions s
-    LEFT JOIN span_turns st ON st.session_id = s.id
+    LEFT JOIN span_turns_20260615 st ON st.session_id = s.id
     WHERE s.id = ANY($1::uuid[])
     GROUP BY s.id
 ) f
@@ -151,7 +151,7 @@ func (q *Queries) FoldSessionRollupsFromSpans(ctx context.Context, sessionIds []
 }
 
 const getSpan = `-- name: GetSpan :one
-SELECT org_id, trace_id, span_id, parent_span_id, session_id, kind, name, status, call_kind, thread_id, model, stop_reason, started_at, duration_ns, input, output, usage, raw_turn_id, node_hash, seq FROM spans
+SELECT org_id, trace_id, span_id, parent_span_id, session_id, kind, name, status, call_kind, thread_id, model, stop_reason, started_at, duration_ns, input, output, usage, raw_turn_id, node_hash, seq FROM spans_20260615
 WHERE org_id = $1 AND trace_id = $2 AND span_id = $3
 `
 
@@ -161,9 +161,9 @@ type GetSpanParams struct {
 	SpanID  string
 }
 
-func (q *Queries) GetSpan(ctx context.Context, arg GetSpanParams) (Span, error) {
+func (q *Queries) GetSpan(ctx context.Context, arg GetSpanParams) (Spans20260615, error) {
 	row := q.db.QueryRow(ctx, getSpan, arg.OrgID, arg.TraceID, arg.SpanID)
-	var i Span
+	var i Spans20260615
 	err := row.Scan(
 		&i.OrgID,
 		&i.TraceID,
@@ -190,7 +190,7 @@ func (q *Queries) GetSpan(ctx context.Context, arg GetSpanParams) (Span, error) 
 }
 
 const getSpanTurn = `-- name: GetSpanTurn :one
-SELECT org_id, trace_id, session_id, user_prompt, synthetic, status, started_at, ended_at, duration_ns, total_input_tokens, total_output_tokens, total_cost_usd, main_input_tokens, main_output_tokens, cache_read_tokens, cache_creation_tokens, response_preview FROM span_turns
+SELECT org_id, trace_id, session_id, user_prompt, synthetic, status, started_at, ended_at, duration_ns, total_input_tokens, total_output_tokens, total_cost_usd, main_input_tokens, main_output_tokens, cache_read_tokens, cache_creation_tokens, response_preview FROM span_turns_20260615
 WHERE org_id = $1 AND trace_id = $2
 `
 
@@ -199,9 +199,9 @@ type GetSpanTurnParams struct {
 	TraceID string
 }
 
-func (q *Queries) GetSpanTurn(ctx context.Context, arg GetSpanTurnParams) (SpanTurn, error) {
+func (q *Queries) GetSpanTurn(ctx context.Context, arg GetSpanTurnParams) (SpanTurns20260615, error) {
 	row := q.db.QueryRow(ctx, getSpanTurn, arg.OrgID, arg.TraceID)
-	var i SpanTurn
+	var i SpanTurns20260615
 	err := row.Scan(
 		&i.OrgID,
 		&i.TraceID,
@@ -225,19 +225,19 @@ func (q *Queries) GetSpanTurn(ctx context.Context, arg GetSpanTurnParams) (SpanT
 }
 
 const listSpanLinksBySession = `-- name: ListSpanLinksBySession :many
-SELECT org_id, from_trace_id, from_span_id, from_io, to_trace_id, to_span_id, to_io, kind, session_id FROM span_links
+SELECT org_id, from_trace_id, from_span_id, from_io, to_trace_id, to_span_id, to_io, kind, session_id FROM span_links_20260615
 WHERE session_id = $1
 `
 
-func (q *Queries) ListSpanLinksBySession(ctx context.Context, sessionID pgtype.UUID) ([]SpanLink, error) {
+func (q *Queries) ListSpanLinksBySession(ctx context.Context, sessionID pgtype.UUID) ([]SpanLinks20260615, error) {
 	rows, err := q.db.Query(ctx, listSpanLinksBySession, sessionID)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []SpanLink
+	var items []SpanLinks20260615
 	for rows.Next() {
-		var i SpanLink
+		var i SpanLinks20260615
 		if err := rows.Scan(
 			&i.OrgID,
 			&i.FromTraceID,
@@ -260,7 +260,7 @@ func (q *Queries) ListSpanLinksBySession(ctx context.Context, sessionID pgtype.U
 }
 
 const listSpanLinksByTrace = `-- name: ListSpanLinksByTrace :many
-SELECT org_id, from_trace_id, from_span_id, from_io, to_trace_id, to_span_id, to_io, kind, session_id FROM span_links
+SELECT org_id, from_trace_id, from_span_id, from_io, to_trace_id, to_span_id, to_io, kind, session_id FROM span_links_20260615
 WHERE org_id = $1 AND (from_trace_id = $2 OR to_trace_id = $2)
 `
 
@@ -269,15 +269,15 @@ type ListSpanLinksByTraceParams struct {
 	FromTraceID string
 }
 
-func (q *Queries) ListSpanLinksByTrace(ctx context.Context, arg ListSpanLinksByTraceParams) ([]SpanLink, error) {
+func (q *Queries) ListSpanLinksByTrace(ctx context.Context, arg ListSpanLinksByTraceParams) ([]SpanLinks20260615, error) {
 	rows, err := q.db.Query(ctx, listSpanLinksByTrace, arg.OrgID, arg.FromTraceID)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []SpanLink
+	var items []SpanLinks20260615
 	for rows.Next() {
-		var i SpanLink
+		var i SpanLinks20260615
 		if err := rows.Scan(
 			&i.OrgID,
 			&i.FromTraceID,
@@ -300,7 +300,7 @@ func (q *Queries) ListSpanLinksByTrace(ctx context.Context, arg ListSpanLinksByT
 }
 
 const listSpanTurns = `-- name: ListSpanTurns :many
-SELECT org_id, trace_id, session_id, user_prompt, synthetic, status, started_at, ended_at, duration_ns, total_input_tokens, total_output_tokens, total_cost_usd, main_input_tokens, main_output_tokens, cache_read_tokens, cache_creation_tokens, response_preview FROM span_turns
+SELECT org_id, trace_id, session_id, user_prompt, synthetic, status, started_at, ended_at, duration_ns, total_input_tokens, total_output_tokens, total_cost_usd, main_input_tokens, main_output_tokens, cache_read_tokens, cache_creation_tokens, response_preview FROM span_turns_20260615
 WHERE org_id = $1
   AND ($3::timestamptz IS NULL
        OR (started_at, trace_id) < ($3::timestamptz, $4::text))
@@ -315,7 +315,7 @@ type ListSpanTurnsParams struct {
 	CursorTraceID   pgtype.Text
 }
 
-func (q *Queries) ListSpanTurns(ctx context.Context, arg ListSpanTurnsParams) ([]SpanTurn, error) {
+func (q *Queries) ListSpanTurns(ctx context.Context, arg ListSpanTurnsParams) ([]SpanTurns20260615, error) {
 	rows, err := q.db.Query(ctx, listSpanTurns,
 		arg.OrgID,
 		arg.Limit,
@@ -326,9 +326,9 @@ func (q *Queries) ListSpanTurns(ctx context.Context, arg ListSpanTurnsParams) ([
 		return nil, err
 	}
 	defer rows.Close()
-	var items []SpanTurn
+	var items []SpanTurns20260615
 	for rows.Next() {
-		var i SpanTurn
+		var i SpanTurns20260615
 		if err := rows.Scan(
 			&i.OrgID,
 			&i.TraceID,
@@ -360,21 +360,21 @@ func (q *Queries) ListSpanTurns(ctx context.Context, arg ListSpanTurnsParams) ([
 
 const listSpanTurnsBySession = `-- name: ListSpanTurnsBySession :many
 
-SELECT org_id, trace_id, session_id, user_prompt, synthetic, status, started_at, ended_at, duration_ns, total_input_tokens, total_output_tokens, total_cost_usd, main_input_tokens, main_output_tokens, cache_read_tokens, cache_creation_tokens, response_preview FROM span_turns
+SELECT org_id, trace_id, session_id, user_prompt, synthetic, status, started_at, ended_at, duration_ns, total_input_tokens, total_output_tokens, total_cost_usd, main_input_tokens, main_output_tokens, cache_read_tokens, cache_creation_tokens, response_preview FROM span_turns_20260615
 WHERE session_id = $1
 ORDER BY started_at ASC, trace_id ASC
 `
 
 // Span model reads.
-func (q *Queries) ListSpanTurnsBySession(ctx context.Context, sessionID pgtype.UUID) ([]SpanTurn, error) {
+func (q *Queries) ListSpanTurnsBySession(ctx context.Context, sessionID pgtype.UUID) ([]SpanTurns20260615, error) {
 	rows, err := q.db.Query(ctx, listSpanTurnsBySession, sessionID)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []SpanTurn
+	var items []SpanTurns20260615
 	for rows.Next() {
-		var i SpanTurn
+		var i SpanTurns20260615
 		if err := rows.Scan(
 			&i.OrgID,
 			&i.TraceID,
@@ -405,22 +405,22 @@ func (q *Queries) ListSpanTurnsBySession(ctx context.Context, sessionID pgtype.U
 }
 
 const listSpansBySession = `-- name: ListSpansBySession :many
-SELECT org_id, trace_id, span_id, parent_span_id, session_id, kind, name, status, call_kind, thread_id, model, stop_reason, started_at, duration_ns, input, output, usage, raw_turn_id, node_hash, seq FROM spans
+SELECT org_id, trace_id, span_id, parent_span_id, session_id, kind, name, status, call_kind, thread_id, model, stop_reason, started_at, duration_ns, input, output, usage, raw_turn_id, node_hash, seq FROM spans_20260615
 WHERE session_id = $1
 ORDER BY trace_id ASC, seq ASC, started_at ASC, span_id ASC
 `
 
 // seq is the deriver's emit ordinal (presentation order); started_at/
 // span_id only break ties for pre-seq rows that haven't re-derived.
-func (q *Queries) ListSpansBySession(ctx context.Context, sessionID pgtype.UUID) ([]Span, error) {
+func (q *Queries) ListSpansBySession(ctx context.Context, sessionID pgtype.UUID) ([]Spans20260615, error) {
 	rows, err := q.db.Query(ctx, listSpansBySession, sessionID)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []Span
+	var items []Spans20260615
 	for rows.Next() {
-		var i Span
+		var i Spans20260615
 		if err := rows.Scan(
 			&i.OrgID,
 			&i.TraceID,
@@ -454,7 +454,7 @@ func (q *Queries) ListSpansBySession(ctx context.Context, sessionID pgtype.UUID)
 }
 
 const listSpansByTrace = `-- name: ListSpansByTrace :many
-SELECT org_id, trace_id, span_id, parent_span_id, session_id, kind, name, status, call_kind, thread_id, model, stop_reason, started_at, duration_ns, input, output, usage, raw_turn_id, node_hash, seq FROM spans
+SELECT org_id, trace_id, span_id, parent_span_id, session_id, kind, name, status, call_kind, thread_id, model, stop_reason, started_at, duration_ns, input, output, usage, raw_turn_id, node_hash, seq FROM spans_20260615
 WHERE org_id = $1 AND trace_id = $2
 ORDER BY seq ASC, started_at ASC, span_id ASC
 `
@@ -464,15 +464,15 @@ type ListSpansByTraceParams struct {
 	TraceID string
 }
 
-func (q *Queries) ListSpansByTrace(ctx context.Context, arg ListSpansByTraceParams) ([]Span, error) {
+func (q *Queries) ListSpansByTrace(ctx context.Context, arg ListSpansByTraceParams) ([]Spans20260615, error) {
 	rows, err := q.db.Query(ctx, listSpansByTrace, arg.OrgID, arg.TraceID)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []Span
+	var items []Spans20260615
 	for rows.Next() {
-		var i Span
+		var i Spans20260615
 		if err := rows.Scan(
 			&i.OrgID,
 			&i.TraceID,
@@ -512,8 +512,8 @@ SELECT t.org_id, t.trace_id, t.session_id, t.user_prompt, t.response_preview, t.
        t.main_input_tokens, t.main_output_tokens,
        t.cache_read_tokens, t.cache_creation_tokens, t.total_cost_usd,
        count(s.span_id) AS span_count
-FROM span_turns t
-LEFT JOIN spans s ON s.org_id = t.org_id AND s.trace_id = t.trace_id
+FROM span_turns_20260615 t
+LEFT JOIN spans_20260615 s ON s.org_id = t.org_id AND s.trace_id = t.trace_id
 WHERE t.session_id = $1
 GROUP BY t.org_id, t.trace_id
 ORDER BY t.started_at ASC, t.trace_id ASC
@@ -581,18 +581,18 @@ func (q *Queries) ListTraceSummariesBySession(ctx context.Context, sessionID pgt
 }
 
 const pruneSpanLinks = `-- name: PruneSpanLinks :execrows
-DELETE FROM span_links
+DELETE FROM span_links_20260615
 WHERE org_id = $1
   AND session_id = ANY($2::uuid[])
   AND NOT EXISTS (
       SELECT 1
       FROM generate_subscripts($3::text[], 1) AS i
-      WHERE ($3::text[])[i] = span_links.from_trace_id
-        AND ($4::text[])[i]  = span_links.from_span_id
-        AND ($5::text[])[i]   = span_links.to_trace_id
-        AND ($6::text[])[i]    = span_links.to_span_id
-        AND ($7::text[])[i]       = span_links.from_io
-        AND ($8::text[])[i]         = span_links.to_io
+      WHERE ($3::text[])[i] = span_links_20260615.from_trace_id
+        AND ($4::text[])[i]  = span_links_20260615.from_span_id
+        AND ($5::text[])[i]   = span_links_20260615.to_trace_id
+        AND ($6::text[])[i]    = span_links_20260615.to_span_id
+        AND ($7::text[])[i]       = span_links_20260615.from_io
+        AND ($8::text[])[i]         = span_links_20260615.to_io
   )
 `
 
@@ -627,7 +627,7 @@ func (q *Queries) PruneSpanLinks(ctx context.Context, arg PruneSpanLinksParams) 
 }
 
 const pruneSpanTurns = `-- name: PruneSpanTurns :execrows
-DELETE FROM span_turns
+DELETE FROM span_turns_20260615
 WHERE org_id = $1
   AND session_id = ANY($2::uuid[])
   AND NOT (trace_id = ANY($3::text[]))
@@ -650,14 +650,14 @@ func (q *Queries) PruneSpanTurns(ctx context.Context, arg PruneSpanTurnsParams) 
 }
 
 const pruneSpans = `-- name: PruneSpans :execrows
-DELETE FROM spans
+DELETE FROM spans_20260615
 WHERE org_id = $1
   AND session_id = ANY($2::uuid[])
   AND NOT EXISTS (
       SELECT 1
       FROM generate_subscripts($3::text[], 1) AS i
-      WHERE ($3::text[])[i] = spans.trace_id
-        AND ($4::text[])[i]  = spans.span_id
+      WHERE ($3::text[])[i] = spans_20260615.trace_id
+        AND ($4::text[])[i]  = spans_20260615.span_id
   )
 `
 
@@ -687,7 +687,7 @@ func (q *Queries) PruneSpans(ctx context.Context, arg PruneSpansParams) (int64, 
 }
 
 const upsertSpan = `-- name: UpsertSpan :exec
-INSERT INTO spans (
+INSERT INTO spans_20260615 (
     org_id, trace_id, span_id, parent_span_id, session_id,
     kind, name, status, call_kind, thread_id, model, stop_reason,
     started_at, duration_ns, seq, input, output, usage, raw_turn_id, node_hash
@@ -698,7 +698,7 @@ INSERT INTO spans (
 )
 ON CONFLICT (org_id, trace_id, span_id) DO UPDATE SET
     parent_span_id = EXCLUDED.parent_span_id,
-    session_id     = COALESCE(spans.session_id, EXCLUDED.session_id),
+    session_id     = COALESCE(spans_20260615.session_id, EXCLUDED.session_id),
     kind           = EXCLUDED.kind,
     name           = EXCLUDED.name,
     status         = EXCLUDED.status,
@@ -766,7 +766,7 @@ func (q *Queries) UpsertSpan(ctx context.Context, arg UpsertSpanParams) error {
 }
 
 const upsertSpanLink = `-- name: UpsertSpanLink :exec
-INSERT INTO span_links (
+INSERT INTO span_links_20260615 (
     org_id, from_trace_id, from_span_id, from_io,
     to_trace_id, to_span_id, to_io, kind, session_id
 ) VALUES (
@@ -776,7 +776,7 @@ INSERT INTO span_links (
 ON CONFLICT (org_id, from_trace_id, from_span_id, to_trace_id, to_span_id, from_io, to_io)
 DO UPDATE SET
     kind       = EXCLUDED.kind,
-    session_id = COALESCE(span_links.session_id, EXCLUDED.session_id)
+    session_id = COALESCE(span_links_20260615.session_id, EXCLUDED.session_id)
 `
 
 type UpsertSpanLinkParams struct {
@@ -808,7 +808,7 @@ func (q *Queries) UpsertSpanLink(ctx context.Context, arg UpsertSpanLinkParams) 
 
 const upsertSpanTurn = `-- name: UpsertSpanTurn :exec
 
-INSERT INTO span_turns (
+INSERT INTO span_turns_20260615 (
     org_id, trace_id, session_id, user_prompt, response_preview, synthetic, status,
     started_at, ended_at, duration_ns,
     total_input_tokens, total_output_tokens,
@@ -824,7 +824,7 @@ INSERT INTO span_turns (
     $17
 )
 ON CONFLICT (org_id, trace_id) DO UPDATE SET
-    session_id            = COALESCE(span_turns.session_id, EXCLUDED.session_id),
+    session_id            = COALESCE(span_turns_20260615.session_id, EXCLUDED.session_id),
     user_prompt           = EXCLUDED.user_prompt,
     response_preview      = EXCLUDED.response_preview,
     synthetic             = EXCLUDED.synthetic,

--- a/pkg/storage/postgres/queries/spans.sql
+++ b/pkg/storage/postgres/queries/spans.sql
@@ -3,7 +3,7 @@
 -- place and prune removes only rows a superseded projection wrote.
 
 -- name: UpsertSpanTurn :exec
-INSERT INTO span_turns (
+INSERT INTO span_turns_20260615 (
     org_id, trace_id, session_id, user_prompt, response_preview, synthetic, status,
     started_at, ended_at, duration_ns,
     total_input_tokens, total_output_tokens,
@@ -19,7 +19,7 @@ INSERT INTO span_turns (
     $17
 )
 ON CONFLICT (org_id, trace_id) DO UPDATE SET
-    session_id            = COALESCE(span_turns.session_id, EXCLUDED.session_id),
+    session_id            = COALESCE(span_turns_20260615.session_id, EXCLUDED.session_id),
     user_prompt           = EXCLUDED.user_prompt,
     response_preview      = EXCLUDED.response_preview,
     synthetic             = EXCLUDED.synthetic,
@@ -36,7 +36,7 @@ ON CONFLICT (org_id, trace_id) DO UPDATE SET
     total_cost_usd        = EXCLUDED.total_cost_usd;
 
 -- name: UpsertSpan :exec
-INSERT INTO spans (
+INSERT INTO spans_20260615 (
     org_id, trace_id, span_id, parent_span_id, session_id,
     kind, name, status, call_kind, thread_id, model, stop_reason,
     started_at, duration_ns, seq, input, output, usage, raw_turn_id, node_hash
@@ -47,7 +47,7 @@ INSERT INTO spans (
 )
 ON CONFLICT (org_id, trace_id, span_id) DO UPDATE SET
     parent_span_id = EXCLUDED.parent_span_id,
-    session_id     = COALESCE(spans.session_id, EXCLUDED.session_id),
+    session_id     = COALESCE(spans_20260615.session_id, EXCLUDED.session_id),
     kind           = EXCLUDED.kind,
     name           = EXCLUDED.name,
     status         = EXCLUDED.status,
@@ -65,7 +65,7 @@ ON CONFLICT (org_id, trace_id, span_id) DO UPDATE SET
     node_hash      = EXCLUDED.node_hash;
 
 -- name: UpsertSpanLink :exec
-INSERT INTO span_links (
+INSERT INTO span_links_20260615 (
     org_id, from_trace_id, from_span_id, from_io,
     to_trace_id, to_span_id, to_io, kind, session_id
 ) VALUES (
@@ -75,12 +75,12 @@ INSERT INTO span_links (
 ON CONFLICT (org_id, from_trace_id, from_span_id, to_trace_id, to_span_id, from_io, to_io)
 DO UPDATE SET
     kind       = EXCLUDED.kind,
-    session_id = COALESCE(span_links.session_id, EXCLUDED.session_id);
+    session_id = COALESCE(span_links_20260615.session_id, EXCLUDED.session_id);
 
 -- name: PruneSpanTurns :execrows
 -- Deterministic ids make prune a no-op on unchanged raw; rows fall out
 -- only when the projection stops producing their key.
-DELETE FROM span_turns
+DELETE FROM span_turns_20260615
 WHERE org_id = $1
   AND session_id = ANY(sqlc.arg(session_ids)::uuid[])
   AND NOT (trace_id = ANY(sqlc.arg(keep_trace_ids)::text[]));
@@ -91,53 +91,53 @@ WHERE org_id = $1
 -- wire ids (request_id, tool_use_id) that can contain any byte, so a '|'
 -- delimiter would collapse distinct (trace, span) pairs and delete the
 -- wrong row inside the derive tx.
-DELETE FROM spans
+DELETE FROM spans_20260615
 WHERE org_id = $1
   AND session_id = ANY(sqlc.arg(session_ids)::uuid[])
   AND NOT EXISTS (
       SELECT 1
       FROM generate_subscripts(sqlc.arg(keep_trace_ids)::text[], 1) AS i
-      WHERE (sqlc.arg(keep_trace_ids)::text[])[i] = spans.trace_id
-        AND (sqlc.arg(keep_span_ids)::text[])[i]  = spans.span_id
+      WHERE (sqlc.arg(keep_trace_ids)::text[])[i] = spans_20260615.trace_id
+        AND (sqlc.arg(keep_span_ids)::text[])[i]  = spans_20260615.span_id
   );
 
 -- name: PruneSpanLinks :execrows
 -- Same tuple-membership guard as PruneSpans: the six link key columns
 -- carry wire ids and cannot be safely '|'-joined into one string.
-DELETE FROM span_links
+DELETE FROM span_links_20260615
 WHERE org_id = $1
   AND session_id = ANY(sqlc.arg(session_ids)::uuid[])
   AND NOT EXISTS (
       SELECT 1
       FROM generate_subscripts(sqlc.arg(keep_from_trace_ids)::text[], 1) AS i
-      WHERE (sqlc.arg(keep_from_trace_ids)::text[])[i] = span_links.from_trace_id
-        AND (sqlc.arg(keep_from_span_ids)::text[])[i]  = span_links.from_span_id
-        AND (sqlc.arg(keep_to_trace_ids)::text[])[i]   = span_links.to_trace_id
-        AND (sqlc.arg(keep_to_span_ids)::text[])[i]    = span_links.to_span_id
-        AND (sqlc.arg(keep_from_ios)::text[])[i]       = span_links.from_io
-        AND (sqlc.arg(keep_to_ios)::text[])[i]         = span_links.to_io
+      WHERE (sqlc.arg(keep_from_trace_ids)::text[])[i] = span_links_20260615.from_trace_id
+        AND (sqlc.arg(keep_from_span_ids)::text[])[i]  = span_links_20260615.from_span_id
+        AND (sqlc.arg(keep_to_trace_ids)::text[])[i]   = span_links_20260615.to_trace_id
+        AND (sqlc.arg(keep_to_span_ids)::text[])[i]    = span_links_20260615.to_span_id
+        AND (sqlc.arg(keep_from_ios)::text[])[i]       = span_links_20260615.from_io
+        AND (sqlc.arg(keep_to_ios)::text[])[i]         = span_links_20260615.to_io
   );
 
 -- Span model reads.
 
 -- name: ListSpanTurnsBySession :many
-SELECT * FROM span_turns
+SELECT * FROM span_turns_20260615
 WHERE session_id = $1
 ORDER BY started_at ASC, trace_id ASC;
 
 -- name: ListSpansBySession :many
 -- seq is the deriver's emit ordinal (presentation order); started_at/
 -- span_id only break ties for pre-seq rows that haven't re-derived.
-SELECT * FROM spans
+SELECT * FROM spans_20260615
 WHERE session_id = $1
 ORDER BY trace_id ASC, seq ASC, started_at ASC, span_id ASC;
 
 -- name: ListSpanLinksBySession :many
-SELECT * FROM span_links
+SELECT * FROM span_links_20260615
 WHERE session_id = $1;
 
 -- name: ListSpanTurns :many
-SELECT * FROM span_turns
+SELECT * FROM span_turns_20260615
 WHERE org_id = $1
   AND (sqlc.narg(cursor_started_at)::timestamptz IS NULL
        OR (started_at, trace_id) < (sqlc.narg(cursor_started_at)::timestamptz, sqlc.narg(cursor_trace_id)::text))
@@ -145,16 +145,16 @@ ORDER BY started_at DESC, trace_id DESC
 LIMIT $2;
 
 -- name: GetSpanTurn :one
-SELECT * FROM span_turns
+SELECT * FROM span_turns_20260615
 WHERE org_id = $1 AND trace_id = $2;
 
 -- name: ListSpansByTrace :many
-SELECT * FROM spans
+SELECT * FROM spans_20260615
 WHERE org_id = $1 AND trace_id = $2
 ORDER BY seq ASC, started_at ASC, span_id ASC;
 
 -- name: ListSpanLinksByTrace :many
-SELECT * FROM span_links
+SELECT * FROM span_links_20260615
 WHERE org_id = $1 AND (from_trace_id = $2 OR to_trace_id = $2);
 
 -- name: ListTraceSummariesBySession :many
@@ -165,14 +165,14 @@ SELECT t.org_id, t.trace_id, t.session_id, t.user_prompt, t.response_preview, t.
        t.main_input_tokens, t.main_output_tokens,
        t.cache_read_tokens, t.cache_creation_tokens, t.total_cost_usd,
        count(s.span_id) AS span_count
-FROM span_turns t
-LEFT JOIN spans s ON s.org_id = t.org_id AND s.trace_id = t.trace_id
+FROM span_turns_20260615 t
+LEFT JOIN spans_20260615 s ON s.org_id = t.org_id AND s.trace_id = t.trace_id
 WHERE t.session_id = $1
 GROUP BY t.org_id, t.trace_id
 ORDER BY t.started_at ASC, t.trace_id ASC;
 
 -- name: GetSpan :one
-SELECT * FROM spans
+SELECT * FROM spans_20260615
 WHERE org_id = $1 AND trace_id = $2 AND span_id = $3;
 
 -- name: FoldSessionRollupsFromSpans :exec
@@ -199,7 +199,7 @@ UPDATE sessions SET
     model_usage = NULL,
     derived_title = NULL,
     derived_model = COALESCE((
-        SELECT sp.model FROM spans sp
+        SELECT sp.model FROM spans_20260615 sp
         WHERE sp.session_id = sessions.id
           AND sp.kind = 'llm' AND sp.call_kind = 'main' AND sp.model <> ''
           -- main thread only: subagents run their own (often cheaper)
@@ -217,7 +217,7 @@ FROM (
            SUM(st.total_output_tokens) AS output_tokens,
            COUNT(st.trace_id)          AS turns
     FROM sessions s
-    LEFT JOIN span_turns st ON st.session_id = s.id
+    LEFT JOIN span_turns_20260615 st ON st.session_id = s.id
     WHERE s.id = ANY(sqlc.arg(session_ids)::uuid[])
     GROUP BY s.id
 ) f
@@ -234,12 +234,12 @@ WHERE sessions.id = f.id;
 --   total_duration_ns = SUM of trace durations — agent time, not the
 --                       wall-clock MAX-MIN window (idle time between
 --                       turns no longer counts)
---   tool_calls        = tool spans started in the window
+--   tool_calls        = tool spans_20260615 started in the window
 WITH matched AS (
     SELECT t.org_id, t.trace_id, t.session_id, t.synthetic, t.duration_ns,
            t.total_input_tokens, t.total_output_tokens,
            t.cache_read_tokens, t.cache_creation_tokens, t.total_cost_usd
-    FROM span_turns t
+    FROM span_turns_20260615 t
     WHERE t.org_id = sqlc.arg(org_id)
       AND (sqlc.narg(since_filter)::timestamptz IS NULL OR t.started_at >= sqlc.narg(since_filter)::timestamptz)
       AND (sqlc.narg(until_filter)::timestamptz IS NULL OR t.started_at < sqlc.narg(until_filter)::timestamptz)
@@ -260,7 +260,7 @@ SELECT
     COALESCE(SUM(cache_read_tokens), 0)::bigint             AS cache_read_tokens,
     COALESCE(SUM(duration_ns), 0)::bigint                   AS total_duration_ns,
     COALESCE(SUM(total_cost_usd), 0)::numeric               AS total_cost_usd,
-    (SELECT COUNT(*) FROM spans sp
+    (SELECT COUNT(*) FROM spans_20260615 sp
      WHERE sp.org_id = sqlc.arg(org_id)
        AND sp.kind = 'tool'
        AND (sqlc.narg(since_filter)::timestamptz IS NULL OR sp.started_at >= sqlc.narg(since_filter)::timestamptz)

--- a/pkg/storage/postgres/spans.go
+++ b/pkg/storage/postgres/spans.go
@@ -335,8 +335,8 @@ func spanTurnRecordFromColumns(c spanTurnColumns) storage.SpanTurnRecord {
 	return rec
 }
 
-// spanRecordFromRow converts a spans row to its flat record.
-func spanRecordFromRow(row gensqlc.Span) storage.SpanRecord {
+// spanRecordFromRow converts a versioned spans row to its flat record.
+func spanRecordFromRow(row gensqlc.Spans20260615) storage.SpanRecord {
 	return storage.SpanRecord{
 		TraceID:      row.TraceID,
 		SpanID:       row.SpanID,


### PR DESCRIPTION
## Summary
- Move the derived span projection to date-versioned physical tables for the initial `2026-06-15` schema: `span_turns_20260615`, `spans_20260615`, and `span_links_20260615`.
- Add `derived_projection_schemas` metadata so future projection schemas can coexist and old data remains readable.
- Point sqlc queries and span embedding joins at the current versioned table family.

related to PCC-690

## Why this is versioned derived data
The raw tapes turns remain the long-lived source of truth. The span/session tables are a derived visualization model: they encode the current answer to "how should the console understand and render this session?" That answer is allowed to evolve as we learn more from real data and UI needs.

This PR starts the projection at compatibility date `2026-06-15` with date-suffixed physical tables. A future projection bump would be warranted when the derived model changes in a way that old rows cannot safely share the same table contract. For example, if we move from "one trace row per user-visible turn" to a richer conversation graph that changes span identity, link cardinality, branch semantics, or the columns needed to distinguish main-thread work from subagent/synthetic work, we would create a new dated table family, register it in `derived_projection_schemas`, backfill it from raw turns, and move unpinned tenants/users and current reads to the new family.

The older table family is a compatibility snapshot, not the default write target forever. New data should flow to the latest projection unless a tenant/user is explicitly pinned to an older compatibility date. Over time, normal retention and archival policy can age old projection rows out of hot storage, and older table families can become sparse: in the limit, they may only exist for tenants/users that were pinned or had historical data at that projection date. We can also stop auto-creating old projection families for new tenants once no new writes target them.

This is similar in spirit to semantic versioning, but date-based compatibility is a better fit for stored projections. A new dated table family is closer to a major version bump: it means the derived row contract changed enough that old and new rows should not silently share one physical schema. Minor or patch-level changes should stay within the existing projection date when they are compatible, such as adding nullable fields, tuning indexes, improving query plans, regenerating sqlc, or fixing derivation bugs without changing the meaning of existing rows. The date is the compatibility boundary; the table suffix is the physical representation of that boundary.

## Verification
- `direnv exec . make generate`
- `direnv exec . go test ./api ./pkg/derive`
- `direnv exec . go test ./... -run '^$'`
- `direnv exec . make e2e-test`
- `direnv exec . make test-kafka-e2e`
- `direnv exec . make build`
- `git diff --check`

Note: `direnv exec . go test ./api ./pkg/derive ./pkg/spanembed` passes api/derive and reaches the expected local guard for spanembed because `TEST_POSTGRES_DSN` is not set; the Dagger E2E run exercises the Postgres migration path.
