### PR TITLE
✨ feat: chunk oversized span embeddings instead of dropping them

### DIFF
--- a/cmd/tapes/serve/embedworker/embedworker.go
+++ b/cmd/tapes/serve/embedworker/embedworker.go
@@ -34,6 +34,7 @@ type embedWorkerCommander struct {
 	metricsListen string
 	waitForDB     bool
 	batchSize     int
+	maxTextBytes  int
 	orgID         string
 
 	embeddingProvider   string
@@ -52,6 +53,7 @@ var embedWorkerFlags = config.FlagSet{
 	config.FlagEmbedWorkerMetricsListen: {Name: "metrics-listen", ViperKey: "embed_worker.metrics_listen", Description: "Address to serve /metrics, /healthz (liveness), /readyz (readiness), and /ping on (empty disables)"},
 	config.FlagEmbedWorkerWaitForDB:     {Name: "wait-for-db", ViperKey: "embed_worker.wait_for_db", Description: "Retry an unreachable Postgres at startup with backoff instead of exiting (for orchestrated environments; default: fail fast)"},
 	config.FlagEmbedWorkerBatchSize:     {Name: "batch-size", ViperKey: "embed_worker.batch_size", Description: "Candidate page size; bounds peak memory per pass (0 uses the built-in default)"},
+	config.FlagEmbedWorkerMaxTextBytes:  {Name: "max-text-bytes", ViperKey: "embed_worker.max_text_bytes", Description: "Cap on a span's rendered text; larger spans are recorded as too_large instead of chunked, bounding per-span memory and embed cost (0 uses the built-in default, negative disables)"},
 	config.FlagEmbedWorkerOrg:           {Name: "org", ViperKey: "embed_worker.org", Description: "Only embed spans belonging to this org UUID (default: all orgs)"},
 	config.FlagEmbeddingProv:            {Name: "embedding-provider", ViperKey: "embedding.provider", Description: "Embedding provider type (e.g., ollama, openai)"},
 	config.FlagEmbeddingTgt:             {Name: "embedding-target", ViperKey: "embedding.target", Description: "Embedding provider URL"},
@@ -93,7 +95,10 @@ orchestrators. SIGTERM/SIGINT drains the in-flight pass (bounded at 30s)
 before exiting; a second signal kills immediately.
 
 --batch-size bounds how many candidate spans are held in memory at once;
-lower it to cap the worker's peak memory, raise it to cut round trips.`
+lower it to cap the worker's peak memory, raise it to cut round trips.
+--max-text-bytes caps a single span's rendered text: a larger span is recorded
+as a too_large failure instead of being chunked, bounding the per-span memory,
+embed cost, and chunk count that batch size alone cannot.`
 
 const embedWorkerShortDesc string = "Run the Tapes embed worker"
 
@@ -120,6 +125,7 @@ func NewEmbedWorkerCmd() *cobra.Command {
 				config.FlagEmbedWorkerMetricsListen,
 				config.FlagEmbedWorkerWaitForDB,
 				config.FlagEmbedWorkerBatchSize,
+				config.FlagEmbedWorkerMaxTextBytes,
 				config.FlagEmbedWorkerOrg,
 				config.FlagEmbeddingProv,
 				config.FlagEmbeddingTgt,
@@ -132,6 +138,7 @@ func NewEmbedWorkerCmd() *cobra.Command {
 			cmder.metricsListen = v.GetString("embed_worker.metrics_listen")
 			cmder.waitForDB = v.GetBool("embed_worker.wait_for_db")
 			cmder.batchSize = v.GetInt("embed_worker.batch_size")
+			cmder.maxTextBytes = v.GetInt("embed_worker.max_text_bytes")
 			cmder.orgID = v.GetString("embed_worker.org")
 
 			embedding := config.ResolveEmbeddingConfigWithOptions(
@@ -175,6 +182,7 @@ func NewEmbedWorkerCmd() *cobra.Command {
 	config.AddStringFlag(cmd, cmder.flags, config.FlagEmbeddingModel, &cmder.embeddingModel)
 	config.AddUintFlag(cmd, cmder.flags, config.FlagEmbeddingDims, &cmder.embeddingDimensions)
 	config.AddIntFlag(cmd, cmder.flags, config.FlagEmbedWorkerBatchSize, &cmder.batchSize)
+	config.AddIntFlag(cmd, cmder.flags, config.FlagEmbedWorkerMaxTextBytes, &cmder.maxTextBytes)
 	config.AddStringFlag(cmd, cmder.flags, config.FlagEmbedWorkerOrg, &cmder.orgID)
 
 	return cmd
@@ -311,9 +319,10 @@ func (c *embedWorkerCommander) buildPass(ctx context.Context, driver *postgres.D
 	}
 
 	pass, err := spanembed.NewPass(store, store, embedder, spanembed.PassConfig{
-		Model:      c.embeddingModel,
-		Dimensions: c.embeddingDimensions,
-		BatchSize:  c.batchSize,
+		Model:        c.embeddingModel,
+		Dimensions:   c.embeddingDimensions,
+		BatchSize:    c.batchSize,
+		MaxTextBytes: c.maxTextBytes,
 	}, c.logger)
 	if err != nil {
 		_ = embedder.Close()
@@ -326,6 +335,7 @@ func (c *embedWorkerCommander) buildPass(ctx context.Context, driver *postgres.D
 		"embedding_model", c.embeddingModel,
 		"embedding_dimensions", c.embeddingDimensions,
 		"batch_size", c.batchSize,
+		"max_text_bytes", c.maxTextBytes,
 	)
 	return pass, func() { _ = embedder.Close() }, nil
 }

--- a/pkg/config/flags.go
+++ b/pkg/config/flags.go
@@ -78,6 +78,7 @@ const (
 	FlagEmbedWorkerMetricsListen = "embed-worker-metrics-listen"
 	FlagEmbedWorkerWaitForDB     = "embed-worker-wait-for-db"
 	FlagEmbedWorkerBatchSize     = "embed-worker-batch-size"
+	FlagEmbedWorkerMaxTextBytes  = "embed-worker-max-text-bytes"
 	FlagEmbedWorkerOrg           = "embed-worker-org"
 )
 

--- a/pkg/embeddings/error.go
+++ b/pkg/embeddings/error.go
@@ -1,0 +1,95 @@
+package embeddings
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"regexp"
+	"strconv"
+
+	"github.com/papercomputeco/tapes/pkg/vector"
+)
+
+// APIError is a structured error from an embedding provider's HTTP API. It
+// lets the embed pass tell three failure modes apart:
+//
+//   - oversize input (IsOversize) — the model rejected the text for exceeding
+//     its context window; the caller should chunk the input and embed the
+//     pieces rather than retry the whole thing.
+//   - transient fault (Retryable) — a rate limit, server error, or transport
+//     failure; the same input may succeed on a later pass.
+//   - any other deterministic rejection — neither of the above; retrying the
+//     same input is pointless, so the caller records it and stops.
+//
+// It unwraps to vector.ErrEmbedding so existing errors.Is(err,
+// vector.ErrEmbedding) checks keep working.
+type APIError struct {
+	// Status is the HTTP status code, or 0 for a transport-level failure
+	// (connection refused, timeout) where no response was received.
+	Status int
+	// Code is the provider's machine error code when present (e.g.
+	// "context_length_exceeded"); empty when the provider omits it.
+	Code string
+	// Message is the provider's human-readable error message, or the
+	// transport error string when Status is 0.
+	Message string
+	// RequestedTokens is the token count the provider reported for the
+	// rejected input, parsed from Message; 0 when not reported.
+	RequestedTokens int
+	// Transient marks a transport-level failure (Status 0) as retryable.
+	Transient bool
+}
+
+func (e *APIError) Error() string {
+	if e.Status == 0 {
+		return fmt.Sprintf("%v: embedding api request failed: %s", vector.ErrEmbedding, e.Message)
+	}
+	return fmt.Sprintf("%v: embedding api returned status %d: %s", vector.ErrEmbedding, e.Status, e.Message)
+}
+
+// Unwrap reports vector.ErrEmbedding so callers can keep matching on the
+// package's sentinel.
+func (e *APIError) Unwrap() error { return vector.ErrEmbedding }
+
+var maxContextRe = regexp.MustCompile(`(?i)maximum context length`)
+
+// IsOversize reports whether the input was rejected for exceeding the model's
+// context window — the signal to chunk the input and embed the pieces.
+func (e *APIError) IsOversize() bool {
+	if e.Status != http.StatusBadRequest {
+		return false
+	}
+	return e.Code == "context_length_exceeded" || maxContextRe.MatchString(e.Message)
+}
+
+// Retryable reports whether the failure is transient (rate limit, server
+// error, or transport failure) and the same input may succeed on a later pass.
+func (e *APIError) Retryable() bool {
+	return e.Transient || e.Status == http.StatusTooManyRequests || e.Status >= http.StatusInternalServerError
+}
+
+// AsAPIError extracts an *APIError from err, if one is present in the chain.
+func AsAPIError(err error) (*APIError, bool) {
+	var apiErr *APIError
+	if errors.As(err, &apiErr) {
+		return apiErr, true
+	}
+	return nil, false
+}
+
+var requestedTokensRe = regexp.MustCompile(`requested (\d+) tokens`)
+
+// ParseRequestedTokens extracts the token count a provider reports in an
+// oversize message (e.g. "...however you requested 9523 tokens..."), returning
+// 0 when no count is present.
+func ParseRequestedTokens(message string) int {
+	m := requestedTokensRe.FindStringSubmatch(message)
+	if len(m) < 2 {
+		return 0
+	}
+	n, err := strconv.Atoi(m[1])
+	if err != nil {
+		return 0
+	}
+	return n
+}

--- a/pkg/embeddings/error_test.go
+++ b/pkg/embeddings/error_test.go
@@ -1,0 +1,90 @@
+package embeddings_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/papercomputeco/tapes/pkg/embeddings"
+	"github.com/papercomputeco/tapes/pkg/vector"
+)
+
+func TestEmbeddings(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Embeddings Suite")
+}
+
+var _ = Describe("APIError", func() {
+	Describe("IsOversize", func() {
+		It("is true for a 400 with a maximum-context-length message", func() {
+			e := &embeddings.APIError{
+				Status:  400,
+				Message: "This model's maximum context length is 8192 tokens, however you requested 9523 tokens (9523 in your prompt). Please reduce the length.",
+			}
+			Expect(e.IsOversize()).To(BeTrue())
+		})
+
+		It("is true for a 400 carrying the context_length_exceeded code", func() {
+			e := &embeddings.APIError{Status: 400, Code: "context_length_exceeded", Message: "too long"}
+			Expect(e.IsOversize()).To(BeTrue())
+		})
+
+		It("is true for OpenAI's terse embeddings message (no code, no token count)", func() {
+			// The real text-embedding-3 oversize 400, captured live: no
+			// machine code and no "requested N tokens" phrasing.
+			e := &embeddings.APIError{Status: 400, Message: "Invalid 'input': maximum context length is 8192 tokens."}
+			Expect(e.IsOversize()).To(BeTrue())
+			Expect(e.RequestedTokens).To(BeZero())
+		})
+
+		It("is false for a generic 400 (e.g. malformed request)", func() {
+			e := &embeddings.APIError{Status: 400, Message: "Invalid value for 'dimensions'."}
+			Expect(e.IsOversize()).To(BeFalse())
+		})
+
+		It("is false for an oversize-looking message on a non-400 status", func() {
+			e := &embeddings.APIError{Status: 500, Message: "maximum context length is 8192 tokens"}
+			Expect(e.IsOversize()).To(BeFalse())
+		})
+	})
+
+	Describe("Retryable", func() {
+		It("is true for 429 and 5xx", func() {
+			Expect((&embeddings.APIError{Status: 429}).Retryable()).To(BeTrue())
+			Expect((&embeddings.APIError{Status: 503}).Retryable()).To(BeTrue())
+		})
+
+		It("is true for a transport failure (status 0)", func() {
+			Expect((&embeddings.APIError{Status: 0, Transient: true, Message: "dial tcp: timeout"}).Retryable()).To(BeTrue())
+		})
+
+		It("is false for a deterministic 4xx", func() {
+			Expect((&embeddings.APIError{Status: 400, Message: "bad"}).Retryable()).To(BeFalse())
+			Expect((&embeddings.APIError{Status: 401, Message: "no key"}).Retryable()).To(BeFalse())
+		})
+	})
+
+	It("unwraps to vector.ErrEmbedding for back-compat", func() {
+		var err error = &embeddings.APIError{Status: 400, Message: "x"}
+		Expect(errors.Is(err, vector.ErrEmbedding)).To(BeTrue())
+	})
+
+	It("is recoverable through a wrapped error chain", func() {
+		wrapped := fmt.Errorf("embedding span: %w", &embeddings.APIError{Status: 400, Code: "context_length_exceeded"})
+		got, ok := embeddings.AsAPIError(wrapped)
+		Expect(ok).To(BeTrue())
+		Expect(got.IsOversize()).To(BeTrue())
+	})
+})
+
+var _ = DescribeTable("ParseRequestedTokens",
+	func(message string, want int) {
+		Expect(embeddings.ParseRequestedTokens(message)).To(Equal(want))
+	},
+	Entry("real oversize message", "This model's maximum context length is 8192 tokens, however you requested 9523 tokens (9523 in your prompt; 0 for the completion).", 9523),
+	Entry("no token count present", "Invalid request: missing input", 0),
+	Entry("empty message", "", 0),
+)

--- a/pkg/embeddings/openai/openai.go
+++ b/pkg/embeddings/openai/openai.go
@@ -128,13 +128,15 @@ func (e *Embedder) Embed(ctx context.Context, text string) ([]float32, error) {
 
 	resp, err := e.httpClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("%w: sending request: %w", vector.ErrEmbedding, err)
+		// No response was received (connection refused, timeout, DNS); a
+		// transport failure is transient, so surface it as retryable.
+		return nil, &embeddings.APIError{Message: err.Error(), Transient: true}
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodyBytes))
-		return nil, fmt.Errorf("%w: openai returned status %d: %s", vector.ErrEmbedding, resp.StatusCode, string(body))
+		return nil, newAPIError(resp.StatusCode, body)
 	}
 
 	var embedResp embedResponse
@@ -152,6 +154,33 @@ func (e *Embedder) Embed(ctx context.Context, text string) ([]float32, error) {
 // Close releases resources held by the embedder.
 func (e *Embedder) Close() error {
 	return nil
+}
+
+// newAPIError builds a structured *embeddings.APIError from a non-200
+// response. It parses OpenAI's error envelope ({"error":{message,type,code}})
+// for the machine code and message, falling back to the raw body when the
+// envelope is absent, and extracts the reported token count for oversize
+// rejections so the caller can size its chunks.
+func newAPIError(status int, body []byte) *embeddings.APIError {
+	var envelope struct {
+		Error struct {
+			Message string `json:"message"`
+			Type    string `json:"type"`
+			Code    string `json:"code"`
+		} `json:"error"`
+	}
+	message := strings.TrimSpace(string(body))
+	code := ""
+	if err := json.Unmarshal(body, &envelope); err == nil && envelope.Error.Message != "" {
+		message = envelope.Error.Message
+		code = envelope.Error.Code
+	}
+	return &embeddings.APIError{
+		Status:          status,
+		Code:            code,
+		Message:         message,
+		RequestedTokens: embeddings.ParseRequestedTokens(message),
+	}
 }
 
 func normalizeBaseURL(raw string) (string, error) {

--- a/pkg/embeddings/openai/openai_test.go
+++ b/pkg/embeddings/openai/openai_test.go
@@ -11,6 +11,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/papercomputeco/tapes/pkg/embeddings"
 )
 
 func TestOpenAI(t *testing.T) {
@@ -86,6 +88,48 @@ var _ = Describe("Embedder", func() {
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring(strings.Repeat("x", maxErrorBodyBytes)))
 		Expect(err.Error()).NotTo(ContainSubstring(strings.Repeat("x", maxErrorBodyBytes+1)))
+	})
+
+	It("returns a classifiable oversize error for a 400 context-length rejection", func(ctx SpecContext) {
+		embedder := &Embedder{
+			baseURL: "https://api.openai.test/v1",
+			model:   "text-embedding-3-large",
+			apiKey:  "sk-test",
+			httpClient: &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusBadRequest,
+					Body:       io.NopCloser(strings.NewReader(`{"error":{"message":"This model's maximum context length is 8192 tokens, however you requested 9523 tokens (9523 in your prompt; 0 for the completion). Please reduce the length.","type":"invalid_request_error","code":"context_length_exceeded"}}`)),
+					Header:     make(http.Header),
+				}, nil
+			})},
+		}
+
+		_, err := embedder.Embed(ctx, "a very long input")
+		Expect(err).To(HaveOccurred())
+
+		apiErr, ok := embeddings.AsAPIError(err)
+		Expect(ok).To(BeTrue())
+		Expect(apiErr.Status).To(Equal(http.StatusBadRequest))
+		Expect(apiErr.IsOversize()).To(BeTrue())
+		Expect(apiErr.Retryable()).To(BeFalse())
+		Expect(apiErr.RequestedTokens).To(Equal(9523))
+	})
+
+	It("classifies a transport failure as retryable", func(ctx SpecContext) {
+		embedder := &Embedder{
+			baseURL: "https://api.openai.test/v1",
+			model:   "text-embedding-3-large",
+			apiKey:  "sk-test",
+			httpClient: &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+				return nil, io.ErrUnexpectedEOF
+			})},
+		}
+
+		_, err := embedder.Embed(ctx, "hello")
+		Expect(err).To(HaveOccurred())
+		apiErr, ok := embeddings.AsAPIError(err)
+		Expect(ok).To(BeTrue())
+		Expect(apiErr.Retryable()).To(BeTrue())
 	})
 })
 

--- a/pkg/embedworker/metrics.go
+++ b/pkg/embedworker/metrics.go
@@ -29,19 +29,39 @@ type Metrics struct {
 	PassDuration prometheus.Histogram
 
 	// Per-span outcomes accumulated across passes. Together they close the
-	// identity scanned = embedded + upToDate + empty + failed, so a
-	// dashboard can both account for every candidate and SEE the
+	// identity scanned = embedded + upToDate + empty + poisoned + failed,
+	// so a dashboard can both account for every candidate and SEE the
 	// re-stream cost: the embed pass lists and renders every main llm
 	// span each pass, so a high upToDate (or scanned) with embedded≈0 is
 	// the wasteful-rescan signature, invisible if only embedded/failed
 	// were exposed. Failed is a per-span embed/write error retried next
 	// pass; UpToDate skipped because content+model already match; Empty
-	// skipped because the delta rendered to no embeddable text.
+	// skipped because the delta rendered to no embeddable text; Poisoned
+	// skipped because the span already failed deterministically under this
+	// content and model.
 	SpansScanned  prometheus.Counter
 	SpansEmbedded prometheus.Counter
 	SpansUpToDate prometheus.Counter
 	SpansEmpty    prometheus.Counter
+	SpansPoisoned prometheus.Counter
 	SpansFailed   prometheus.Counter
+
+	// SpansChunked counts spans whose text exceeded the model context
+	// window and was embedded as several pieces; ChunkRows counts the
+	// pieces written (so chunked spans contribute more than one row).
+	SpansChunked prometheus.Counter
+	ChunkRows    prometheus.Counter
+
+	// Oversize counts spans the model rejected as too large; OversizeTokens
+	// is the distribution of their reported/estimated token sizes — the
+	// answer to "how big are the inputs we're chunking?".
+	Oversize       prometheus.Counter
+	OversizeTokens prometheus.Histogram
+
+	// SpanFailures counts deterministic per-span failures by reason (e.g.
+	// oversize, api_400) — the recorded, non-retried failures, a subset of
+	// SpansFailed broken out for alerting on a specific cause.
+	SpanFailures *prometheus.CounterVec
 
 	// OrphansPruned counts embedding rows removed because their span no
 	// longer exists as a main llm span.
@@ -91,10 +111,38 @@ func NewMetrics() *Metrics {
 			Name: "tapes_embed_worker_spans_empty_total",
 			Help: "Spans skipped because their delta content rendered to no embeddable text.",
 		}),
+		SpansPoisoned: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "tapes_embed_worker_spans_poisoned_total",
+			Help: "Spans skipped because they already failed deterministically under this content and model; not retried until content/model changes.",
+		}),
 		SpansFailed: prometheus.NewCounter(prometheus.CounterOpts{
 			Name: "tapes_embed_worker_spans_failed_total",
-			Help: "Per-span embed/write failures; the span stays un-embedded and is retried on the next pass.",
+			Help: "Per-span embed/write failures this pass (transient retried next pass; deterministic also recorded and skipped thereafter).",
 		}),
+		SpansChunked: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "tapes_embed_worker_spans_chunked_total",
+			Help: "Spans whose text exceeded the model context window and was embedded as multiple pieces.",
+		}),
+		ChunkRows: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "tapes_embed_worker_chunk_rows_total",
+			Help: "Embedding rows written (one per piece); chunked spans contribute more than one.",
+		}),
+		Oversize: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "tapes_embed_worker_oversize_total",
+			Help: "Spans the model rejected as exceeding its context window (whether the split then succeeded or exhausted the depth cap).",
+		}),
+		OversizeTokens: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Name:    "tapes_embed_worker_oversize_tokens",
+			Help:    "Reported or estimated token count of oversized spans.",
+			Buckets: []float64{8192, 10000, 12000, 16000, 24000, 32000, 48000, 64000, 96000, 131072},
+		}),
+		SpanFailures: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "tapes_embed_worker_span_failures_total",
+				Help: "Deterministic per-span embed failures recorded this pass, by reason.",
+			},
+			[]string{"reason"},
+		),
 		OrphansPruned: prometheus.NewCounter(prometheus.CounterOpts{
 			Name: "tapes_embed_worker_orphans_pruned_total",
 			Help: "Orphaned embedding rows removed (their span was pruned or reclassified by a re-derive).",
@@ -110,7 +158,8 @@ func NewMetrics() *Metrics {
 	}
 	reg.MustRegister(
 		m.Passes, m.PassDuration,
-		m.SpansScanned, m.SpansEmbedded, m.SpansUpToDate, m.SpansEmpty, m.SpansFailed,
+		m.SpansScanned, m.SpansEmbedded, m.SpansUpToDate, m.SpansEmpty, m.SpansPoisoned, m.SpansFailed,
+		m.SpansChunked, m.ChunkRows, m.Oversize, m.OversizeTokens, m.SpanFailures,
 		m.OrphansPruned, m.ConsecutiveFailures, m.LastSuccessTimestamp,
 	)
 	return m

--- a/pkg/embedworker/worker.go
+++ b/pkg/embedworker/worker.go
@@ -208,8 +208,18 @@ func (w *Worker) passSucceeded(report *spanembed.Report, dur time.Duration) {
 		w.metrics.SpansEmbedded.Add(float64(report.Embedded))
 		w.metrics.SpansUpToDate.Add(float64(report.UpToDate))
 		w.metrics.SpansEmpty.Add(float64(report.Empty))
+		w.metrics.SpansPoisoned.Add(float64(report.Poisoned))
 		w.metrics.SpansFailed.Add(float64(report.Failed))
+		w.metrics.SpansChunked.Add(float64(report.Chunked))
+		w.metrics.ChunkRows.Add(float64(report.ChunkRows))
+		w.metrics.Oversize.Add(float64(report.Oversized))
 		w.metrics.OrphansPruned.Add(float64(report.Pruned))
+		for _, tokens := range report.OversizeTokens {
+			w.metrics.OversizeTokens.Observe(float64(tokens))
+		}
+		for reason, n := range report.FailuresByReason {
+			w.metrics.SpanFailures.WithLabelValues(reason).Add(float64(n))
+		}
 	}
 	if w.consecutiveFailures > 0 {
 		w.logger.Info("embed worker recovered",

--- a/pkg/spanembed/chunk.go
+++ b/pkg/spanembed/chunk.go
@@ -1,0 +1,108 @@
+package spanembed
+
+const (
+	// chunkTokenBudget is the per-piece token target used when splitting an
+	// oversized span. It sits under text-embedding-3's 8192-token hard limit so
+	// a proportional split — which is only approximate, since we divide by
+	// characters against a token count — lands safely under the limit in one
+	// pass most of the time, with recursion as the backstop when it doesn't.
+	chunkTokenBudget = 8000
+
+	// avgCharsPerToken approximates characters per token for the mixed
+	// prose/code tapes embeds. OpenAI's embeddings oversize error
+	// ("Invalid 'input': maximum context length is 8192 tokens.") reports no
+	// token count, so when a provider omits it we estimate from text length to
+	// size the split and the oversize metric. Recursive re-splitting backstops
+	// an underestimate.
+	avgCharsPerToken = 4
+)
+
+// estimateTokens approximates the token count of text from its length, for
+// providers whose oversize error omits the measured count.
+func estimateTokens(text string) int {
+	return (len([]rune(text)) + avgCharsPerToken - 1) / avgCharsPerToken
+}
+
+// splitParts divides text into pieces small enough to embed. reportedTokens is
+// the token count the provider measured for the whole text (0 when the provider
+// didn't report one, in which case it is estimated from length); it sizes the
+// split so a span of, say, 25k tokens is cut into four pieces rather than halved
+// repeatedly. The pieces concatenate back to the original text exactly. Returns
+// nil when the text is too short to split.
+func splitParts(text string, reportedTokens int) []string {
+	runes := []rune(text)
+	if len(runes) < 2 {
+		return nil
+	}
+	tokens := reportedTokens
+	if tokens <= 0 {
+		tokens = estimateTokens(text)
+	}
+	n := 2
+	if tokens > chunkTokenBudget {
+		n = (tokens + chunkTokenBudget - 1) / chunkTokenBudget
+	}
+	if n < 2 {
+		n = 2
+	}
+	if n > len(runes) {
+		n = len(runes)
+	}
+	return splitRunesInto(runes, n)
+}
+
+// splitRunesInto cuts runes into n contiguous pieces of roughly equal length,
+// nudging each cut to a nearby newline so a piece doesn't slice through the
+// middle of a line when a line break is close to the even-division point. The
+// concatenation of the returned pieces equals string(runes).
+func splitRunesInto(runes []rune, n int) []string {
+	total := len(runes)
+	parts := make([]string, 0, n)
+	window := (total / n) / 8
+	start := 0
+	for i := 1; i <= n && start < total; i++ {
+		end := total
+		if i < n {
+			end = adjustToNewline(runes, start+1, i*total/n, window)
+		}
+		if end <= start {
+			end = start + 1
+		}
+		if end > total {
+			end = total
+		}
+		parts = append(parts, string(runes[start:end]))
+		start = end
+	}
+	return parts
+}
+
+// adjustToNewline returns target moved to just after the nearest newline within
+// ±window (clamped to [lo, len(runes)]), or target unchanged when no newline is
+// close. Cutting after the newline keeps it as the tail of the current piece.
+func adjustToNewline(runes []rune, lo, target, window int) int {
+	if window < 1 {
+		return target
+	}
+	low := max(target-window, lo)
+	high := min(target+window, len(runes))
+	best := -1
+	bestDist := window + 1
+	for i := low; i < high; i++ {
+		if runes[i] != '\n' {
+			continue
+		}
+		dist := i - target
+		if dist < 0 {
+			dist = -dist
+		}
+		if dist < bestDist {
+			bestDist = dist
+			best = i
+		}
+	}
+	if best < 0 {
+		return target
+	}
+	return best + 1
+}

--- a/pkg/spanembed/chunk_internal_test.go
+++ b/pkg/spanembed/chunk_internal_test.go
@@ -1,0 +1,61 @@
+package spanembed
+
+import (
+	"strings"
+
+	ginkgo "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// Internal test: splitParts is unexported. Specs register into the suite run by
+// spanembed_suite_test.go, so this file deliberately does not call RunSpecs and
+// imports ginkgo qualified (a dot-import would clash with this package's Report
+// type).
+var _ = ginkgo.Describe("splitParts", func() {
+	ginkgo.It("returns nil for text too short to split", func() {
+		Expect(splitParts("", 0)).To(BeNil())
+		Expect(splitParts("a", 999999)).To(BeNil())
+	})
+
+	ginkgo.It("halves when the token count is unknown or near the budget", func() {
+		parts := splitParts(strings.Repeat("a", 100), 0)
+		Expect(parts).To(HaveLen(2))
+		Expect(strings.Join(parts, "")).To(Equal(strings.Repeat("a", 100)))
+	})
+
+	ginkgo.It("splits into ceil(tokens/budget) pieces when the count is large", func() {
+		// ~25k tokens against an 8k budget -> 4 pieces.
+		parts := splitParts(strings.Repeat("x", 4000), 25000)
+		Expect(parts).To(HaveLen(4))
+		Expect(strings.Join(parts, "")).To(Equal(strings.Repeat("x", 4000)))
+	})
+
+	ginkgo.It("estimates tokens from length when the provider reports none (real OpenAI case)", func() {
+		// 200k chars at ~4 chars/token -> ~50k tokens -> ceil(50000/8000) = 7
+		// pieces in one shot, instead of falling back to repeated halving.
+		text := strings.Repeat("x", 200000)
+		parts := splitParts(text, 0)
+		Expect(parts).To(HaveLen(7))
+		Expect(strings.Join(parts, "")).To(Equal(text))
+	})
+
+	ginkgo.It("always reassembles to the original text exactly", func() {
+		text := strings.Repeat("line of words\n", 500) + "tail"
+		for _, tokens := range []int{0, 9000, 17000, 40000} {
+			parts := splitParts(text, tokens)
+			Expect(strings.Join(parts, "")).To(Equal(text), "tokens=%d", tokens)
+			for _, p := range parts {
+				Expect(p).NotTo(BeEmpty())
+			}
+		}
+	})
+
+	ginkgo.It("prefers to cut on a newline when one is near the even-division point", func() {
+		// Two equal halves separated by a single newline near the midpoint.
+		text := strings.Repeat("a", 50) + "\n" + strings.Repeat("b", 50)
+		parts := splitParts(text, 0)
+		Expect(parts).To(HaveLen(2))
+		Expect(parts[0]).To(HaveSuffix("\n"))
+		Expect(parts[1]).To(Equal(strings.Repeat("b", 50)))
+	})
+})

--- a/pkg/spanembed/pass.go
+++ b/pkg/spanembed/pass.go
@@ -12,6 +12,19 @@ import (
 // DefaultBatchSize bounds one candidate page.
 const DefaultBatchSize = 100
 
+// DefaultMaxTextBytes caps a single span's rendered text. Chunking splits an
+// oversized span into ceil(tokens/budget) pieces, so an unbounded span would
+// fan out into hundreds of embed calls and rows and hold several copies of its
+// text in memory at once. Past this ceiling the span is recorded as a
+// deterministic "too_large" failure instead — bounding per-span memory, embed
+// cost, and chunk count regardless of batch size or pod limits. ~1 MiB is ~33
+// chunks at the model's per-chunk budget. 0 disables the guard.
+const DefaultMaxTextBytes = 1 << 20
+
+// reasonTooLarge labels the failure recorded for a span whose rendered text
+// exceeds PassConfig.MaxTextBytes.
+const reasonTooLarge = "too_large"
+
 // Source lists embed candidates. *Store implements it; tests
 // substitute a fake.
 type Source interface {
@@ -21,7 +34,8 @@ type Source interface {
 // Sink persists embeddings. *Store implements it; tests substitute a
 // fake.
 type Sink interface {
-	Upsert(ctx context.Context, rec Record) error
+	UpsertSpanChunks(ctx context.Context, rec ChunkRecord) error
+	RecordFailure(ctx context.Context, rec FailureRecord) error
 	PruneOrphans(ctx context.Context) (int64, error)
 }
 
@@ -40,6 +54,12 @@ type PassConfig struct {
 
 	// BatchSize bounds one candidate page (default DefaultBatchSize).
 	BatchSize int
+
+	// MaxTextBytes caps a span's rendered text; a larger span is recorded
+	// as a "too_large" failure rather than embedded, bounding per-span
+	// memory, chunk count, and embed cost. Zero takes DefaultMaxTextBytes;
+	// negative disables the guard.
+	MaxTextBytes int
 }
 
 // Pass walks every eligible span and embeds the ones whose embedding
@@ -72,6 +92,9 @@ func NewPass(src Source, sink Sink, embedder embeddings.Embedder, cfg PassConfig
 	if cfg.BatchSize <= 0 {
 		cfg.BatchSize = DefaultBatchSize
 	}
+	if cfg.MaxTextBytes == 0 {
+		cfg.MaxTextBytes = DefaultMaxTextBytes
+	}
 	return &Pass{
 		src:      src,
 		sink:     sink,
@@ -89,7 +112,7 @@ func NewPass(src Source, sink Sink, embedder embeddings.Embedder, cfg PassConfig
 // the next run retries it. Only infrastructure failures (candidate
 // listing) abort, since they would starve every remaining page.
 func (p *Pass) Run(ctx context.Context) (*Report, error) {
-	report := &Report{}
+	report := &Report{FailuresByReason: map[string]int{}}
 
 	pruned, err := p.sink.PruneOrphans(ctx)
 	if err != nil {
@@ -123,13 +146,21 @@ func (p *Pass) Run(ctx context.Context) (*Report, error) {
 	p.logger.Info("span embed pass complete",
 		"scanned", report.Scanned,
 		"embedded", report.Embedded,
+		"chunked", report.Chunked,
 		"up_to_date", report.UpToDate,
 		"empty", report.Empty,
+		"poisoned", report.Poisoned,
 		"failed", report.Failed,
 		"pruned", report.Pruned,
 	)
 	return report, nil
 }
+
+// maxSplitDepth bounds how many times an oversized span is recursively split
+// before it is declared un-embeddable and recorded as a failure. Each level at
+// least halves the text, so the depth doubles as a guard against a pathological
+// input (e.g. one enormous token-dense line) looping forever.
+const maxSplitDepth = 4
 
 // processCandidate embeds one candidate when due. The returned error
 // is fatal to the pass (configuration, not data): today that is only
@@ -144,35 +175,43 @@ func (p *Pass) processCandidate(ctx context.Context, c *Candidate, report *Repor
 	case actionUpToDate:
 		report.UpToDate++
 		return nil
+	case actionPoisoned:
+		report.Poisoned++
+		return nil
 	case actionEmbed:
 	}
 
-	embedding, err := p.embedder.Embed(ctx, text)
-	if err != nil {
-		report.Failed++
-		p.logger.Warn("span embed failed",
-			"trace_id", c.TraceID,
-			"span_id", c.SpanID,
-			"error", err,
-		)
-		return nil
-	}
-	if uint(len(embedding)) != p.cfg.Dimensions {
-		return fmt.Errorf(
-			"embedding model %q returned %d dimensions but %d are configured; fix --embedding-model/--embedding-dimensions so the vector table matches",
-			p.cfg.Model, len(embedding), p.cfg.Dimensions,
-		)
+	if p.cfg.MaxTextBytes > 0 && len(text) > p.cfg.MaxTextBytes {
+		return p.recordTooLarge(ctx, c, hash, text, report)
 	}
 
-	if err := p.sink.Upsert(ctx, Record{
+	vectors, oversizeTokens, err := p.embedChunked(ctx, text)
+	if oversizeTokens > 0 {
+		report.Oversized++
+		report.OversizeTokens = append(report.OversizeTokens, oversizeTokens)
+	}
+	if err != nil {
+		return p.handleEmbedError(ctx, c, hash, oversizeTokens, report, err)
+	}
+	for _, v := range vectors {
+		if uint(len(v)) != p.cfg.Dimensions {
+			return fmt.Errorf(
+				"embedding model %q returned %d dimensions but %d are configured; fix --embedding-model/--embedding-dimensions so the vector table matches",
+				p.cfg.Model, len(v), p.cfg.Dimensions,
+			)
+		}
+	}
+
+	if err := p.sink.UpsertSpanChunks(ctx, ChunkRecord{
 		OrgID:       c.OrgID,
 		TraceID:     c.TraceID,
 		SpanID:      c.SpanID,
 		SessionID:   c.SessionID,
 		Model:       p.cfg.Model,
 		ContentHash: hash,
-		Embedding:   embedding,
+		Embeddings:  vectors,
 	}); err != nil {
+		// A write failure is transient (DB hiccup); the next pass retries.
 		report.Failed++
 		p.logger.Warn("span embedding write failed",
 			"trace_id", c.TraceID,
@@ -182,5 +221,170 @@ func (p *Pass) processCandidate(ctx context.Context, c *Candidate, report *Repor
 		return nil
 	}
 	report.Embedded++
+	report.ChunkRows += len(vectors)
+	if len(vectors) > 1 {
+		report.Chunked++
+	}
 	return nil
+}
+
+// handleEmbedError records and logs an embed failure, sorting it into a
+// deterministic failure (recorded so the span is skipped until its content or
+// model changes) or a transient one (left for the next pass to retry). It never
+// aborts the pass.
+func (p *Pass) handleEmbedError(ctx context.Context, c *Candidate, hash string, oversizeTokens int, report *Report, embedErr error) error {
+	report.Failed++
+
+	apiErr, ok := embeddings.AsAPIError(embedErr)
+	deterministic := ok && !apiErr.Retryable()
+	if !deterministic {
+		// Transient (rate limit, server/transport error) or an unclassified
+		// error: assume it may succeed later and retry next pass.
+		p.logger.Warn("span embed failed",
+			"trace_id", c.TraceID,
+			"span_id", c.SpanID,
+			"error", embedErr,
+		)
+		return nil
+	}
+
+	reason := failureReason(apiErr)
+	report.FailuresByReason[reason]++
+	if err := p.sink.RecordFailure(ctx, FailureRecord{
+		OrgID:       c.OrgID,
+		TraceID:     c.TraceID,
+		SpanID:      c.SpanID,
+		SessionID:   c.SessionID,
+		Model:       p.cfg.Model,
+		ContentHash: hash,
+		Reason:      reason,
+		ErrorDetail: embedErr.Error(),
+		TokenCount:  oversizeTokens,
+	}); err != nil {
+		// Recording the marker failed; the span simply gets retried next
+		// pass, so log and move on.
+		p.logger.Warn("recording span embed failure failed",
+			"trace_id", c.TraceID,
+			"span_id", c.SpanID,
+			"error", err,
+		)
+		return nil
+	}
+	p.logger.Warn("span embed failed permanently; recorded",
+		"trace_id", c.TraceID,
+		"span_id", c.SpanID,
+		"reason", reason,
+		"token_count", oversizeTokens,
+		"error", embedErr,
+	)
+	return nil
+}
+
+// recordTooLarge marks a span whose rendered text exceeds MaxTextBytes as a
+// deterministic failure, so it is skipped (not chunked into hundreds of pieces)
+// until its content shrinks — bounding per-span memory, embed cost, and chunk
+// count. Recorded with an estimated token count so the failure row shows how
+// large it was.
+func (p *Pass) recordTooLarge(ctx context.Context, c *Candidate, hash, text string, report *Report) error {
+	report.Failed++
+	report.FailuresByReason[reasonTooLarge]++
+	if err := p.sink.RecordFailure(ctx, FailureRecord{
+		OrgID:       c.OrgID,
+		TraceID:     c.TraceID,
+		SpanID:      c.SpanID,
+		SessionID:   c.SessionID,
+		Model:       p.cfg.Model,
+		ContentHash: hash,
+		Reason:      reasonTooLarge,
+		ErrorDetail: fmt.Sprintf("rendered text %d bytes exceeds max %d", len(text), p.cfg.MaxTextBytes),
+		TokenCount:  estimateTokens(text),
+	}); err != nil {
+		p.logger.Warn("recording too-large span failure failed",
+			"trace_id", c.TraceID,
+			"span_id", c.SpanID,
+			"error", err,
+		)
+		return nil
+	}
+	p.logger.Warn("span too large to embed; recorded",
+		"trace_id", c.TraceID,
+		"span_id", c.SpanID,
+		"bytes", len(text),
+		"max_bytes", p.cfg.MaxTextBytes,
+	)
+	return nil
+}
+
+// embedChunked embeds text, transparently splitting it into pieces when the
+// model rejects it for exceeding the context window, and returns one embedding
+// per piece in order (a single embedding for text that fit). oversizeTokens is
+// the token count the model reported for the whole text (0 when it fit or the
+// count was unparseable), surfaced for telemetry. A returned error is terminal
+// for this span: a non-oversize failure, or text still oversize past the split
+// depth cap.
+func (p *Pass) embedChunked(ctx context.Context, text string) (vectors [][]float32, oversizeTokens int, err error) {
+	vec, err := p.embedder.Embed(ctx, text)
+	if err == nil {
+		return [][]float32{vec}, 0, nil
+	}
+	apiErr, ok := embeddings.AsAPIError(err)
+	if !ok || !apiErr.IsOversize() {
+		return nil, 0, err
+	}
+	// OpenAI's embeddings oversize error reports no token count, so estimate
+	// from length when the provider omits it — this both sizes the split and
+	// gives the oversize_tokens metric a non-zero value.
+	reported := apiErr.RequestedTokens
+	if reported == 0 {
+		reported = estimateTokens(text)
+	}
+	chunks, splitErr := p.embedSplit(ctx, text, reported, 1)
+	if splitErr != nil {
+		return nil, reported, splitErr
+	}
+	return chunks, reported, nil
+}
+
+// embedSplit splits text into pieces sized against reportedTokens and embeds
+// each, recursing on any piece the model still rejects as oversize until
+// maxSplitDepth.
+func (p *Pass) embedSplit(ctx context.Context, text string, reportedTokens, depth int) ([][]float32, error) {
+	parts := splitParts(text, reportedTokens)
+	if len(parts) < 2 {
+		return nil, errors.New("oversized embedding input cannot be split further")
+	}
+	var out [][]float32
+	for _, part := range parts {
+		vec, err := p.embedder.Embed(ctx, part)
+		if err == nil {
+			out = append(out, vec)
+			continue
+		}
+		apiErr, ok := embeddings.AsAPIError(err)
+		if !ok || !apiErr.IsOversize() {
+			return nil, err
+		}
+		if depth >= maxSplitDepth {
+			return nil, fmt.Errorf("embedding input still oversize after %d splits: %w", depth, err)
+		}
+		sub, err := p.embedSplit(ctx, part, apiErr.RequestedTokens, depth+1)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, sub...)
+	}
+	return out, nil
+}
+
+// failureReason labels a deterministic failure for the failure record and the
+// metric: "oversize" when the model rejected the size, otherwise the HTTP
+// status (e.g. "api_400").
+func failureReason(e *embeddings.APIError) string {
+	if e.IsOversize() {
+		return "oversize"
+	}
+	if e.Status > 0 {
+		return fmt.Sprintf("api_%d", e.Status)
+	}
+	return "api_error"
 }

--- a/pkg/spanembed/pass_test.go
+++ b/pkg/spanembed/pass_test.go
@@ -5,10 +5,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/papercomputeco/tapes/pkg/embeddings"
 	"github.com/papercomputeco/tapes/pkg/logger"
 	"github.com/papercomputeco/tapes/pkg/spanembed"
 )
@@ -18,14 +20,20 @@ const testOrg = "11111111-1111-1111-1111-111111111111"
 // fakeStore implements spanembed.Source and spanembed.Sink in memory.
 type fakeStore struct {
 	candidates []spanembed.Candidate
-	records    map[string]spanembed.Record
+	records    map[string]spanembed.ChunkRecord
+	failures   map[string]spanembed.FailureRecord
+	attempts   map[string]int
 	pruned     int64
 	listErr    error
 	upsertErr  error
 }
 
 func newFakeStore() *fakeStore {
-	return &fakeStore{records: map[string]spanembed.Record{}}
+	return &fakeStore{
+		records:  map[string]spanembed.ChunkRecord{},
+		failures: map[string]spanembed.FailureRecord{},
+		attempts: map[string]int{},
+	}
 }
 
 func (f *fakeStore) ListCandidates(_ context.Context, after spanembed.Key, limit int) ([]spanembed.Candidate, error) {
@@ -39,11 +47,15 @@ func (f *fakeStore) ListCandidates(_ context.Context, after spanembed.Key, limit
 			continue
 		}
 		if keyLess(after, key) {
-			// reflect any embedding this pass already wrote, the way
-			// a second DB read would
+			// reflect any embedding or failure this pass already wrote,
+			// the way a second DB read (the real LEFT JOINs) would
 			if rec, ok := f.records[key.TraceID+"|"+key.SpanID]; ok {
 				c.ExistingHash = rec.ContentHash
 				c.ExistingModel = rec.Model
+			}
+			if fail, ok := f.failures[key.TraceID+"|"+key.SpanID]; ok {
+				c.ExistingFailHash = fail.ContentHash
+				c.ExistingFailModel = fail.Model
 			}
 			out = append(out, c)
 		}
@@ -64,11 +76,20 @@ func keyLess(a, b spanembed.Key) bool {
 	return a.SpanID < b.SpanID
 }
 
-func (f *fakeStore) Upsert(_ context.Context, rec spanembed.Record) error {
+func (f *fakeStore) UpsertSpanChunks(_ context.Context, rec spanembed.ChunkRecord) error {
 	if f.upsertErr != nil {
 		return f.upsertErr
 	}
-	f.records[rec.TraceID+"|"+rec.SpanID] = rec
+	key := rec.TraceID + "|" + rec.SpanID
+	f.records[key] = rec
+	delete(f.failures, key) // a successful write clears any failure marker
+	return nil
+}
+
+func (f *fakeStore) RecordFailure(_ context.Context, rec spanembed.FailureRecord) error {
+	key := rec.TraceID + "|" + rec.SpanID
+	f.failures[key] = rec
+	f.attempts[key]++
 	return nil
 }
 
@@ -77,16 +98,32 @@ func (f *fakeStore) PruneOrphans(context.Context) (int64, error) {
 }
 
 // countingEmbedder returns fixed-size vectors and records the texts it
-// was asked to embed.
+// was asked to embed. It can simulate the model rejecting oversized input,
+// either above a rune threshold or unconditionally, so the chunking and
+// failure paths can be exercised without a real provider.
 type countingEmbedder struct {
-	dims  int
-	texts []string
-	fail  error
+	dims           int
+	texts          []string
+	fail           error
+	oversizeOver   int  // reject text longer than this many runes as oversize (0 = never)
+	tokenScale     int  // reported tokens per rune in an oversize error (default 1)
+	alwaysOversize bool // reject every input as oversize
 }
 
 func (e *countingEmbedder) Embed(_ context.Context, text string) ([]float32, error) {
 	if e.fail != nil {
 		return nil, e.fail
+	}
+	runes := len([]rune(text))
+	if e.alwaysOversize || (e.oversizeOver > 0 && runes > e.oversizeOver) {
+		scale := max(e.tokenScale, 1)
+		tokens := runes * scale
+		return nil, &embeddings.APIError{
+			Status:          400,
+			Code:            "context_length_exceeded",
+			Message:         fmt.Sprintf("maximum context length is 8192 tokens, however you requested %d tokens", tokens),
+			RequestedTokens: tokens,
+		}
 	}
 	e.texts = append(e.texts, text)
 	return make([]float32, e.dims), nil
@@ -222,6 +259,124 @@ var _ = Describe("Pass", func() {
 		})
 	})
 
+	Describe("poison gate", func() {
+		It("skips a span that already failed under the same content and model", func() {
+			store.candidates = []spanembed.Candidate{
+				{
+					OrgID: testOrg, TraceID: "trc_a", SpanID: "llm_big",
+					Input:             textBlocks("enormous prompt"),
+					ExistingFailHash:  spanembed.ContentHash("enormous prompt"),
+					ExistingFailModel: "m",
+				},
+			}
+			report, err := newPass(spanembed.PassConfig{Model: "m", Dimensions: 4}).Run(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(report.Poisoned).To(Equal(1))
+			Expect(report.Embedded).To(BeZero())
+			Expect(embedder.texts).To(BeEmpty())
+		})
+
+		It("retries a poisoned span once its content changes", func() {
+			store.candidates = []spanembed.Candidate{
+				{
+					OrgID: testOrg, TraceID: "trc_a", SpanID: "llm_big",
+					Input:             textBlocks("smaller prompt now"),
+					ExistingFailHash:  spanembed.ContentHash("the old enormous prompt"),
+					ExistingFailModel: "m",
+				},
+			}
+			report, err := newPass(spanembed.PassConfig{Model: "m", Dimensions: 4}).Run(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(report.Poisoned).To(BeZero())
+			Expect(report.Embedded).To(Equal(1))
+		})
+	})
+
+	Describe("oversize chunking", func() {
+		It("splits an oversized span and stores one embedding per piece", func() {
+			embedder = &countingEmbedder{dims: 4, oversizeOver: 10}
+			big := strings.Repeat("a", 30) // no newlines: exact halving
+			store.candidates = []spanembed.Candidate{mainSpan("trc_a", "llm_big", textBlocks(big), nil)}
+
+			report, err := newPass(spanembed.PassConfig{Model: "m", Dimensions: 4}).Run(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(report.Embedded).To(Equal(1))
+			Expect(report.Chunked).To(Equal(1))
+			Expect(report.Failed).To(BeZero())
+
+			rec := store.records["trc_a|llm_big"]
+			Expect(len(rec.Embeddings)).To(BeNumerically(">", 1))
+			// Every piece embedded, and the pieces reassemble to the original.
+			Expect(strings.Join(embedder.texts, "")).To(Equal(big))
+			for _, piece := range embedder.texts {
+				Expect(len([]rune(piece))).To(BeNumerically("<=", 10))
+			}
+		})
+
+		It("uses the reported token count to choose the number of pieces", func() {
+			// 4000 runes reported as 32000 tokens -> ceil(32000/8000) = 4 pieces,
+			// each 1000 runes and under the oversize threshold.
+			embedder = &countingEmbedder{dims: 4, oversizeOver: 1500, tokenScale: 8}
+			big := strings.Repeat("x", 4000)
+			store.candidates = []spanembed.Candidate{mainSpan("trc_a", "llm_big", textBlocks(big), nil)}
+
+			report, err := newPass(spanembed.PassConfig{Model: "m", Dimensions: 4}).Run(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(report.Embedded).To(Equal(1))
+			Expect(store.records["trc_a|llm_big"].Embeddings).To(HaveLen(4))
+		})
+
+		It("records a deterministic failure when the text cannot be split small enough", func() {
+			embedder = &countingEmbedder{dims: 4, alwaysOversize: true}
+			store.candidates = []spanembed.Candidate{mainSpan("trc_a", "llm_big", textBlocks(strings.Repeat("a", 40)), nil)}
+
+			report, err := newPass(spanembed.PassConfig{Model: "m", Dimensions: 4}).Run(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(report.Failed).To(Equal(1))
+			Expect(report.Embedded).To(BeZero())
+			Expect(store.records).To(BeEmpty())
+
+			fail, ok := store.failures["trc_a|llm_big"]
+			Expect(ok).To(BeTrue())
+			Expect(fail.Reason).To(Equal("oversize"))
+			Expect(store.attempts["trc_a|llm_big"]).To(Equal(1))
+		})
+	})
+
+	Describe("failure classification", func() {
+		It("records a non-oversize 4xx as a deterministic failure", func() {
+			embedder.fail = &embeddings.APIError{Status: 400, Message: "Invalid value for 'dimensions'."}
+			store.candidates = []spanembed.Candidate{mainSpan("trc_a", "llm_1", textBlocks("hi"), nil)}
+
+			report, err := newPass(spanembed.PassConfig{Model: "m", Dimensions: 4}).Run(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(report.Failed).To(Equal(1))
+			Expect(store.failures["trc_a|llm_1"].Reason).To(Equal("api_400"))
+		})
+
+		It("records a span over MaxTextBytes as too_large instead of chunking it", func() {
+			store.candidates = []spanembed.Candidate{mainSpan("trc_a", "llm_huge", textBlocks(strings.Repeat("a", 100)), nil)}
+
+			report, err := newPass(spanembed.PassConfig{Model: "m", Dimensions: 4, MaxTextBytes: 50}).Run(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(report.Failed).To(Equal(1))
+			Expect(report.Embedded).To(BeZero())
+			Expect(report.FailuresByReason).To(HaveKeyWithValue("too_large", 1))
+			Expect(store.failures["trc_a|llm_huge"].Reason).To(Equal("too_large"))
+			Expect(embedder.texts).To(BeEmpty()) // embedder never called for an over-cap span
+		})
+
+		It("retries a transient failure without recording it", func() {
+			embedder.fail = &embeddings.APIError{Status: 503, Message: "service unavailable"}
+			store.candidates = []spanembed.Candidate{mainSpan("trc_a", "llm_1", textBlocks("hi"), nil)}
+
+			report, err := newPass(spanembed.PassConfig{Model: "m", Dimensions: 4}).Run(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(report.Failed).To(Equal(1))
+			Expect(store.failures).To(BeEmpty())
+		})
+	})
+
 	Describe("error discipline", func() {
 		It("counts per-span embed failures and keeps going", func() {
 			embedder.fail = errors.New("backend down")
@@ -247,6 +402,50 @@ var _ = Describe("Pass", func() {
 			store.listErr = errors.New("db gone")
 			_, err := newPass(spanembed.PassConfig{Model: "m", Dimensions: 4}).Run(ctx)
 			Expect(err).To(MatchError(ContainSubstring("db gone")))
+		})
+	})
+
+	Describe("report accounting", func() {
+		It("counts span outcomes, oversize splits, and chunk rows in the Report", func() {
+			embedder = &countingEmbedder{dims: 4, oversizeOver: 10}
+			store.candidates = []spanembed.Candidate{
+				mainSpan("trc_a", "llm_norm", textBlocks("short"), nil),
+				mainSpan("trc_a", "llm_big", textBlocks(strings.Repeat("a", 30)), nil),
+				mainSpan("trc_a", "llm_empty", nil, json.RawMessage(`[{"type":"tool_use","tool_use_id":"t","tool_name":"Bash"}]`)),
+				{
+					OrgID: testOrg, TraceID: "trc_a", SpanID: "llm_dup",
+					Input:        textBlocks("unchanged"),
+					ExistingHash: spanembed.ContentHash("unchanged"), ExistingModel: "m",
+				},
+				{
+					OrgID: testOrg, TraceID: "trc_a", SpanID: "llm_pois",
+					Input:            textBlocks("bad"),
+					ExistingFailHash: spanembed.ContentHash("bad"), ExistingFailModel: "m",
+				},
+			}
+
+			report, err := newPass(spanembed.PassConfig{Model: "m", Dimensions: 4}).Run(ctx)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(report.Embedded).To(Equal(2))
+			Expect(report.UpToDate).To(Equal(1))
+			Expect(report.Empty).To(Equal(1))
+			Expect(report.Poisoned).To(Equal(1))
+			Expect(report.Chunked).To(Equal(1))   // only llm_big split
+			Expect(report.Oversized).To(Equal(1)) // only llm_big oversize
+			Expect(report.OversizeTokens).To(HaveLen(1))
+			Expect(report.ChunkRows).To(BeNumerically(">=", 3)) // 1 (norm) + >=2 (big)
+		})
+
+		It("records deterministic failures by reason in the Report", func() {
+			embedder = &countingEmbedder{dims: 4, alwaysOversize: true}
+			store.candidates = []spanembed.Candidate{mainSpan("trc_a", "llm_huge", textBlocks(strings.Repeat("a", 40)), nil)}
+
+			report, err := newPass(spanembed.PassConfig{Model: "m", Dimensions: 4}).Run(ctx)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(report.Failed).To(Equal(1))
+			Expect(report.FailuresByReason).To(HaveKeyWithValue("oversize", 1))
 		})
 	})
 

--- a/pkg/spanembed/spanembed.go
+++ b/pkg/spanembed/spanembed.go
@@ -43,6 +43,13 @@ type Candidate struct {
 	// row; both empty when the span has never been embedded.
 	ExistingHash  string
 	ExistingModel string
+
+	// ExistingFailHash and ExistingFailModel describe a recorded
+	// deterministic embed failure; both empty when the span has no
+	// failure marker. A span whose current content and model match a
+	// recorded failure is skipped instead of re-attempted.
+	ExistingFailHash  string
+	ExistingFailModel string
 }
 
 // Key orders candidates for keyset pagination.
@@ -57,15 +64,33 @@ func (c *Candidate) Key() Key {
 	return Key{OrgID: c.OrgID, TraceID: c.TraceID, SpanID: c.SpanID}
 }
 
-// Record is one embedding write.
-type Record struct {
+// ChunkRecord is one span's embedding write. A span that fit the model's
+// context window has a single embedding; an oversized span was split into
+// pieces and carries one embedding per piece, stored under chunk_idx 0..N-1 in
+// slice order.
+type ChunkRecord struct {
 	OrgID       string
 	TraceID     string
 	SpanID      string
 	SessionID   string
 	Model       string
 	ContentHash string
-	Embedding   []float32
+	Embeddings  [][]float32
+}
+
+// FailureRecord captures a deterministic embed failure so the pass can stop
+// retrying the span while keeping the loss observable: why it failed, how big
+// the input was, and (via the store) how many times it has failed.
+type FailureRecord struct {
+	OrgID       string
+	TraceID     string
+	SpanID      string
+	SessionID   string
+	Model       string
+	ContentHash string
+	Reason      string
+	ErrorDetail string
+	TokenCount  int
 }
 
 // Hit is one similarity-search result with its trace/turn context.
@@ -93,12 +118,35 @@ type Report struct {
 	// Empty counts spans skipped because their delta content renders
 	// to no text at all (e.g. a pure tool-call response).
 	Empty int `json:"empty"`
-	// Failed counts spans whose embed or write errored; the pass
-	// continues past them and the next run retries.
+	// Poisoned counts spans skipped because they already failed
+	// deterministically under this content and model; they are not
+	// re-attempted until their content or model changes.
+	Poisoned int `json:"poisoned"`
+	// Chunked counts spans whose text exceeded the model's context
+	// window and was split into multiple embedded pieces.
+	Chunked int `json:"chunked"`
+	// ChunkRows counts total embedding rows written this pass (one per
+	// piece), so chunked spans contribute more than one.
+	ChunkRows int `json:"chunk_rows"`
+	// Oversized counts spans the model rejected as too large (whether the
+	// split then succeeded or exhausted the depth cap).
+	Oversized int `json:"oversized"`
+	// Failed counts spans whose embed or write failed this pass — both
+	// transient faults (retried next pass) and deterministic ones (also
+	// recorded and skipped thereafter).
 	Failed int `json:"failed"`
 	// Pruned counts orphaned embedding rows removed (their span was
 	// pruned or reclassified by a re-derive).
 	Pruned int64 `json:"pruned"`
+
+	// OversizeTokens holds the reported/estimated token count of each
+	// oversized span this pass — the per-observation source for the embed
+	// worker's oversize-tokens histogram. Excluded from JSON to keep the
+	// logged summary scalar.
+	OversizeTokens []int `json:"-"`
+	// FailuresByReason counts deterministic failures recorded this pass,
+	// keyed by reason (e.g. "oversize", "api_400"). Excluded from JSON.
+	FailuresByReason map[string]int `json:"-"`
 }
 
 // action is the decision for one candidate.
@@ -108,12 +156,17 @@ const (
 	actionEmbed action = iota
 	actionUpToDate
 	actionEmpty
+	actionPoisoned
 )
 
 // decide computes the candidate's embed text and content hash and
 // returns whether it needs embedding under the configured model. The
 // content hash covers only the rendered text; the model is compared
 // separately so switching embedding models re-embeds everything.
+//
+// A span that already failed deterministically under this exact content
+// and model is poisoned: re-attempting it would just fail again and burn
+// an API call, so it is skipped until its content or model changes.
 func decide(c *Candidate, model string) (text, hash string, act action) {
 	text = RenderSpanText(c.Input, c.Output)
 	if text == "" {
@@ -122,6 +175,9 @@ func decide(c *Candidate, model string) (text, hash string, act action) {
 	hash = ContentHash(text)
 	if c.ExistingHash == hash && c.ExistingModel == model {
 		return text, hash, actionUpToDate
+	}
+	if c.ExistingFailHash == hash && c.ExistingFailModel == model {
+		return text, hash, actionPoisoned
 	}
 	return text, hash, actionEmbed
 }

--- a/pkg/spanembed/store.go
+++ b/pkg/spanembed/store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"hash/fnv"
 	"log/slog"
 
 	"github.com/google/uuid"
@@ -19,6 +20,12 @@ const (
 	// same database as the versioned spans projection — candidate selection
 	// and search both join against the current physical table family.
 	DefaultTableName = "span_embeddings"
+
+	// failuresTableSuffix names the sidecar table that records spans whose
+	// embed failed deterministically (e.g. oversize that can't be chunked,
+	// or a non-retryable API rejection). It is derived from the embedding
+	// table name so a custom TableName keeps its failures alongside it.
+	failuresTableSuffix = "_failures"
 
 	// maxVectorDimensions is the upper bound pgvector supports for the
 	// vector type.
@@ -51,12 +58,13 @@ type StoreConfig struct {
 // belongs to the derive-side embed pass; the read path (Search) backs
 // the API's span search.
 type Store struct {
-	pool   *pgxpool.Pool
-	table  pgx.Identifier
-	dims   uint
-	orgID  pgtype.UUID
-	scoped bool
-	logger *slog.Logger
+	pool     *pgxpool.Pool
+	table    pgx.Identifier
+	failures pgx.Identifier
+	dims     uint
+	orgID    pgtype.UUID
+	scoped   bool
+	logger   *slog.Logger
 }
 
 // NewStore wraps an existing connection pool. It performs no IO:
@@ -77,10 +85,11 @@ func NewStore(pool *pgxpool.Pool, cfg StoreConfig, log *slog.Logger) (*Store, er
 		table = DefaultTableName
 	}
 	s := &Store{
-		pool:   pool,
-		table:  pgx.Identifier{table},
-		dims:   cfg.Dimensions,
-		logger: log,
+		pool:     pool,
+		table:    pgx.Identifier{table},
+		failures: pgx.Identifier{table + failuresTableSuffix},
+		dims:     cfg.Dimensions,
+		logger:   log,
 	}
 	if cfg.OrgID != "" {
 		parsed, err := uuid.Parse(cfg.OrgID)
@@ -134,22 +143,34 @@ func (s *Store) EnsureSchema(ctx context.Context) error {
 
 	// No FK onto spans: the projection's down-migrations and prunes
 	// must never be blocked by the embedding sidecar table. Orphans
-	// are reaped by PruneOrphans instead.
+	// are reaped by PruneOrphans instead. chunk_idx lets one span carry
+	// several embedding rows: an oversized span is split into pieces, each
+	// embedded and stored under its own chunk_idx (single-piece spans use
+	// chunk_idx 0).
 	createTable := fmt.Sprintf(`
 		CREATE TABLE IF NOT EXISTS %s (
 			org_id       UUID NOT NULL,
 			trace_id     TEXT NOT NULL,
 			span_id      TEXT NOT NULL,
+			chunk_idx    INT NOT NULL DEFAULT 0,
 			session_id   UUID,
 			model        TEXT NOT NULL,
 			content_hash TEXT NOT NULL,
 			embedded_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
 			embedding    vector(%d) NOT NULL,
-			PRIMARY KEY (org_id, trace_id, span_id)
+			PRIMARY KEY (org_id, trace_id, span_id, chunk_idx)
 		)
 	`, table, s.dims)
 	if _, err := s.pool.Exec(ctx, createTable); err != nil {
 		return fmt.Errorf("creating table: %w", err)
+	}
+
+	if err := s.migrateChunkIdx(ctx); err != nil {
+		return err
+	}
+
+	if err := s.ensureFailuresTable(ctx); err != nil {
+		return err
 	}
 
 	indexName := pgx.Identifier{s.table[0] + "_embedding_idx"}.Sanitize()
@@ -169,24 +190,163 @@ func (s *Store) EnsureSchema(ctx context.Context) error {
 	return nil
 }
 
-// ListCandidates pages every main llm span (keyset-ordered) joined
-// with its current embedding row. The caller decides per candidate
-// whether an embed is due — content hashing happens in Go, so the
+// migrateChunkIdx brings a pre-chunking table (PK on org/trace/span, one row
+// per span) up to the chunked layout in place. It is a no-op once the column
+// exists — which is always the case for a freshly created table — so it is
+// safe to run on every startup. Existing rows fall into chunk_idx 0, i.e. the
+// sole chunk of their span, which is exactly correct.
+func (s *Store) migrateChunkIdx(ctx context.Context) error {
+	// Fast path: the column is already present (always true for a freshly
+	// created table), so most startups never open a transaction.
+	hasColumn, err := s.hasChunkIdxColumn(ctx, s.pool)
+	if err != nil {
+		return err
+	}
+	if hasColumn {
+		return nil
+	}
+
+	table := s.table.Sanitize()
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin chunk_idx migration: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	// Serialize concurrent migrators (multiple embed-worker replicas, or the
+	// old and new pod during a rolling restart) so the check-then-ALTER is
+	// atomic: without this, both replicas see the column missing and the
+	// second's ADD COLUMN fails ("column already exists"), crashlooping the
+	// pod. The transaction-scoped lock releases on commit/rollback.
+	if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock($1)`, advisoryLockKey(s.table[0])); err != nil {
+		return fmt.Errorf("locking chunk_idx migration: %w", err)
+	}
+	// Re-check under the lock — another replica may have migrated while we
+	// waited for it.
+	hasColumn, err = s.hasChunkIdxColumn(ctx, tx)
+	if err != nil {
+		return err
+	}
+	if hasColumn {
+		return tx.Commit(ctx) // already migrated; just release the lock
+	}
+
+	if _, err := tx.Exec(ctx, fmt.Sprintf(`ALTER TABLE %s ADD COLUMN chunk_idx INT NOT NULL DEFAULT 0`, table)); err != nil {
+		return fmt.Errorf("adding chunk_idx column: %w", err)
+	}
+
+	// The original CREATE TABLE left the primary key unnamed, so Postgres
+	// auto-named it; look it up rather than assume "<table>_pkey".
+	var pkName string
+	if err := tx.QueryRow(ctx, `
+		SELECT conname FROM pg_constraint
+		WHERE conrelid = to_regclass($1) AND contype = 'p'
+	`, table).Scan(&pkName); err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		return fmt.Errorf("finding primary key constraint: %w", err)
+	}
+	if pkName != "" {
+		if _, err := tx.Exec(ctx, fmt.Sprintf(`ALTER TABLE %s DROP CONSTRAINT %s`, table, pgx.Identifier{pkName}.Sanitize())); err != nil {
+			return fmt.Errorf("dropping old primary key: %w", err)
+		}
+	}
+	if _, err := tx.Exec(ctx, fmt.Sprintf(`ALTER TABLE %s ADD PRIMARY KEY (org_id, trace_id, span_id, chunk_idx)`, table)); err != nil {
+		return fmt.Errorf("adding chunked primary key: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit chunk_idx migration: %w", err)
+	}
+	s.logger.Info("migrated span embeddings to chunked layout", "table", table)
+	return nil
+}
+
+// rowQuerier is the QueryRow subset shared by *pgxpool.Pool and pgx.Tx, so the
+// chunk_idx check can run either outside a transaction (the fast path) or inside
+// the migration transaction (the re-check under the advisory lock).
+type rowQuerier interface {
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+}
+
+// hasChunkIdxColumn reports whether the embedding table already has the
+// chunk_idx column.
+func (s *Store) hasChunkIdxColumn(ctx context.Context, q rowQuerier) (bool, error) {
+	var has bool
+	if err := q.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1 FROM information_schema.columns
+			WHERE table_name = $1 AND column_name = 'chunk_idx'
+		)
+	`, s.table[0]).Scan(&has); err != nil {
+		return false, fmt.Errorf("checking chunk_idx column: %w", err)
+	}
+	return has, nil
+}
+
+// advisoryLockKey derives a stable Postgres advisory-lock key from the table
+// name, namespaced so it can't collide with advisory locks taken elsewhere.
+func advisoryLockKey(table string) int64 {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte("spanembed.migrateChunkIdx:" + table))
+	return int64(h.Sum64()) // #nosec G115 -- any 64-bit value is a valid lock key
+}
+
+// ensureFailuresTable creates the sidecar that records deterministic embed
+// failures. A row here means "this span's content cannot be embedded under
+// this model, so don't keep retrying it every pass" — while preserving why,
+// how big, and how often, so the loss is observable rather than silent. The
+// span re-enters the embed set the moment its content (hash) or model changes.
+func (s *Store) ensureFailuresTable(ctx context.Context) error {
+	create := fmt.Sprintf(`
+		CREATE TABLE IF NOT EXISTS %s (
+			org_id          UUID NOT NULL,
+			trace_id        TEXT NOT NULL,
+			span_id         TEXT NOT NULL,
+			session_id      UUID,
+			model           TEXT NOT NULL,
+			content_hash    TEXT NOT NULL,
+			reason          TEXT NOT NULL,
+			error_detail    TEXT,
+			token_count     INT,
+			attempts        INT NOT NULL DEFAULT 1,
+			first_failed_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+			last_failed_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+			PRIMARY KEY (org_id, trace_id, span_id)
+		)
+	`, s.failures.Sanitize())
+	if _, err := s.pool.Exec(ctx, create); err != nil {
+		return fmt.Errorf("creating failures table: %w", err)
+	}
+	return nil
+}
+
+// ListCandidates pages every main llm span (keyset-ordered) joined with its
+// current embedding state and any recorded failure. All of a span's chunk rows
+// share one content hash and model, so the embedding join collapses them to a
+// single row; the failure table is already one row per span. The caller decides
+// per candidate whether an embed is due — content hashing happens in Go, so the
 // query stays a cheap indexable join.
 func (s *Store) ListCandidates(ctx context.Context, after Key, limit int) ([]Candidate, error) {
 	table := s.table.Sanitize()
 	query := fmt.Sprintf(`
 		SELECT s.org_id, s.trace_id, s.span_id, s.session_id, s.input, s.output,
-		       COALESCE(e.content_hash, ''), COALESCE(e.model, '')
+		       COALESCE(e.content_hash, ''), COALESCE(e.model, ''),
+		       COALESCE(f.content_hash, ''), COALESCE(f.model, '')
 		FROM spans_20260615 s
-		LEFT JOIN %s e
+		LEFT JOIN (
+			SELECT org_id, trace_id, span_id,
+			       max(content_hash) AS content_hash, max(model) AS model
+			FROM %s
+			GROUP BY org_id, trace_id, span_id
+		) e
 		  ON e.org_id = s.org_id AND e.trace_id = s.trace_id AND e.span_id = s.span_id
+		LEFT JOIN %s f
+		  ON f.org_id = s.org_id AND f.trace_id = s.trace_id AND f.span_id = s.span_id
 		WHERE s.kind = 'llm' AND s.call_kind = 'main'
 		  AND (s.org_id, s.trace_id, s.span_id) > (@org, @trace, @span)
 		  AND (NOT @scoped::boolean OR s.org_id = @scope_org)
 		ORDER BY s.org_id, s.trace_id, s.span_id
 		LIMIT @page
-	`, table)
+	`, table, s.failures.Sanitize())
 
 	afterOrg := pgtype.UUID{Valid: true} // nil UUID sorts first
 	if after.OrgID != "" {
@@ -213,13 +373,14 @@ func (s *Store) ListCandidates(ctx context.Context, after Key, limit int) ([]Can
 	var out []Candidate
 	for rows.Next() {
 		var (
-			c         Candidate
-			org       pgtype.UUID
-			session   pgtype.UUID
-			inp, outp []byte
-			hash, mdl string
+			c                   Candidate
+			org                 pgtype.UUID
+			session             pgtype.UUID
+			inp, outp           []byte
+			hash, mdl           string
+			failHash, failModel string
 		)
-		if err := rows.Scan(&org, &c.TraceID, &c.SpanID, &session, &inp, &outp, &hash, &mdl); err != nil {
+		if err := rows.Scan(&org, &c.TraceID, &c.SpanID, &session, &inp, &outp, &hash, &mdl, &failHash, &failModel); err != nil {
 			return nil, fmt.Errorf("scanning embed candidate: %w", err)
 		}
 		c.OrgID = uuid.UUID(org.Bytes).String()
@@ -230,6 +391,8 @@ func (s *Store) ListCandidates(ctx context.Context, after Key, limit int) ([]Can
 		c.Output = outp
 		c.ExistingHash = hash
 		c.ExistingModel = mdl
+		c.ExistingFailHash = failHash
+		c.ExistingFailModel = failModel
 		out = append(out, c)
 	}
 	if err := rows.Err(); err != nil {
@@ -238,21 +401,16 @@ func (s *Store) ListCandidates(ctx context.Context, after Key, limit int) ([]Can
 	return out, nil
 }
 
-// Upsert writes one embedding keyed by span identity. Re-derives keep
-// identities stable, so re-embedding overwrites in place.
-func (s *Store) Upsert(ctx context.Context, rec Record) error {
-	table := s.table.Sanitize()
-	query := fmt.Sprintf(`
-		INSERT INTO %s (org_id, trace_id, span_id, session_id, model, content_hash, embedding, embedded_at)
-		VALUES (@org, @trace, @span, @session, @model, @hash, @embedding, now())
-		ON CONFLICT (org_id, trace_id, span_id) DO UPDATE SET
-			session_id   = EXCLUDED.session_id,
-			model        = EXCLUDED.model,
-			content_hash = EXCLUDED.content_hash,
-			embedding    = EXCLUDED.embedding,
-			embedded_at  = now()
-	`, table)
-
+// UpsertSpanChunks writes a span's embeddings as chunk rows 0..N-1 and removes
+// any higher-indexed rows left over from a previous, longer chunking of the
+// same span — all in one transaction so search never sees a partially-rewritten
+// span. A successful write also clears any failure marker for the span: the
+// content that once failed now embeds. Re-derives keep span identity stable, so
+// re-embedding overwrites in place.
+func (s *Store) UpsertSpanChunks(ctx context.Context, rec ChunkRecord) error {
+	if len(rec.Embeddings) == 0 {
+		return fmt.Errorf("upserting span embedding %s/%s: no embeddings", rec.TraceID, rec.SpanID)
+	}
 	org, err := uuid.Parse(rec.OrgID)
 	if err != nil {
 		return fmt.Errorf("parse org id: %w", err)
@@ -266,50 +424,157 @@ func (s *Store) Upsert(ctx context.Context, rec Record) error {
 		session = pgtype.UUID{Bytes: parsed, Valid: true}
 	}
 
-	if _, err := s.pool.Exec(ctx, query, pgx.NamedArgs{
-		"org":       pgtype.UUID{Bytes: org, Valid: true},
-		"trace":     rec.TraceID,
-		"span":      rec.SpanID,
-		"session":   session,
-		"model":     rec.Model,
-		"hash":      rec.ContentHash,
-		"embedding": pgvectorgo.NewVector(rec.Embedding),
+	table := s.table.Sanitize()
+	insert := fmt.Sprintf(`
+		INSERT INTO %s (org_id, trace_id, span_id, chunk_idx, session_id, model, content_hash, embedding, embedded_at)
+		VALUES (@org, @trace, @span, @chunk, @session, @model, @hash, @embedding, now())
+		ON CONFLICT (org_id, trace_id, span_id, chunk_idx) DO UPDATE SET
+			session_id   = EXCLUDED.session_id,
+			model        = EXCLUDED.model,
+			content_hash = EXCLUDED.content_hash,
+			embedding    = EXCLUDED.embedding,
+			embedded_at  = now()
+	`, table)
+	pruneTail := fmt.Sprintf(`DELETE FROM %s WHERE org_id = @org AND trace_id = @trace AND span_id = @span AND chunk_idx >= @count`, table)
+	clearFailure := fmt.Sprintf(`DELETE FROM %s WHERE org_id = @org AND trace_id = @trace AND span_id = @span`, s.failures.Sanitize())
+
+	orgArg := pgtype.UUID{Bytes: org, Valid: true}
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin span embedding write: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	for i, embedding := range rec.Embeddings {
+		if _, err := tx.Exec(ctx, insert, pgx.NamedArgs{
+			"org":       orgArg,
+			"trace":     rec.TraceID,
+			"span":      rec.SpanID,
+			"chunk":     i,
+			"session":   session,
+			"model":     rec.Model,
+			"hash":      rec.ContentHash,
+			"embedding": pgvectorgo.NewVector(embedding),
+		}); err != nil {
+			return fmt.Errorf("upserting span embedding %s/%s chunk %d: %w", rec.TraceID, rec.SpanID, i, err)
+		}
+	}
+	if _, err := tx.Exec(ctx, pruneTail, pgx.NamedArgs{
+		"org":   orgArg,
+		"trace": rec.TraceID,
+		"span":  rec.SpanID,
+		"count": len(rec.Embeddings),
 	}); err != nil {
-		return fmt.Errorf("upserting span embedding %s/%s: %w", rec.TraceID, rec.SpanID, err)
+		return fmt.Errorf("pruning stale chunks for %s/%s: %w", rec.TraceID, rec.SpanID, err)
+	}
+	if _, err := tx.Exec(ctx, clearFailure, pgx.NamedArgs{
+		"org":   orgArg,
+		"trace": rec.TraceID,
+		"span":  rec.SpanID,
+	}); err != nil {
+		return fmt.Errorf("clearing failure marker for %s/%s: %w", rec.TraceID, rec.SpanID, err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit span embedding write %s/%s: %w", rec.TraceID, rec.SpanID, err)
 	}
 	return nil
 }
 
-// PruneOrphans removes embeddings whose span no longer exists as a
-// main llm span — pruned by a re-derive, or reclassified out of the
-// embeddable set.
-func (s *Store) PruneOrphans(ctx context.Context) (int64, error) {
-	table := s.table.Sanitize()
+// RecordFailure marks a span as deterministically un-embeddable under its
+// current content and model. The candidate gate skips such spans until their
+// content (hash) or model changes; attempts accrue across passes so the table
+// shows how persistent the failure is.
+func (s *Store) RecordFailure(ctx context.Context, rec FailureRecord) error {
+	org, err := uuid.Parse(rec.OrgID)
+	if err != nil {
+		return fmt.Errorf("parse org id: %w", err)
+	}
+	session := pgtype.UUID{}
+	if rec.SessionID != "" {
+		parsed, err := uuid.Parse(rec.SessionID)
+		if err != nil {
+			return fmt.Errorf("parse session id: %w", err)
+		}
+		session = pgtype.UUID{Bytes: parsed, Valid: true}
+	}
+	tokenCount := pgtype.Int4{}
+	if rec.TokenCount > 0 {
+		tokenCount = pgtype.Int4{Int32: int32(rec.TokenCount), Valid: true} // #nosec G115 -- token counts are small positive ints
+	}
+
 	query := fmt.Sprintf(`
-		DELETE FROM %s e
+		INSERT INTO %s (org_id, trace_id, span_id, session_id, model, content_hash, reason, error_detail, token_count)
+		VALUES (@org, @trace, @span, @session, @model, @hash, @reason, @detail, @tokens)
+		ON CONFLICT (org_id, trace_id, span_id) DO UPDATE SET
+			session_id     = EXCLUDED.session_id,
+			model          = EXCLUDED.model,
+			content_hash   = EXCLUDED.content_hash,
+			reason         = EXCLUDED.reason,
+			error_detail   = EXCLUDED.error_detail,
+			token_count    = EXCLUDED.token_count,
+			attempts       = %s.attempts + 1,
+			last_failed_at = now()
+	`, s.failures.Sanitize(), s.failures.Sanitize())
+
+	if _, err := s.pool.Exec(ctx, query, pgx.NamedArgs{
+		"org":     pgtype.UUID{Bytes: org, Valid: true},
+		"trace":   rec.TraceID,
+		"span":    rec.SpanID,
+		"session": session,
+		"model":   rec.Model,
+		"hash":    rec.ContentHash,
+		"reason":  rec.Reason,
+		"detail":  rec.ErrorDetail,
+		"tokens":  tokenCount,
+	}); err != nil {
+		return fmt.Errorf("recording span embed failure %s/%s: %w", rec.TraceID, rec.SpanID, err)
+	}
+	return nil
+}
+
+// PruneOrphans removes embedding and failure rows whose span no longer exists
+// as a main llm span — pruned by a re-derive, or reclassified out of the
+// embeddable set. Returns the total number of rows removed across both tables.
+func (s *Store) PruneOrphans(ctx context.Context) (int64, error) {
+	orphanFilter := `
 		WHERE (NOT @scoped::boolean OR e.org_id = @scope_org)
 		  AND NOT EXISTS (
 			SELECT 1 FROM spans_20260615 s
 			WHERE s.org_id = e.org_id AND s.trace_id = e.trace_id AND s.span_id = e.span_id
 			  AND s.kind = 'llm' AND s.call_kind = 'main'
-		)
-	`, table)
-	tag, err := s.pool.Exec(ctx, query, pgx.NamedArgs{
-		"scoped":    s.scoped,
-		"scope_org": s.orgID,
-	})
+		)`
+	args := pgx.NamedArgs{"scoped": s.scoped, "scope_org": s.orgID}
+
+	tag, err := s.pool.Exec(ctx, fmt.Sprintf(`DELETE FROM %s e%s`, s.table.Sanitize(), orphanFilter), args)
 	if err != nil {
 		if isUndefinedTable(err) {
 			return 0, nil // nothing embedded yet, nothing to prune
 		}
 		return 0, fmt.Errorf("pruning orphaned span embeddings: %w", err)
 	}
-	return tag.RowsAffected(), nil
+	pruned := tag.RowsAffected()
+
+	failTag, err := s.pool.Exec(ctx, fmt.Sprintf(`DELETE FROM %s e%s`, s.failures.Sanitize(), orphanFilter), args)
+	if err != nil {
+		if isUndefinedTable(err) {
+			return pruned, nil
+		}
+		return pruned, fmt.Errorf("pruning orphaned span embed failures: %w", err)
+	}
+	return pruned + failTag.RowsAffected(), nil
 }
 
-// Search returns the topK spans most similar to the query embedding,
-// joined with their trace context (turn prompt and span payloads for
-// the snippet). Scoped to one org — search is a tenant-facing read.
+// searchOverfetch multiplies topK when pulling nearest chunks, so that several
+// chunks of the same span collapsing to one hit still leaves enough distinct
+// spans to fill the result. Chunks per span are few, so a small factor suffices.
+const searchOverfetch = 4
+
+// Search returns the topK spans most similar to the query embedding, joined
+// with their trace context (turn prompt and span payloads for the snippet).
+// A span may have several chunk embeddings; results collapse to one hit per
+// span, scored by the span's best-matching chunk. Scoped to one org — search is
+// a tenant-facing read.
 func (s *Store) Search(ctx context.Context, orgID string, embedding []float32, topK int) ([]Hit, error) {
 	if topK <= 0 {
 		topK = 5
@@ -321,22 +586,35 @@ func (s *Store) Search(ctx context.Context, orgID string, embedding []float32, t
 
 	table := s.table.Sanitize()
 	query := fmt.Sprintf(`
-		SELECT e.trace_id, e.span_id, e.session_id,
-		       1 - (e.embedding <=> @embedding) AS score,
+		WITH nearest AS (
+			SELECT e.trace_id, e.span_id, e.session_id,
+			       e.embedding <=> @embedding AS dist
+			FROM %s e
+			WHERE e.org_id = @org
+			ORDER BY e.embedding <=> @embedding
+			LIMIT @fetch
+		),
+		best AS (
+			SELECT DISTINCT ON (trace_id, span_id) trace_id, span_id, session_id, dist
+			FROM nearest
+			ORDER BY trace_id, span_id, dist
+		)
+		SELECT b.trace_id, b.span_id, b.session_id,
+		       1 - b.dist AS score,
 		       t.user_prompt, s.model, s.started_at, s.input, s.output
-		FROM %s e
+		FROM best b
 		JOIN spans_20260615 s
-		  ON s.org_id = e.org_id AND s.trace_id = e.trace_id AND s.span_id = e.span_id
+		  ON s.org_id = @org AND s.trace_id = b.trace_id AND s.span_id = b.span_id
 		JOIN span_turns_20260615 t
-		  ON t.org_id = e.org_id AND t.trace_id = e.trace_id
-		WHERE e.org_id = @org
-		ORDER BY e.embedding <=> @embedding
+		  ON t.org_id = @org AND t.trace_id = b.trace_id
+		ORDER BY b.dist
 		LIMIT @topk
 	`, table)
 
 	rows, err := s.pool.Query(ctx, query, pgx.NamedArgs{
 		"org":       pgtype.UUID{Bytes: org, Valid: true},
 		"embedding": pgvectorgo.NewVector(embedding),
+		"fetch":     topK * searchOverfetch,
 		"topk":      topK,
 	})
 	if err != nil {

--- a/pkg/spanembed/store_test.go
+++ b/pkg/spanembed/store_test.go
@@ -79,6 +79,8 @@ var _ = Describe("Store", func() {
 	AfterEach(func() {
 		_, err := pool.Exec(ctx, "DROP TABLE IF EXISTS "+pgx.Identifier{tableName}.Sanitize())
 		Expect(err).NotTo(HaveOccurred())
+		_, err = pool.Exec(ctx, "DROP TABLE IF EXISTS "+pgx.Identifier{tableName + "_failures"}.Sanitize())
+		Expect(err).NotTo(HaveOccurred())
 		_, err = pool.Exec(ctx, "DELETE FROM spans_20260615 WHERE org_id = $1", org)
 		Expect(err).NotTo(HaveOccurred())
 		_, err = pool.Exec(ctx, "DELETE FROM span_turns_20260615 WHERE org_id = $1", org)
@@ -111,6 +113,15 @@ var _ = Describe("Store", func() {
 		return store
 	}
 
+	countRows := func(table, spanID string) int {
+		var n int
+		Expect(pool.QueryRow(ctx,
+			fmt.Sprintf(`SELECT count(*) FROM %s WHERE span_id = $1`, pgx.Identifier{table}.Sanitize()),
+			spanID,
+		).Scan(&n)).To(Succeed())
+		return n
+	}
+
 	Describe("EnsureSchema", func() {
 		It("refuses to reuse a table whose dimensions differ from the configuration", func() {
 			Expect(newStore(3).EnsureSchema(ctx)).To(Succeed())
@@ -141,18 +152,18 @@ var _ = Describe("Store", func() {
 			Expect(candidates[0].SpanID).To(Equal("llm_main"))
 			Expect(candidates[0].ExistingHash).To(BeEmpty())
 
-			rec := spanembed.Record{
+			rec := spanembed.ChunkRecord{
 				OrgID:       org,
 				TraceID:     traceA,
 				SpanID:      "llm_main",
 				Model:       "test-model",
 				ContentHash: spanembed.ContentHash("x"),
-				Embedding:   []float32{1, 0, 0},
+				Embeddings:  [][]float32{{1, 0, 0}},
 			}
-			Expect(store.Upsert(ctx, rec)).To(Succeed())
+			Expect(store.UpsertSpanChunks(ctx, rec)).To(Succeed())
 			// Idempotent by identity: a second write replaces in place.
-			rec.Embedding = []float32{0, 1, 0}
-			Expect(store.Upsert(ctx, rec)).To(Succeed())
+			rec.Embeddings = [][]float32{{0, 1, 0}}
+			Expect(store.UpsertSpanChunks(ctx, rec)).To(Succeed())
 
 			candidates, err = store.ListCandidates(ctx, spanembed.Key{}, 100)
 			Expect(err).NotTo(HaveOccurred())
@@ -172,6 +183,122 @@ var _ = Describe("Store", func() {
 			// Pruning: drop the span, the embedding follows.
 			_, err = pool.Exec(ctx, "DELETE FROM spans_20260615 WHERE org_id = $1 AND span_id = 'llm_main'", org)
 			Expect(err).NotTo(HaveOccurred())
+			pruned, err := store.PruneOrphans(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pruned).To(Equal(int64(1)))
+		})
+	})
+
+	Describe("chunked layout migration", func() {
+		It("adds chunk_idx and a chunked primary key to a pre-chunking table in place", func() {
+			// Recreate the original one-row-per-span schema by hand, with a row in it.
+			_, err := pool.Exec(ctx, `CREATE EXTENSION IF NOT EXISTS vector`)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = pool.Exec(ctx, fmt.Sprintf(`
+				CREATE TABLE %s (
+					org_id UUID NOT NULL, trace_id TEXT NOT NULL, span_id TEXT NOT NULL,
+					session_id UUID, model TEXT NOT NULL, content_hash TEXT NOT NULL,
+					embedded_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+					embedding vector(3) NOT NULL,
+					PRIMARY KEY (org_id, trace_id, span_id)
+				)`, pgx.Identifier{tableName}.Sanitize()))
+			Expect(err).NotTo(HaveOccurred())
+			_, err = pool.Exec(ctx, fmt.Sprintf(`
+				INSERT INTO %s (org_id, trace_id, span_id, model, content_hash, embedding)
+				VALUES ($1, $2, 'llm_main', 'test-model', 'h', '[1,0,0]')`, pgx.Identifier{tableName}.Sanitize()),
+				org, traceA)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(newStore(3).EnsureSchema(ctx)).To(Succeed())
+
+			// The pre-existing row becomes chunk 0.
+			var chunkIdx int
+			Expect(pool.QueryRow(ctx,
+				fmt.Sprintf(`SELECT chunk_idx FROM %s WHERE span_id = 'llm_main'`, pgx.Identifier{tableName}.Sanitize()),
+			).Scan(&chunkIdx)).To(Succeed())
+			Expect(chunkIdx).To(BeZero())
+
+			// The new primary key admits a second chunk for the same span.
+			Expect(newStore(3).UpsertSpanChunks(ctx, spanembed.ChunkRecord{
+				OrgID: org, TraceID: traceA, SpanID: "llm_main", Model: "test-model",
+				ContentHash: spanembed.ContentHash("x"),
+				Embeddings:  [][]float32{{1, 0, 0}, {0, 1, 0}},
+			})).To(Succeed())
+			Expect(countRows(tableName, "llm_main")).To(Equal(2))
+		})
+	})
+
+	Describe("chunked writes and failure records", func() {
+		BeforeEach(func() {
+			Expect(newStore(3).EnsureSchema(ctx)).To(Succeed())
+		})
+
+		It("stores one row per chunk and prunes rows left by a shorter re-chunk", func() {
+			store := newStore(3)
+			rec := spanembed.ChunkRecord{
+				OrgID: org, TraceID: traceA, SpanID: "llm_main", Model: "m", ContentHash: "h",
+				Embeddings: [][]float32{{1, 0, 0}, {0, 1, 0}, {0, 0, 1}},
+			}
+			Expect(store.UpsertSpanChunks(ctx, rec)).To(Succeed())
+			Expect(countRows(tableName, "llm_main")).To(Equal(3))
+
+			rec.Embeddings = [][]float32{{1, 0, 0}, {0, 1, 0}}
+			Expect(store.UpsertSpanChunks(ctx, rec)).To(Succeed())
+			Expect(countRows(tableName, "llm_main")).To(Equal(2))
+		})
+
+		It("records a failure with accruing attempts and clears it on a later success", func() {
+			store := newStore(3)
+			fail := spanembed.FailureRecord{
+				OrgID: org, TraceID: traceA, SpanID: "llm_big", Model: "m",
+				ContentHash: "h", Reason: "oversize", TokenCount: 9523,
+			}
+			Expect(store.RecordFailure(ctx, fail)).To(Succeed())
+			Expect(store.RecordFailure(ctx, fail)).To(Succeed())
+
+			var attempts, tokens int
+			Expect(pool.QueryRow(ctx,
+				fmt.Sprintf(`SELECT attempts, token_count FROM %s WHERE span_id = 'llm_big'`, pgx.Identifier{tableName + "_failures"}.Sanitize()),
+			).Scan(&attempts, &tokens)).To(Succeed())
+			Expect(attempts).To(Equal(2))
+			Expect(tokens).To(Equal(9523))
+
+			Expect(store.UpsertSpanChunks(ctx, spanembed.ChunkRecord{
+				OrgID: org, TraceID: traceA, SpanID: "llm_big", Model: "m",
+				ContentHash: "h2", Embeddings: [][]float32{{1, 0, 0}},
+			})).To(Succeed())
+			Expect(countRows(tableName+"_failures", "llm_big")).To(BeZero())
+		})
+
+		It("returns one hit per span scored by the span's best-matching chunk", func() {
+			insertSpan("llm_a", "llm", "main", `[{"type":"text","text":"alpha content"}]`, "")
+			insertSpan("llm_b", "llm", "main", `[{"type":"text","text":"beta content"}]`, "")
+			store := newStore(3)
+
+			// Span A carries three chunks; one of them is the exact query vector.
+			Expect(store.UpsertSpanChunks(ctx, spanembed.ChunkRecord{
+				OrgID: org, TraceID: traceA, SpanID: "llm_a", Model: "m", ContentHash: "ha",
+				Embeddings: [][]float32{{1, 0, 0}, {0, 1, 0}, {0, 0, 1}},
+			})).To(Succeed())
+			Expect(store.UpsertSpanChunks(ctx, spanembed.ChunkRecord{
+				OrgID: org, TraceID: traceA, SpanID: "llm_b", Model: "m", ContentHash: "hb",
+				Embeddings: [][]float32{{0.9, 0.1, 0}},
+			})).To(Succeed())
+
+			hits, err := store.Search(ctx, org, []float32{0, 1, 0}, 5)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(hits).To(HaveLen(2)) // span A appears once despite three chunks
+			Expect([]string{hits[0].SpanID, hits[1].SpanID}).To(ConsistOf("llm_a", "llm_b"))
+			Expect(hits[0].SpanID).To(Equal("llm_a")) // best score first
+			Expect(hits[0].Score).To(BeNumerically("~", 1.0, 1e-4))
+		})
+
+		It("prunes orphaned failure rows when the span no longer exists", func() {
+			store := newStore(3)
+			Expect(store.RecordFailure(ctx, spanembed.FailureRecord{
+				OrgID: org, TraceID: traceA, SpanID: "llm_absent", Model: "m",
+				ContentHash: "h", Reason: "oversize",
+			})).To(Succeed())
 			pruned, err := store.PruneOrphans(ctx)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(pruned).To(Equal(int64(1)))


### PR DESCRIPTION
🧍I am following on to Jason's PR to break out the embed worker so that it can detect a failed embed due to size and chunk it. This avoids us measuring every single embed when the vast majority of them will embed just fine. If we find our metrics shift where more are needing to be chunked, then we can shift the algorithm but this should be a JIT chunk just for the bigger requests. I went with a naive _divide by characters_ approach rather than a proper tokenizer but we can always shift to a proper token measurement if we find this isn't reliable enough.🧍

🤖

## Summary

- Oversized spans (> the model's 8192-token embedding limit) were counted as a
  failure, logged, and retried every pass forever — never embedded, absent from
  search, re-billed each pass. This PR embeds them by chunking.
- The hot path is unchanged and pays nothing: only on the model's "too large"
  400 does the pass split the text and embed the pieces. Splitting is
  dependency-free — sized by the token count the provider reports, estimated
  from length when it omits one (the real OpenAI embeddings 400 is terse).
- Storage moves to one row per chunk (`chunk_idx` in the PK); existing
  single-row-per-span tables migrate in place under a Postgres advisory lock so
  concurrent embed-worker replicas don't race. Search collapses a span's chunks
  back to one hit, scored by its best chunk.
- Deterministic failures (non-size 4xx, or a span past a per-span size guard)
  are recorded in a failures sidecar and skipped until content/model changes —
  no more forever-retry. Transient faults still retry.
- New `tapes_embed_worker_*` metrics (poisoned / chunked / chunk_rows / oversize
  / oversize_tokens / span_failures{reason}) are emitted from the pass `Report`,
  following #232's worker→Report pattern — no metric defined twice.

## How it works

`processCandidate` renders a span's delta text and embeds it. On success nothing
changes. On an oversize API error it calls `embedChunked` → `embedSplit`, which
divides the text into `ceil(tokens/8000)` pieces on rune/newline boundaries,
embeds each, and recurses on any piece still rejected (depth-capped). The
candidate query collapses a span's chunk rows to one `(content_hash, model)` and
left-joins the failures table so the poison gate skips already-failed spans.

## Behavior matrix

| Span / outcome | Before | After |
|---|---|---|
| Fits the limit | 1 embedding | unchanged (1 chunk) |
| Over the limit | fail → retry forever, lost from search | split → N chunks, searchable once |
| Non-size 4xx | retry forever | recorded, skipped until content changes |
| Transient (429/5xx) | retry | retry (unchanged) |
| Past size guard (≫1 MiB) | would fan out into 100s of calls | recorded `too_large`, skipped |

## Test plan

- [x] Ginkgo unit specs: APIError classification incl. the real terse OpenAI
      message; splitter reassembly/boundaries/estimate; reactive chunking
      (split-once, proportional, depth-exhaust); poison gate; size guard;
      Report accounting.
- [x] Postgres integration specs (Dagger): chunk_idx in-place migration,
      multi-chunk write + stale-row prune, failure record/clear/prune, search
      best-chunk-per-span dedup.
- [x] `make check` (golangci-lint + generate + go-mod-tidy) and full `make test`
      green.
- [x] Manual end-to-end in a local clearing against real OpenAI
      `text-embedding-3-large`: normal turn → 1 chunk; a ~287 KB turn → split
      into chunks, `oversize_*` metrics fire, zero failures, search returns once.

Fixes PCC-714
