### PR TITLE
feat: support Codex OAuth in tapes start part 2

### DIFF
--- a/cmd/tapes/start/start.go
+++ b/cmd/tapes/start/start.go
@@ -81,6 +81,7 @@ type startConfig struct {
 	DefaultUpstream     string
 	OllamaUpstream      string
 	OpenCodeProvider    string
+	CodexUpstream       string
 	Project             string
 	APIWebUI            bool
 }
@@ -239,6 +240,9 @@ func (c *startCommander) runAgent(ctx context.Context, agent string, passthrough
 		agentArgs = append(agentArgs, "--model", pref.Provider+"/"+pref.Model)
 		fmt.Fprintf(os.Stderr, "Note: tapes will capture telemetry for %s/%s. Switching models inside opencode will not be captured by tapes.\n", pref.Provider, pref.Model)
 	}
+	if agent == agentCodex {
+		agentArgs = append(agentArgs, codexProxyArgs(agentBaseURL)...)
+	}
 
 	agentArgs = append(agentArgs, passthroughArgs...)
 
@@ -321,6 +325,17 @@ func (c *startCommander) runAgent(ctx context.Context, agent string, passthrough
 	}
 
 	return nil
+}
+
+func codexProxyArgs(agentBaseURL string) []string {
+	return []string{
+		"-c", `model_provider="tapes"`,
+		"-c", `model_providers.tapes.name="Tapes Codex Proxy"`,
+		"-c", fmt.Sprintf("model_providers.tapes.base_url=%q", agentBaseURL),
+		"-c", `model_providers.tapes.wire_api="responses"`,
+		"-c", "model_providers.tapes.requires_openai_auth=true",
+		"-c", "model_providers.tapes.supports_websockets=false",
+	}
 }
 
 func (c *startCommander) runForeground(ctx context.Context) error {
@@ -427,6 +442,7 @@ func (c *startCommander) runServices(ctx context.Context, manager *start.Manager
 	}
 
 	openCodeRoute := resolveOpenCodeAgentRoute(startCfg)
+	codexRoute := resolveCodexAgentRoute(startCfg)
 
 	proxyConfig := proxy.Config{
 		ListenAddr:   proxyListener.Addr().String(),
@@ -436,7 +452,7 @@ func (c *startCommander) runServices(ctx context.Context, manager *start.Manager
 		AgentRoutes: map[string]proxy.AgentRoute{
 			agentClaude:   {ProviderType: "anthropic", UpstreamURL: "https://api.anthropic.com"},
 			agentOpenCode: openCodeRoute,
-			agentCodex:    {ProviderType: "openai", UpstreamURL: "https://api.openai.com/v1"},
+			agentCodex:    codexRoute,
 		},
 		ProviderUpstreams: map[string]string{
 			"anthropic": "https://api.anthropic.com",
@@ -743,6 +759,10 @@ func (c *startCommander) loadConfig() (*startConfig, error) {
 	if err != nil {
 		return nil, fmt.Errorf("loading embedding credentials: %w", err)
 	}
+	codexUpstream, err := c.resolveCodexUpstream()
+	if err != nil {
+		return nil, err
+	}
 
 	return &startConfig{
 		PostgresDSN:         v.GetString("storage.postgres_dsn"),
@@ -756,29 +776,46 @@ func (c *startCommander) loadConfig() (*startConfig, error) {
 		DefaultUpstream:     upstream,
 		OllamaUpstream:      resolveOllamaUpstream(provider, upstream),
 		OpenCodeProvider:    v.GetString("opencode.provider"),
+		CodexUpstream:       codexUpstream,
 		Project:             v.GetString("proxy.project"),
 		APIWebUI:            v.GetBool("api.web_ui"),
 	}, nil
 }
 
+func (c *startCommander) resolveCodexUpstream() (string, error) {
+	mgr, err := credentials.NewManager(c.configDir)
+	if err != nil {
+		return "", fmt.Errorf("loading tapes credentials: %w", err)
+	}
+	apiKey, err := mgr.GetKey("openai")
+	if err != nil {
+		return "", fmt.Errorf("loading openai credentials: %w", err)
+	}
+	if apiKey != "" {
+		return "https://api.openai.com/v1", nil
+	}
+	return "https://chatgpt.com/backend-api/codex", nil
+}
+
 // configureCodexAuth temporarily writes the stored OpenAI API key into codex's
 // ~/.codex/auth.json so that codex uses it instead of its OAuth token when
-// routing through the tapes proxy. The returned cleanup function restores the
+// routing through the tapes proxy. When no key is stored, Codex's existing
+// OAuth login is left intact. The returned cleanup function restores the
 // original auth.json contents.
 func (c *startCommander) configureCodexAuth() (func() error, error) {
 	noop := func() error { return nil }
 
 	mgr, err := credentials.NewManager(c.configDir)
 	if err != nil {
-		return noop, errors.New("run 'tapes auth openai' with a service account key (sk-svcacct-...) before starting codex")
+		return noop, fmt.Errorf("loading tapes credentials: %w", err)
 	}
 
 	apiKey, err := mgr.GetKey("openai")
 	if err != nil {
-		return noop, errors.New("run 'tapes auth openai' with a service account key (sk-svcacct-...) before starting codex")
+		return noop, fmt.Errorf("loading openai credentials: %w", err)
 	}
 	if apiKey == "" {
-		return noop, errors.New("no OpenAI API key found — run 'tapes auth openai' with a service account key first")
+		return noop, nil
 	}
 
 	original, authPath := credentials.ReadCodexAuthFile()
@@ -1180,6 +1217,14 @@ func resolveOpenCodeAgentRoute(cfg *startConfig) proxy.AgentRoute {
 	}
 
 	return proxy.AgentRoute{ProviderType: provider, UpstreamURL: upstream}
+}
+
+func resolveCodexAgentRoute(cfg *startConfig) proxy.AgentRoute {
+	upstream := strings.TrimSpace(cfg.CodexUpstream)
+	if upstream == "" {
+		upstream = "https://chatgpt.com/backend-api/codex"
+	}
+	return proxy.AgentRoute{ProviderType: "openai", UpstreamURL: upstream}
 }
 
 func resolveOllamaUpstream(provider, upstream string) string {

--- a/cmd/tapes/start/start.go
+++ b/cmd/tapes/start/start.go
@@ -54,6 +54,9 @@ Examples:
 	agentClaude   = "claude"
 	agentOpenCode = "opencode"
 	agentCodex    = "codex"
+
+	codexAuthModeAPIKey = "api-key"
+	codexAuthModeOAuth  = "oauth"
 )
 
 type startCommander struct {
@@ -65,6 +68,8 @@ type startCommander struct {
 	model         string
 	project       string
 	postgresDSN   string
+	codexAuthMode string
+	codexAPIKey   string
 	daemonTimeout time.Duration   // timeout for waitForDaemon; 0 means 30s default
 	daemonDone    <-chan struct{} // closed when daemon child process exits; nil if not tracking
 }
@@ -122,6 +127,10 @@ func NewStartCmd() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("could not get daemon flag: %w", err)
 			}
+			cmder.codexAuthMode, err = cmd.Flags().GetString("codex-auth-mode")
+			if err != nil {
+				return fmt.Errorf("could not get codex-auth-mode flag: %w", err)
+			}
 
 			agent, passthroughArgs := parseStartArgs(args, cmd.ArgsLenAtDash())
 
@@ -143,6 +152,8 @@ func NewStartCmd() *cobra.Command {
 	cmd.Flags().Bool("logs", false, "Stream logs from the running tapes start daemon")
 	cmd.Flags().Bool("daemon", false, "Run start daemon (internal)")
 	_ = cmd.Flags().MarkHidden("daemon")
+	cmd.Flags().String("codex-auth-mode", "", "Codex auth mode for daemon routing (internal)")
+	_ = cmd.Flags().MarkHidden("codex-auth-mode")
 	cmd.Flags().StringVar(&cmder.provider, "provider", "", "LLM provider for opencode (anthropic, openai, ollama)")
 	cmd.Flags().StringVar(&cmder.model, "model", "", "Model for opencode (e.g. claude-sonnet-4-5)")
 	cmd.Flags().StringVar(&cmder.project, "project", "", "Project name to tag sessions (default: auto-detect from git)")
@@ -216,6 +227,15 @@ func (c *startCommander) runAgent(ctx context.Context, agent string, passthrough
 		return fmt.Errorf("unsupported agent: %s", agent)
 	}
 
+	if agent == agentCodex {
+		apiKey, mode, err := c.resolveCodexAuth()
+		if err != nil {
+			return err
+		}
+		c.codexAPIKey = apiKey
+		c.codexAuthMode = mode
+	}
+
 	manager, err := start.NewManager(c.configDir)
 	if err != nil {
 		return err
@@ -263,7 +283,7 @@ func (c *startCommander) runAgent(ctx context.Context, agent string, passthrough
 			"OPENAI_BASE_URL="+agentBaseURL,
 			"OPENAI_API_BASE="+agentBaseURL,
 		)
-		codexCleanup, err := c.configureCodexAuth()
+		codexCleanup, err := c.configureCodexAuth(c.codexAPIKey)
 		if err != nil {
 			return err
 		}
@@ -613,6 +633,9 @@ func (c *startCommander) spawnDaemon(ctx context.Context, manager *start.Manager
 	if c.postgresDSN != "" {
 		args = append(args, "--postgres", c.postgresDSN)
 	}
+	if c.codexAuthMode != "" {
+		args = append(args, "--codex-auth-mode", c.codexAuthMode)
+	}
 
 	cmd := exec.CommandContext(ctx, execPath, args...)
 	cmd.Stdout = logFile
@@ -783,18 +806,40 @@ func (c *startCommander) loadConfig() (*startConfig, error) {
 }
 
 func (c *startCommander) resolveCodexUpstream() (string, error) {
+	if c.codexAuthMode != "" {
+		return codexUpstreamForAuthMode(c.codexAuthMode)
+	}
+	_, mode, err := c.resolveCodexAuth()
+	if err != nil {
+		return "", err
+	}
+	return codexUpstreamForAuthMode(mode)
+}
+
+func (c *startCommander) resolveCodexAuth() (string, string, error) {
 	mgr, err := credentials.NewManager(c.configDir)
 	if err != nil {
-		return "", fmt.Errorf("loading tapes credentials: %w", err)
+		return "", "", fmt.Errorf("loading tapes credentials: %w", err)
 	}
 	apiKey, err := mgr.GetKey("openai")
 	if err != nil {
-		return "", fmt.Errorf("loading openai credentials: %w", err)
+		return "", "", fmt.Errorf("loading openai credentials: %w", err)
 	}
 	if apiKey != "" {
-		return "https://api.openai.com/v1", nil
+		return apiKey, codexAuthModeAPIKey, nil
 	}
-	return "https://chatgpt.com/backend-api/codex", nil
+	return "", codexAuthModeOAuth, nil
+}
+
+func codexUpstreamForAuthMode(mode string) (string, error) {
+	switch mode {
+	case codexAuthModeAPIKey:
+		return "https://api.openai.com/v1", nil
+	case codexAuthModeOAuth:
+		return "https://chatgpt.com/backend-api/codex", nil
+	default:
+		return "", fmt.Errorf("unsupported codex auth mode %q", mode)
+	}
 }
 
 // configureCodexAuth temporarily writes the stored OpenAI API key into codex's
@@ -802,18 +847,9 @@ func (c *startCommander) resolveCodexUpstream() (string, error) {
 // routing through the tapes proxy. When no key is stored, Codex's existing
 // OAuth login is left intact. The returned cleanup function restores the
 // original auth.json contents.
-func (c *startCommander) configureCodexAuth() (func() error, error) {
+func (c *startCommander) configureCodexAuth(apiKey string) (func() error, error) {
 	noop := func() error { return nil }
 
-	mgr, err := credentials.NewManager(c.configDir)
-	if err != nil {
-		return noop, fmt.Errorf("loading tapes credentials: %w", err)
-	}
-
-	apiKey, err := mgr.GetKey("openai")
-	if err != nil {
-		return noop, fmt.Errorf("loading openai credentials: %w", err)
-	}
 	if apiKey == "" {
 		return noop, nil
 	}

--- a/cmd/tapes/start/start_test.go
+++ b/cmd/tapes/start/start_test.go
@@ -220,7 +220,7 @@ var _ = Describe("configureCodexAuth", func() {
 		Expect(os.WriteFile(authPath, original, 0o600)).To(Succeed())
 
 		cmder := &startCommander{configDir: configDir}
-		cleanup, err := cmder.configureCodexAuth()
+		cleanup, err := cmder.configureCodexAuth("")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(cleanup()).To(Succeed())
 
@@ -238,7 +238,12 @@ var _ = Describe("configureCodexAuth", func() {
 		Expect(mgr.SetKey("openai", "sk-svcacct-test")).To(Succeed())
 
 		cmder := &startCommander{configDir: configDir}
-		cleanup, err := cmder.configureCodexAuth()
+		apiKey, mode, err := cmder.resolveCodexAuth()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(apiKey).To(Equal("sk-svcacct-test"))
+		Expect(mode).To(Equal(codexAuthModeAPIKey))
+
+		cleanup, err := cmder.configureCodexAuth(apiKey)
 		Expect(err).NotTo(HaveOccurred())
 
 		data, err := os.ReadFile(authPath)
@@ -373,6 +378,17 @@ var _ = Describe("resolveCodexUpstream", func() {
 		upstream, err := cmder.resolveCodexUpstream()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(upstream).To(Equal("https://api.openai.com/v1"))
+	})
+
+	It("uses the already-resolved daemon auth mode without rereading credentials", func() {
+		mgr, err := credentials.NewManager(tmpDir)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(mgr.SetKey("openai", "sk-svcacct-test")).To(Succeed())
+
+		cmder := &startCommander{configDir: tmpDir, codexAuthMode: codexAuthModeOAuth}
+		upstream, err := cmder.resolveCodexUpstream()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(upstream).To(Equal("https://chatgpt.com/backend-api/codex"))
 	})
 })
 

--- a/cmd/tapes/start/start_test.go
+++ b/cmd/tapes/start/start_test.go
@@ -3,6 +3,7 @@ package startcmder
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -186,6 +187,74 @@ var _ = Describe("injectCredentials", func() {
 	})
 })
 
+var _ = Describe("configureCodexAuth", func() {
+	var (
+		configDir string
+		homeDir   string
+		authPath  string
+		oldHome   string
+	)
+
+	BeforeEach(func() {
+		var err error
+		configDir, err = os.MkdirTemp("", "tapes-codex-auth-config-*")
+		Expect(err).NotTo(HaveOccurred())
+		homeDir, err = os.MkdirTemp("", "tapes-codex-auth-home-*")
+		Expect(err).NotTo(HaveOccurred())
+
+		oldHome = os.Getenv("HOME")
+		Expect(os.Setenv("HOME", homeDir)).To(Succeed())
+
+		authPath = filepath.Join(homeDir, ".codex", "auth.json")
+		Expect(os.MkdirAll(filepath.Dir(authPath), 0o755)).To(Succeed())
+	})
+
+	AfterEach(func() {
+		Expect(os.Setenv("HOME", oldHome)).To(Succeed())
+		Expect(os.RemoveAll(configDir)).To(Succeed())
+		Expect(os.RemoveAll(homeDir)).To(Succeed())
+	})
+
+	It("leaves Codex OAuth credentials untouched when no OpenAI API key is stored", func() {
+		original := []byte(`{"tokens":{"access_token":"chatgpt-token"},"last_refresh":123}`)
+		Expect(os.WriteFile(authPath, original, 0o600)).To(Succeed())
+
+		cmder := &startCommander{configDir: configDir}
+		cleanup, err := cmder.configureCodexAuth()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cleanup()).To(Succeed())
+
+		data, err := os.ReadFile(authPath)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(data).To(MatchJSON(original))
+	})
+
+	It("patches Codex auth with a stored API key and restores the original file", func() {
+		original := []byte(`{"tokens":{"access_token":"chatgpt-token"},"last_refresh":123}`)
+		Expect(os.WriteFile(authPath, original, 0o600)).To(Succeed())
+
+		mgr, err := credentials.NewManager(configDir)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(mgr.SetKey("openai", "sk-svcacct-test")).To(Succeed())
+
+		cmder := &startCommander{configDir: configDir}
+		cleanup, err := cmder.configureCodexAuth()
+		Expect(err).NotTo(HaveOccurred())
+
+		data, err := os.ReadFile(authPath)
+		Expect(err).NotTo(HaveOccurred())
+		var patched map[string]json.RawMessage
+		Expect(json.Unmarshal(data, &patched)).To(Succeed())
+		Expect(patched).To(HaveKey("OPENAI_API_KEY"))
+		Expect(patched).NotTo(HaveKey("tokens"))
+
+		Expect(cleanup()).To(Succeed())
+		restored, err := os.ReadFile(authPath)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(restored).To(MatchJSON(original))
+	})
+})
+
 var _ = Describe("loadConfig project resolution", func() {
 	var tmpDir string
 
@@ -259,6 +328,60 @@ var _ = Describe("parseStartArgs", func() {
 			[]string{"  Claude  ", "--dangerously-skip-permissions"}, 1,
 			"claude", []string{"--dangerously-skip-permissions"}),
 	)
+})
+
+var _ = Describe("codexProxyArgs", func() {
+	It("points a Codex Responses provider at the agent proxy", func() {
+		args := codexProxyArgs("http://127.0.0.1:34015/agents/codex")
+		Expect(args).To(Equal([]string{
+			"-c", `model_provider="tapes"`,
+			"-c", `model_providers.tapes.name="Tapes Codex Proxy"`,
+			"-c", `model_providers.tapes.base_url="http://127.0.0.1:34015/agents/codex"`,
+			"-c", `model_providers.tapes.wire_api="responses"`,
+			"-c", "model_providers.tapes.requires_openai_auth=true",
+			"-c", "model_providers.tapes.supports_websockets=false",
+		}))
+	})
+})
+
+var _ = Describe("resolveCodexUpstream", func() {
+	var tmpDir string
+
+	BeforeEach(func() {
+		var err error
+		tmpDir, err = os.MkdirTemp("", "tapes-codex-upstream-*")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		Expect(os.RemoveAll(tmpDir)).To(Succeed())
+	})
+
+	It("uses the ChatGPT Codex backend when no OpenAI API key is stored", func() {
+		cmder := &startCommander{configDir: tmpDir}
+		upstream, err := cmder.resolveCodexUpstream()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(upstream).To(Equal("https://chatgpt.com/backend-api/codex"))
+	})
+
+	It("uses the OpenAI API when a Tapes OpenAI API key is stored", func() {
+		mgr, err := credentials.NewManager(tmpDir)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(mgr.SetKey("openai", "sk-svcacct-test")).To(Succeed())
+
+		cmder := &startCommander{configDir: tmpDir}
+		upstream, err := cmder.resolveCodexUpstream()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(upstream).To(Equal("https://api.openai.com/v1"))
+	})
+})
+
+var _ = Describe("resolveCodexAgentRoute", func() {
+	It("returns an OpenAI route to the configured Codex upstream", func() {
+		route := resolveCodexAgentRoute(&startConfig{CodexUpstream: "https://example.test/codex"})
+		Expect(route.ProviderType).To(Equal("openai"))
+		Expect(route.UpstreamURL).To(Equal("https://example.test/codex"))
+	})
 })
 
 var _ = Describe("waitForDaemon", func() {

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -254,7 +254,7 @@ func (p *Proxy) handleNonStreamingProxy(c *fiber.Ctx, path, method, upstreamURL 
 
 	// If this was a chat request, enqueue for async storage
 	if parsedReq != nil && httpResp.StatusCode == http.StatusOK {
-		parsedResp, err := prov.ParseResponse(respBody)
+		parsedResp, err := p.parseNonStreamingResponse(respBody, httpResp.Header.Get("Content-Type"), parsedReq, prov)
 		if err != nil {
 			p.logger.Warn("failed to parse response",
 				"error", err,
@@ -350,6 +350,8 @@ func (p *Proxy) handleHTTPRespToPipeWriter(httpResp *http.Response, pw *io.PipeW
 	defer pw.Close()
 
 	switch ct := httpResp.Header.Get("Content-Type"); {
+	case isOpenAIResponsesEndpoint(parsedReq):
+		p.handleSSEStream(httpResp, pw, parsedReq, prov, agentName, startTime)
 	case strings.HasPrefix(ct, "text/event-stream"):
 		p.handleSSEStream(httpResp, pw, parsedReq, prov, agentName, startTime)
 	default:
@@ -365,11 +367,37 @@ func (p *Proxy) handleHTTPRespToPipeWriter(httpResp *http.Response, pw *io.PipeW
 // reduction; everything else falls back to the in-proxy extraction helpers
 // until it migrates into the shared library.
 func (p *Proxy) handleSSEStream(httpResp *http.Response, pw *io.PipeWriter, parsedReq *llm.ChatRequest, prov provider.Provider, agentName string, startTime time.Time) {
+	if r := responseReducerForRequest(parsedReq, prov); r != nil {
+		p.handleSSEStreamViaCapture(r, httpResp, pw, parsedReq, prov, agentName, startTime)
+		return
+	}
 	if r, ok := p.reducers[prov.Name()]; ok {
 		p.handleSSEStreamViaCapture(r, httpResp, pw, parsedReq, prov, agentName, startTime)
 		return
 	}
 	p.handleSSEStreamLegacy(httpResp, pw, parsedReq, prov, agentName, startTime)
+}
+
+func (p *Proxy) parseNonStreamingResponse(respBody []byte, contentType string, parsedReq *llm.ChatRequest, prov provider.Provider) (*llm.ChatResponse, error) {
+	if r := responseReducerForRequest(parsedReq, prov); r != nil {
+		return r.Reduce(context.Background(), nil, bytes.NewReader(respBody), contentType)
+	}
+	return prov.ParseResponse(respBody)
+}
+
+func responseReducerForRequest(parsedReq *llm.ChatRequest, prov provider.Provider) capture.Reducer {
+	if prov == nil || prov.Name() != providerOpenAI || !isOpenAIResponsesEndpoint(parsedReq) {
+		return nil
+	}
+	return capture.NewOpenAIResponsesReducer()
+}
+
+func isOpenAIResponsesEndpoint(parsedReq *llm.ChatRequest) bool {
+	if parsedReq == nil || parsedReq.Extra == nil {
+		return false
+	}
+	endpoint, _ := parsedReq.Extra["endpoint"].(string)
+	return endpoint == "responses"
 }
 
 // handleSSEStreamViaCapture forwards chunks to the client while teeing the

--- a/proxy/proxy_sse_test.go
+++ b/proxy/proxy_sse_test.go
@@ -168,6 +168,60 @@ var _ = Describe("SSE Streaming Proxy", func() {
 		})
 	})
 
+	Context("when upstream returns an OpenAI Responses SSE stream", func() {
+		BeforeEach(func() {
+			upstream = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				Expect(r.URL.Path).To(Equal("/v1/responses"))
+				flusher, ok := w.(http.Flusher)
+				Expect(ok).To(BeTrue())
+
+				events := []string{
+					"event: response.created\n" +
+						"data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_test\",\"object\":\"response\",\"created_at\":1781218506,\"status\":\"in_progress\",\"model\":\"gpt-5.5\",\"output\":[]}}\n\n",
+					"event: response.output_item.done\n" +
+						"data: {\"type\":\"response.output_item.done\",\"item\":{\"id\":\"msg_test\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"text\":\"TAPES_CODEX_RESPONSES_OK\"}],\"role\":\"assistant\"},\"output_index\":0}\n\n",
+					"event: response.completed\n" +
+						"data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_test\",\"object\":\"response\",\"created_at\":1781218506,\"status\":\"completed\",\"model\":\"gpt-5.5\",\"output\":[],\"usage\":{\"input_tokens\":3,\"output_tokens\":5,\"total_tokens\":8}}}\n\n",
+				}
+
+				for _, event := range events {
+					fmt.Fprint(w, event)
+					flusher.Flush()
+				}
+			}))
+			p, driver = newOpenAITestProxy(upstream.URL)
+		})
+
+		It("tees the raw Responses stream and stores the reduced turn", func() {
+			reqBody := []byte(`{"model":"gpt-5.5","stream":true,"input":[{"role":"user","content":[{"type":"input_text","text":"smoke"}]}]}`)
+
+			resp, err := p.server.Test(httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(string(reqBody))), -1)
+			Expect(err).NotTo(HaveOccurred())
+			defer resp.Body.Close()
+
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+			body, err := io.ReadAll(resp.Body)
+			Expect(err).NotTo(HaveOccurred())
+			bodyStr := string(body)
+			Expect(bodyStr).To(ContainSubstring("event: response.completed"))
+			Expect(bodyStr).To(ContainSubstring("TAPES_CODEX_RESPONSES_OK"))
+
+			p.Close()
+			p = nil
+
+			ctx := GinkgoT().Context()
+			nodes, err := driver.List(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(nodes).To(HaveLen(2))
+
+			leaves, err := driver.Leaves(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(leaves).To(HaveLen(1))
+			Expect(leaves[0].Bucket.Role).To(Equal("assistant"))
+			Expect(leaves[0].Bucket.ExtractText()).To(Equal("TAPES_CODEX_RESPONSES_OK"))
+		})
+	})
+
 	Context("when upstream returns an Anthropic-style SSE response with event types", func() {
 		BeforeEach(func() {
 			upstream = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
 ## Summary

 I’m not sure if this is already handled internally, but this adds a working path for `tapes start codex` to use the normal
  `codex login` OAuth flow while preserving the existing API-key path.


  - If a Tapes OpenAI API key is configured, the existing API-key behavior is preserved.
  - If no Tapes OpenAI API key is configured, Codex's OAuth auth is left untouched and traffic is routed to `chatgpt.com/
  backend-api/codex`.
  - Codex is launched with a temporary Tapes Responses provider and WebSockets disabled, so turns go through the local proxy over HTTPS.
  - OpenAI Responses-shaped proxy traffic now uses the existing Responses reducer instead of the legacy Chat Completions SSE
  path.

  ## Testing

  - `GOEXPERIMENT=jsonv2 go test ./cmd/tapes/start`
  - `GOEXPERIMENT=jsonv2 go test ./proxy`
  - `make build-local`
  - Manual: captured a real Codex OAuth turn and confirmed it appeared in `tapes deck`.
