### PR TITLE
:wrench: fix: project Codex Responses turns into traces

### DIFF
--- a/pkg/derive/classify.go
+++ b/pkg/derive/classify.go
@@ -139,6 +139,8 @@ func ClassifyCall(req *llm.ChatRequest, resp *llm.ChatResponse) string {
 	{
 		lt := strings.ToLower(lastText(req))
 		if strings.Contains(lt, "summary of the conversation so far") ||
+			strings.Contains(lt, "context checkpoint compaction") ||
+			strings.Contains(lt, "create a handoff summary for another llm") ||
 			isCompactionSummary(responseText(resp)) {
 			return KindCompaction
 		}

--- a/pkg/derive/classify_test.go
+++ b/pkg/derive/classify_test.go
@@ -2,6 +2,7 @@ package derive_test
 
 import (
 	"encoding/json"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -108,6 +109,27 @@ var _ = Describe("ClassifyCall", func() {
 			},
 		}
 		Expect(derive.ClassifyCall(req, assistantText("<analysis>…</analysis><summary>…</summary>"))).To(Equal(derive.KindCompaction))
+	})
+
+	It("classifies Codex checkpoint compaction", func() {
+		req := &llm.ChatRequest{
+			Stream: boolp(true),
+			Messages: []llm.Message{
+				textMsg("developer", "You are Codex."),
+				textMsg("user", "real conversation history"),
+				textMsg("user", `You are performing a CONTEXT CHECKPOINT COMPACTION. Create a handoff summary for another LLM that will resume the task.
+
+Include:
+- Current progress and key decisions made
+- Important context, constraints, or user preferences
+- What remains to be done (clear next steps)
+- Any critical data, examples, or references needed to continue
+
+Be concise, structured, and focused on helping the next LLM seamlessly continue the work.
+`),
+			},
+		}
+		Expect(derive.ClassifyCall(req, assistantText("**Current Progress**\n- ..."))).To(Equal(derive.KindCompaction))
 	})
 
 	It("classifies the conversation spine", func() {
@@ -270,5 +292,92 @@ var _ = Describe("BuildDerivedSet", func() {
 			Expect(a.Nodes[i].Node.Hash).To(Equal(b.Nodes[i].Node.Hash))
 			Expect(a.Nodes[i].Node.Kind).To(Equal(b.Nodes[i].Node.Kind))
 		}
+	})
+
+	It("projects Codex Responses tool calls as the conversation spine", func() {
+		turn1 := storage.RawTurnRecord{
+			ID:               1,
+			Provider:         "openai",
+			HarnessID:        "codex",
+			HarnessSessionID: "sess-codex",
+			RequestID:        "resp_req_1",
+			ReceivedAt:       time.Unix(1781218506, 0),
+			RawRequest: json.RawMessage(`{
+				"model":"gpt-5.5",
+				"instructions":"You are Codex.",
+				"stream":true,
+				"tools":[{"type":"function","name":"exec_command"}],
+				"input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"list files"}]}]
+			}`),
+			Response: json.RawMessage(`{
+				"model":"gpt-5.5",
+				"message":{"role":"assistant","content":[
+					{"type":"thinking","thinking":"inspect"},
+					{"type":"tool_use","tool_use_id":"call_1","tool_name":"exec_command","tool_input":{"cmd":"ls"}}
+				]},
+				"stop_reason":"tool_use",
+				"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}
+			}`),
+			Meta: json.RawMessage(`{}`),
+		}
+		turn2 := storage.RawTurnRecord{
+			ID:               2,
+			Provider:         "openai",
+			HarnessID:        "codex",
+			HarnessSessionID: "sess-codex",
+			RequestID:        "resp_req_2",
+			ReceivedAt:       time.Unix(1781218507, 0),
+			RawRequest: json.RawMessage(`{
+				"model":"gpt-5.5",
+				"instructions":"You are Codex.",
+				"stream":true,
+				"tools":[{"type":"function","name":"exec_command"}],
+				"input":[
+					{"type":"message","role":"user","content":[{"type":"input_text","text":"list files"}]},
+					{"type":"function_call","call_id":"call_1","name":"exec_command","arguments":"{\"cmd\":\"ls\"}"},
+					{"type":"function_call_output","call_id":"call_1","output":"README.md"}
+				]
+			}`),
+			Response: json.RawMessage(`{
+				"model":"gpt-5.5",
+				"message":{"role":"assistant","content":[{"type":"text","text":"README.md"}]},
+				"stop_reason":"stop",
+				"usage":{"prompt_tokens":20,"completion_tokens":2,"total_tokens":22}
+			}`),
+			Meta: json.RawMessage(`{}`),
+		}
+
+		set, err := derive.BuildDerivedSet([]storage.RawTurnRecord{turn1, turn2}, "p")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(set.Report.CallKinds).To(HaveKeyWithValue(derive.KindMain, 2))
+		Expect(set.Report.CallKinds).NotTo(HaveKey(derive.KindUnknown))
+
+		spans := derive.EmitSpans(set)
+		Expect(spans.Report.Traces).To(Equal(1))
+		Expect(spans.Report.Synthetic).To(Equal(0))
+		Expect(spans.Report.SpanKinds).To(HaveKeyWithValue(derive.SpanKindAgent, 1))
+		Expect(spans.Report.SpanKinds).To(HaveKeyWithValue(derive.SpanKindLLM, 2))
+		Expect(spans.Report.SpanKinds).To(HaveKeyWithValue(derive.SpanKindTool, 1))
+		Expect(spans.Report.CallKinds).To(HaveKeyWithValue(derive.KindMain, 2))
+		Expect(spans.Report.LinkKinds).To(HaveKeyWithValue(derive.LinkFeeds, 1))
+
+		trace := spans.Turns[0]
+		Expect(trace.UserPrompt).To(Equal("list files"))
+		Expect(trace.ResponsePreview).To(Equal("README.md"))
+		Expect(trace.MainInputTokens).To(Equal(int64(30)))
+		Expect(trace.MainOutputTokens).To(Equal(int64(7)))
+
+		var tool *derive.Span
+		for _, span := range trace.Spans {
+			if span.Kind == derive.SpanKindTool {
+				tool = span
+				break
+			}
+		}
+		Expect(tool).NotTo(BeNil())
+		Expect(tool.SpanID).To(Equal("call_1"))
+		Expect(tool.Name).To(Equal("Bash"))
+		Expect(tool.Output).To(HaveLen(1))
+		Expect(tool.Output[0].ToolOutput).To(Equal("README.md"))
 	})
 })

--- a/pkg/derive/spans.go
+++ b/pkg/derive/spans.go
@@ -37,6 +37,7 @@ const (
 // ContentBlock.Type values and message roles).
 const (
 	roleUser           = "user"
+	roleTool           = "tool"
 	blockText          = "text"
 	blockToolUse       = "tool_use"
 	blockServerToolUse = "server_tool_use"
@@ -410,7 +411,7 @@ func (em *spanEmitter) emitConversation(src *SpanSource, turn *SpanTurn, parent 
 			}
 			continue
 		}
-		if node.Bucket.Role != roleUser {
+		if node.Bucket.Role != roleUser && node.Bucket.Role != roleTool {
 			continue
 		}
 		for _, b := range node.Bucket.Content {
@@ -448,15 +449,11 @@ func (em *spanEmitter) emitConversation(src *SpanSource, turn *SpanTurn, parent 
 			})
 			continue
 		}
-		name := b.ToolName
-		if name == "" {
-			name = "tool"
-		}
 		ts := &Span{
 			SpanID:       b.ToolUseID,
 			ParentSpanID: parent.SpanID,
 			Kind:         SpanKindTool,
-			Name:         name,
+			Name:         displayToolName(b.ToolName, b.ToolInput),
 			Status:       "ok",
 			StartedAt:    src.CapturedAt,
 			ThreadID:     src.ThreadID,
@@ -471,6 +468,51 @@ func (em *spanEmitter) emitConversation(src *SpanSource, turn *SpanTurn, parent 
 			Kind: LinkEmits,
 		})
 	}
+}
+
+// displayToolName returns the user-facing tool name for a span. Some
+// Responses-first harnesses, notably Codex, expose a generic function wrapper
+// such as exec/exec_command while the input shape carries the actual action.
+// Keep the raw tool_use block in Span.Input, but use the semantic label for
+// the span row so Console groups it with Claude's Bash tool.
+func displayToolName(name string, input map[string]any) string {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "exec", "exec_command", "shell", "shell_command":
+		if hasShellCommandInput(input) {
+			return "Bash"
+		}
+	}
+	if name == "" {
+		return "tool"
+	}
+	return name
+}
+
+func hasShellCommandInput(input map[string]any) bool {
+	if input == nil {
+		return false
+	}
+	for _, key := range []string{"command", "cmd"} {
+		v, ok := input[key]
+		if !ok {
+			continue
+		}
+		switch t := v.(type) {
+		case string:
+			if strings.TrimSpace(t) != "" {
+				return true
+			}
+		case []string:
+			if len(t) > 0 {
+				return true
+			}
+		case []any:
+			if len(t) > 0 {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // fillToolResult stores a tool_result block on its tool span and

--- a/pkg/llm/provider/openai/responses.go
+++ b/pkg/llm/provider/openai/responses.go
@@ -18,15 +18,16 @@ import (
 // maps onto llm.ChatRequest. `input` is either a bare string or an array of
 // items; items are kept raw and decoded per type.
 type responsesRequest struct {
-	Model           string          `json:"model"`
-	Input           json.RawMessage `json:"input"`
-	Instructions    string          `json:"instructions,omitempty"`
-	MaxOutputTokens *int            `json:"max_output_tokens,omitempty"`
-	Temperature     *float64        `json:"temperature,omitempty"`
-	TopP            *float64        `json:"top_p,omitempty"`
-	Stream          *bool           `json:"stream,omitempty"`
-	Reasoning       map[string]any  `json:"reasoning,omitempty"`
-	PreviousID      string          `json:"previous_response_id,omitempty"`
+	Model           string            `json:"model"`
+	Input           json.RawMessage   `json:"input"`
+	Instructions    string            `json:"instructions,omitempty"`
+	MaxOutputTokens *int              `json:"max_output_tokens,omitempty"`
+	Temperature     *float64          `json:"temperature,omitempty"`
+	TopP            *float64          `json:"top_p,omitempty"`
+	Stream          *bool             `json:"stream,omitempty"`
+	Tools           []json.RawMessage `json:"tools,omitempty"`
+	Reasoning       map[string]any    `json:"reasoning,omitempty"`
+	PreviousID      string            `json:"previous_response_id,omitempty"`
 }
 
 // responsesItem is the union of the Responses input/output item shapes tapes
@@ -117,6 +118,7 @@ func parseResponsesRequest(payload []byte) (*llm.ChatRequest, error) {
 		Temperature: req.Temperature,
 		TopP:        req.TopP,
 		Stream:      req.Stream,
+		Tools:       req.Tools,
 		RawRequest:  payload,
 	}
 

--- a/pkg/llm/provider/openai/responses_test.go
+++ b/pkg/llm/provider/openai/responses_test.go
@@ -19,6 +19,7 @@ var _ = Describe("Responses API request parsing", func() {
 			"model": "gpt-5.5",
 			"instructions": "You are Codex.",
 			"stream": true,
+			"tools": [{"type": "function", "name": "shell"}],
 			"input": [
 				{"type": "message", "role": "user", "content": [{"type": "input_text", "text": "list files"}]},
 				{"type": "reasoning", "summary": [{"type": "summary_text", "text": "plan"}], "encrypted_content": "blob"},
@@ -34,6 +35,7 @@ var _ = Describe("Responses API request parsing", func() {
 		Expect(req.System).To(Equal("You are Codex."))
 		Expect(req.Stream).NotTo(BeNil())
 		Expect(*req.Stream).To(BeTrue())
+		Expect(req.Tools).To(HaveLen(1))
 		Expect(req.Extra).To(HaveKeyWithValue("endpoint", "responses"))
 
 		Expect(req.Messages).To(HaveLen(4))

--- a/pkg/storage/postgres/gensqlc/raw_turns.sql.go
+++ b/pkg/storage/postgres/gensqlc/raw_turns.sql.go
@@ -78,8 +78,8 @@ func (q *Queries) InsertRawTurn(ctx context.Context, arg InsertRawTurnParams) (i
 const listRawTurnHeadersBySession = `-- name: ListRawTurnHeadersBySession :many
 SELECT id, org_id, source, provider, agent_name, request_id,
        received_at, meta,
-       length(raw_request) AS request_bytes,
-       length(response) AS response_bytes
+       length(raw_request::text)::bigint AS request_bytes,
+       length(response::text)::bigint AS response_bytes
 FROM raw_turns
 WHERE org_id = $1 AND harness_id = $2 AND harness_session_id = $3
 ORDER BY id ASC
@@ -100,8 +100,8 @@ type ListRawTurnHeadersBySessionRow struct {
 	RequestID     string
 	ReceivedAt    pgtype.Timestamptz
 	Meta          []byte
-	RequestBytes  float64
-	ResponseBytes float64
+	RequestBytes  int64
+	ResponseBytes int64
 }
 
 // Operator wire log: identity + sizes, no payloads. The raw layer is

--- a/pkg/storage/postgres/queries/raw_turns.sql
+++ b/pkg/storage/postgres/queries/raw_turns.sql
@@ -45,8 +45,8 @@ SELECT COUNT(*) FROM raw_turns;
 -- the capture truth; this surfaces it without shipping the blobs.
 SELECT id, org_id, source, provider, agent_name, request_id,
        received_at, meta,
-       length(raw_request) AS request_bytes,
-       length(response) AS response_bytes
+       length(raw_request::text)::bigint AS request_bytes,
+       length(response::text)::bigint AS response_bytes
 FROM raw_turns
 WHERE org_id = $1 AND harness_id = $2 AND harness_session_id = $3
 ORDER BY id ASC;

--- a/pkg/storage/postgres/raw_turns_test.go
+++ b/pkg/storage/postgres/raw_turns_test.go
@@ -128,6 +128,19 @@ var _ = Describe("RawTurnStore", func() {
 		Expect(page2).To(HaveLen(1))
 		Expect(page2[0].RequestID).To(Equal("req-c"))
 	})
+
+	It("lists raw turn header sizes for JSONB payloads", func() {
+		rec := rawRecord("req-headers")
+		_, err := driver.PutRawTurn(ctx, rec)
+		Expect(err).NotTo(HaveOccurred())
+
+		headers, err := driver.ListRawTurnHeaders(ctx, "", rec.HarnessID, rec.HarnessSessionID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(headers).To(HaveLen(1))
+		Expect(headers[0].RequestID).To(Equal("req-headers"))
+		Expect(headers[0].RequestBytes).To(BeNumerically(">", 0))
+		Expect(headers[0].ResponseBytes).To(BeNumerically(">", 0))
+	})
 })
 
 var _ = Describe("node request params round-trip", func() {

--- a/pkg/storage/postgres/spans.go
+++ b/pkg/storage/postgres/spans.go
@@ -535,8 +535,8 @@ func (d *Driver) ListRawTurnHeaders(ctx context.Context, orgID, harnessID, harne
 			RequestID:     r.RequestID,
 			ReceivedAt:    r.ReceivedAt.Time,
 			Meta:          r.Meta,
-			RequestBytes:  int64(r.RequestBytes),
-			ResponseBytes: int64(r.ResponseBytes),
+			RequestBytes:  r.RequestBytes,
+			ResponseBytes: r.ResponseBytes,
 		})
 	}
 	return out, nil


### PR DESCRIPTION
## Summary
- preserve Responses API request tools so derived spans can render available tool context
- project Codex tool-role/function-call-output turns and label shell execution spans as Bash
- classify Codex compaction prompts and fix JSONB raw-turn header sizing

## Testing
- direnv exec . go test ./pkg/derive ./pkg/llm/provider/openai
- TEST_POSTGRES_DSN=... direnv exec . go test ./pkg/storage/postgres

related to PCC-690
related to PCC-681