### PR TITLE
🔧 fix: bound derive-worker peak memory with a cgroup-derived soft limit

### DIFF
--- a/cmd/tapes/serve/deriveworker/deriveworker.go
+++ b/cmd/tapes/serve/deriveworker/deriveworker.go
@@ -162,6 +162,15 @@ func NewDeriveWorkerCmd() *cobra.Command {
 func (c *deriveWorkerCommander) run(ctx context.Context) error {
 	c.logger = logger.New(logger.WithDebug(c.debug), logger.WithPretty(true))
 
+	// Bound the transient allocation overshoot of a large session derive
+	// to the container budget (PCC-767): the live set fits, but the
+	// per-turn re-parse churn lets the heap roughly double before GC runs,
+	// so deriving a large session can spike past the memory limit and get
+	// the worker OOM-killed. A cgroup-derived soft limit GC-paces the peak
+	// back toward the live set. No-op when GOMEMLIMIT is set or no cgroup
+	// limit exists.
+	worker.ApplySoftMemoryLimit(c.logger)
+
 	if c.postgresDSN == "" {
 		return errors.New("derive worker requires a postgres DSN (--postgres or storage.postgres_dsn)")
 	}

--- a/pkg/derive/giant_memory_test.go
+++ b/pkg/derive/giant_memory_test.go
@@ -1,0 +1,209 @@
+package derive_test
+
+// Regression coverage for the derive-worker memory bound (PCC-767).
+//
+// A real session re-sends its whole prior conversation on every wire turn,
+// so the deriver re-parses an O(N) request per turn and the per-turn
+// garbage piles up faster than the GC reclaims it. Under the default
+// GOGC=100 the heap is allowed to roughly double its live size before a
+// collection, so a large session's TRANSIENT peak runs ~2x its live set —
+// enough to cross the container limit in a brief spike and get the worker
+// OOM-killed. The durable fix is a soft memory limit
+// (worker.ApplySoftMemoryLimit) that GC-paces the peak back toward the
+// live set.
+//
+// These specs (a) pin the synthetic fixture that reproduces the growth and
+// (b) prove a derive of a large session completes correctly under a tight
+// soft memory limit. The sampled-peak demonstration of the spike itself is
+// gated behind TAPES_MEMPROBE: a wall-clock heap sample is too timing-
+// sensitive to gate CI on, but it documents and locally guards the win.
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"os"
+	"runtime"
+	"runtime/debug"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/papercomputeco/tapes/pkg/derive"
+	"github.com/papercomputeco/tapes/pkg/storage"
+)
+
+// syntheticSession builds anthropic wire rows for ONE session whose every
+// turn re-sends the full prior history (the real wire shape). Turn i sends
+// messages [u1,a1,…,u_i] and responds a_i; the re-sent prefix is byte-
+// identical across turns, so it dedups exactly like live capture. Each
+// turn contributes 2 new unique nodes (fresh user + assistant), so a
+// K-turn session derives to ~2K nodes — and turn i re-parses i messages,
+// the O(N^2) churn that drives the transient peak. stream+tools make every
+// call classify as the conversation spine (KindMain), exercising the real
+// derive path.
+func syntheticSession(turns, msgBytes int) []storage.RawTurnRecord {
+	const sess = "synthetic-giant-0000-0000-0000-000000000000"
+	system := strings.Repeat("S", 7000) // ~7KB, like the real Claude Code system prompt
+	// A tool set re-sent verbatim every turn — a big share of each
+	// request's bytes and parse cost in real traffic. Not retained on
+	// nodes (only ToolCount is), so it stresses the transient term only.
+	tools := make([]map[string]any, 0, 96)
+	for i := range 96 {
+		tools = append(tools, map[string]any{
+			"name":         fmt.Sprintf("tool_%02d", i),
+			"description":  strings.Repeat("d", 400),
+			"input_schema": map[string]any{"type": "object", "properties": map[string]any{"x": map[string]any{"type": "string", "description": strings.Repeat("p", 200)}}},
+		})
+	}
+	streamTrue := true
+	type amsg struct {
+		Role    string `json:"role"`
+		Content any    `json:"content"`
+	}
+	var history []amsg
+	rows := make([]storage.RawTurnRecord, 0, turns)
+	for i := 1; i <= turns; i++ {
+		history = append(history, amsg{Role: "user", Content: fmt.Sprintf("U%06d:", i) + strings.Repeat("u", msgBytes)})
+		rr, err := json.Marshal(map[string]any{
+			"model": "claude-opus-4-8", "system": system, "max_tokens": 4096,
+			"stream": streamTrue, "tools": tools, "messages": history,
+		})
+		if err != nil {
+			panic(err)
+		}
+		asstText := fmt.Sprintf("A%06d:", i) + strings.Repeat("a", msgBytes)
+		rj, err := json.Marshal(map[string]any{
+			"done": true, "model": "claude-opus-4-8", "stop_reason": "end_turn",
+			"usage":   map[string]any{"prompt_tokens": 1000, "completion_tokens": 100, "total_tokens": 1100},
+			"message": map[string]any{"role": "assistant", "content": []map[string]any{{"type": "text", "text": asstText}}},
+		})
+		if err != nil {
+			panic(err)
+		}
+		rows = append(rows, storage.RawTurnRecord{
+			ID: int64(i), Provider: "anthropic", HarnessID: "claude", HarnessSessionID: sess,
+			RequestID: fmt.Sprintf("req-%06d", i), RawRequest: rr, Response: rj,
+			ReceivedAt: time.Unix(int64(1700000000+i), 0),
+		})
+		history = append(history, amsg{Role: "assistant", Content: []map[string]any{{"type": "text", "text": asstText}}})
+	}
+	return rows
+}
+
+// streamDerive feeds rows one at a time and drops each immediately, like
+// the production worker (which streams rows from the store, not all at
+// once). Returns the derived set and span projection.
+func streamDerive(rows []storage.RawTurnRecord) (*derive.DerivedSet, *derive.SpanSet) {
+	dv, err := derive.NewDeriver("")
+	Expect(err).NotTo(HaveOccurred())
+	for i := range rows {
+		dv.AddTurn(&rows[i])
+		rows[i] = storage.RawTurnRecord{}
+	}
+	set := dv.Finish()
+	return set, derive.EmitSpans(set)
+}
+
+var _ = Describe("synthetic giant session (PCC-767)", func() {
+	It("dedups re-sent history to two new nodes per growing turn", func() {
+		set, err := derive.BuildDerivedSet(syntheticSession(20, 64), "")
+		Expect(err).NotTo(HaveOccurred())
+		// 20 growing turns -> 40 unique nodes (one user + one assistant
+		// each), every call the conversation spine.
+		Expect(set.Nodes).To(HaveLen(40))
+		Expect(set.Report.CallKinds).To(Equal(map[string]int{derive.KindMain: 20}))
+	})
+
+	It("derives a large session correctly under a tight soft memory limit", func() {
+		// Set a soft heap ceiling well under the unbounded transient peak,
+		// the way the worker does in a memory-limited container. The derive
+		// must still complete and project the full set — GC pacing changes
+		// timing, never the pure projection.
+		restore := debug.SetMemoryLimit(220 * 1024 * 1024)
+		DeferCleanup(func() { debug.SetMemoryLimit(restore) })
+
+		const turns = 200
+		set, spans := streamDerive(syntheticSession(turns, 1024))
+		Expect(set.Nodes).To(HaveLen(2 * turns))
+		Expect(set.Report.CallKinds).To(Equal(map[string]int{derive.KindMain: turns}))
+		// One trace per genuine prompt; one spine llm span per turn.
+		Expect(spans.Turns).To(HaveLen(turns))
+	})
+
+	It("keeps the transient peak under a soft limit [gated: TAPES_MEMPROBE]", func() {
+		if os.Getenv("TAPES_MEMPROBE") == "" {
+			Skip("set TAPES_MEMPROBE=1 to run the sampled-peak demonstration")
+		}
+		const turns, msgBytes = 400, 2048
+
+		// Unbounded: default GOGC lets the transient churn overshoot the
+		// live set ~2x.
+		debug.SetMemoryLimit(math.MaxInt64)
+		runtime.GC()
+		stop := peakSampler()
+		set, _ := streamDerive(syntheticSession(turns, msgBytes))
+		unbounded := stop()
+		live := liveHeap()
+		runtime.KeepAlive(set)
+
+		// Bounded: a soft limit just above the live set collapses the peak.
+		soft := uint64(float64(live) * 1.10)
+		debug.SetMemoryLimit(int64(soft))
+		DeferCleanup(func() { debug.SetMemoryLimit(math.MaxInt64) })
+		runtime.GC()
+		stop = peakSampler()
+		set2, _ := streamDerive(syntheticSession(turns, msgBytes))
+		bounded := stop()
+		runtime.KeepAlive(set2)
+
+		GinkgoWriter.Printf("giant derive: live=%s unbounded peak=%s bounded peak=%s (soft=%s)\n",
+			mb(live), mb(unbounded), mb(bounded), mb(soft))
+		// The soft limit must meaningfully cut the transient peak.
+		Expect(bounded).To(BeNumerically("<", unbounded*8/10))
+	})
+})
+
+func mb(b uint64) string { return fmt.Sprintf("%.1f MB", float64(b)/(1024*1024)) }
+
+func liveHeap() uint64 {
+	runtime.GC()
+	runtime.GC()
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+	return m.HeapAlloc
+}
+
+// peakSampler polls HeapAlloc and returns the max observed until stopped.
+// maxHeap is written only by the sampler goroutine and read only after
+// stop() observes its exit via <-finished, so the channel close
+// establishes the happens-before edge — no atomics needed.
+func peakSampler() (stop func() uint64) {
+	var maxHeap uint64
+	done := make(chan struct{})
+	finished := make(chan struct{})
+	go func() {
+		defer close(finished)
+		var m runtime.MemStats
+		tk := time.NewTicker(500 * time.Microsecond)
+		defer tk.Stop()
+		for {
+			select {
+			case <-done:
+				return
+			case <-tk.C:
+				runtime.ReadMemStats(&m)
+				if m.HeapAlloc > maxHeap {
+					maxHeap = m.HeapAlloc
+				}
+			}
+		}
+	}()
+	return func() uint64 {
+		close(done)
+		<-finished
+		return maxHeap
+	}
+}

--- a/pkg/derive/worker/memlimit.go
+++ b/pkg/derive/worker/memlimit.go
@@ -1,0 +1,112 @@
+package worker
+
+import (
+	"log/slog"
+	"os"
+	"runtime/debug"
+	"strconv"
+	"strings"
+)
+
+// A full session derive allocates transiently far above its live set:
+// every wire turn re-sends the whole prior conversation, so the deriver
+// re-parses an O(N) request per turn and the per-turn garbage piles up
+// faster than the GC reclaims it. Under the default GOGC=100 the heap is
+// allowed to roughly DOUBLE its live size before a collection, so a big
+// session's transient peak runs ~2x its (already large) live set and can
+// exceed the container memory limit in a brief spike, getting the worker
+// OOM-killed even though its steady-state live set fits the budget
+// (PCC-767).
+//
+// The live set itself fits the budget; only the transient overshoot does
+// not. A soft memory limit (GOMEMLIMIT) is the right tool: it makes the
+// GC pace against a ceiling instead of against live-heap-times-GOGC, so
+// the peak collapses back toward the live set, trading some extra GC CPU
+// for a bounded heap. We derive the ceiling from the cgroup memory limit
+// the orchestrator already sets, so it tracks the container budget
+// without a second knob to keep in sync.
+
+// memLimitFraction is the share of the cgroup memory limit used as the
+// soft heap ceiling. The remainder is headroom for non-heap memory
+// (goroutine stacks, the pgx driver, the Go runtime itself) so the soft
+// limit bites — driving more frequent GC — before the hard cgroup limit
+// OOMKills the process.
+const memLimitFraction = 0.9
+
+// cgroup limit file paths (v2 first, then v1). Overridable in tests.
+var (
+	cgroupV2MaxPath = "/sys/fs/cgroup/memory.max"
+	cgroupV1MaxPath = "/sys/fs/cgroup/memory/memory.limit_in_bytes"
+)
+
+// cgroupUnlimited is the sentinel cgroup v1 writes for "no limit": a
+// page-aligned near-max int64. Anything at or above it (or v2's literal
+// "max") means the container is unconstrained, so we set no soft limit.
+const cgroupUnlimited int64 = 0x7000000000000000
+
+// ApplySoftMemoryLimit sets a soft heap ceiling (GOMEMLIMIT) derived from
+// the cgroup memory limit, so a large session's transient allocation
+// overshoot is GC-paced under the container budget instead of OOMKilling
+// the worker. It is a no-op — leaving the Go default in place — when the
+// operator already pinned GOMEMLIMIT, when no cgroup memory limit is
+// readable (local dev, unconstrained container), or on non-Linux.
+//
+// Returns the soft limit applied in bytes, or 0 when none was set.
+func ApplySoftMemoryLimit(log *slog.Logger) int64 {
+	// Respect an explicit operator override: the Go runtime already
+	// honored GOMEMLIMIT at startup, so don't second-guess it. This
+	// includes "off", which disables the limit — an operator who sets it
+	// is opting out, and re-applying a cgroup-derived limit would silently
+	// override that intent.
+	if v := strings.TrimSpace(os.Getenv("GOMEMLIMIT")); v != "" {
+		log.Info("soft memory limit: honoring GOMEMLIMIT from environment", "GOMEMLIMIT", v)
+		return 0
+	}
+
+	limit, ok := readCgroupMemoryLimit()
+	if !ok {
+		log.Debug("soft memory limit: no cgroup memory limit found; leaving GC at default")
+		return 0
+	}
+
+	soft := int64(float64(limit) * memLimitFraction)
+	debug.SetMemoryLimit(soft)
+	log.Info("soft memory limit applied",
+		"cgroup_limit_bytes", limit,
+		"soft_limit_bytes", soft,
+		"fraction", memLimitFraction)
+	return soft
+}
+
+// readCgroupMemoryLimit returns the container's memory limit in bytes,
+// preferring cgroup v2. ok is false when no finite limit is configured.
+func readCgroupMemoryLimit() (limit int64, ok bool) {
+	if v, ok := parseCgroupLimit(readFileTrim(cgroupV2MaxPath)); ok {
+		return v, true
+	}
+	return parseCgroupLimit(readFileTrim(cgroupV1MaxPath))
+}
+
+// parseCgroupLimit interprets one cgroup limit file's contents. The empty
+// string (unreadable file), v2's "max", and v1's near-max sentinel all
+// mean "no limit".
+func parseCgroupLimit(s string) (int64, bool) {
+	if s == "" || s == "max" {
+		return 0, false
+	}
+	v, err := strconv.ParseInt(s, 10, 64)
+	if err != nil || v <= 0 || v >= cgroupUnlimited {
+		return 0, false
+	}
+	return v, true
+}
+
+// readFileTrim reads a small sysfs file and trims it, returning "" on any
+// error (missing path on non-Linux, permission, etc.).
+func readFileTrim(path string) string {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(b))
+}

--- a/pkg/derive/worker/memlimit_internal_test.go
+++ b/pkg/derive/worker/memlimit_internal_test.go
@@ -1,0 +1,124 @@
+package worker
+
+import (
+	"io"
+	"log/slog"
+	"math"
+	"os"
+	"path/filepath"
+	"runtime/debug"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+var _ = Describe("parseCgroupLimit", func() {
+	DescribeTable("interprets a cgroup limit file's contents",
+		func(in string, wantVal int64, wantOK bool) {
+			v, ok := parseCgroupLimit(in)
+			Expect(ok).To(Equal(wantOK))
+			Expect(v).To(Equal(wantVal))
+		},
+		Entry("empty (unreadable) means no limit", "", int64(0), false),
+		Entry("v2 'max' means no limit", "max", int64(0), false),
+		Entry("a finite limit parses", "2147483648", int64(2147483648), true),
+		Entry("zero is not a usable limit", "0", int64(0), false),
+		Entry("negative is rejected", "-1", int64(0), false),
+		Entry("non-numeric is rejected", "garbage", int64(0), false),
+		// cgroup v1 writes a near-max sentinel for "unlimited".
+		Entry("v1 unlimited sentinel means no limit", "9223372036854771712", int64(0), false),
+	)
+})
+
+var _ = Describe("readCgroupMemoryLimit", func() {
+	var dir string
+	var v2, v1 string
+
+	BeforeEach(func() {
+		dir = GinkgoT().TempDir()
+		v2 = filepath.Join(dir, "memory.max")
+		v1 = filepath.Join(dir, "memory.limit_in_bytes")
+		origV2, origV1 := cgroupV2MaxPath, cgroupV1MaxPath
+		cgroupV2MaxPath, cgroupV1MaxPath = v2, v1
+		DeferCleanup(func() { cgroupV2MaxPath, cgroupV1MaxPath = origV2, origV1 })
+	})
+
+	It("prefers cgroup v2 when present", func() {
+		Expect(os.WriteFile(v2, []byte("2147483648\n"), 0o644)).To(Succeed())
+		Expect(os.WriteFile(v1, []byte("1073741824\n"), 0o644)).To(Succeed())
+		v, ok := readCgroupMemoryLimit()
+		Expect(ok).To(BeTrue())
+		Expect(v).To(Equal(int64(2147483648)))
+	})
+
+	It("falls back to v1 when v2 is 'max'", func() {
+		Expect(os.WriteFile(v2, []byte("max\n"), 0o644)).To(Succeed())
+		Expect(os.WriteFile(v1, []byte("1073741824\n"), 0o644)).To(Succeed())
+		v, ok := readCgroupMemoryLimit()
+		Expect(ok).To(BeTrue())
+		Expect(v).To(Equal(int64(1073741824)))
+	})
+
+	It("reports no limit when neither file is constrained", func() {
+		Expect(os.WriteFile(v2, []byte("max\n"), 0o644)).To(Succeed())
+		// v1 absent
+		_, ok := readCgroupMemoryLimit()
+		Expect(ok).To(BeFalse())
+	})
+})
+
+var _ = Describe("ApplySoftMemoryLimit", func() {
+	var restore int64
+
+	BeforeEach(func() {
+		// Snapshot and restore the process-global soft limit so specs
+		// don't leak GC state into each other.
+		restore = debug.SetMemoryLimit(math.MaxInt64)
+		DeferCleanup(func() { debug.SetMemoryLimit(restore) })
+	})
+
+	It("honors an operator GOMEMLIMIT override and sets nothing itself", func() {
+		GinkgoT().Setenv("GOMEMLIMIT", "1GiB")
+		Expect(ApplySoftMemoryLimit(discardLogger())).To(BeZero())
+	})
+
+	It("treats GOMEMLIMIT=off as an explicit opt-out and applies no cgroup limit", func() {
+		GinkgoT().Setenv("GOMEMLIMIT", "off")
+		// Point at a real cgroup limit so a fall-through would apply one.
+		dir := GinkgoT().TempDir()
+		v2 := filepath.Join(dir, "memory.max")
+		Expect(os.WriteFile(v2, []byte("2147483648\n"), 0o644)).To(Succeed())
+		origV2 := cgroupV2MaxPath
+		cgroupV2MaxPath = v2
+		DeferCleanup(func() { cgroupV2MaxPath = origV2 })
+
+		Expect(ApplySoftMemoryLimit(discardLogger())).To(BeZero())
+	})
+
+	It("derives the soft limit from the cgroup memory limit", func() {
+		GinkgoT().Setenv("GOMEMLIMIT", "")
+		dir := GinkgoT().TempDir()
+		v2 := filepath.Join(dir, "memory.max")
+		Expect(os.WriteFile(v2, []byte("2147483648\n"), 0o644)).To(Succeed())
+		origV2 := cgroupV2MaxPath
+		cgroupV2MaxPath = v2
+		DeferCleanup(func() { cgroupV2MaxPath = origV2 })
+
+		got := ApplySoftMemoryLimit(discardLogger())
+		limit := int64(2147483648)
+		Expect(got).To(Equal(int64(float64(limit) * memLimitFraction)))
+	})
+
+	It("is a no-op when no cgroup limit is readable", func() {
+		GinkgoT().Setenv("GOMEMLIMIT", "")
+		origV2, origV1 := cgroupV2MaxPath, cgroupV1MaxPath
+		cgroupV2MaxPath = filepath.Join(GinkgoT().TempDir(), "absent")
+		cgroupV1MaxPath = filepath.Join(GinkgoT().TempDir(), "absent")
+		DeferCleanup(func() { cgroupV2MaxPath, cgroupV1MaxPath = origV2, origV1 })
+		Expect(ApplySoftMemoryLimit(discardLogger())).To(BeZero())
+	})
+})


### PR DESCRIPTION
## Summary

- A large session's derive re-parses the whole re-sent conversation on every turn, so its transient allocation peak runs ~2× its live set. Under the default GOGC=100 the heap is allowed to roughly double before a collection, so deriving a large session can exceed the container memory limit in a brief spike and get the worker OOM-killed — even though its steady-state live set fits the budget comfortably.
- Fix: the derive worker sets a soft heap limit (`debug.SetMemoryLimit`) derived from its cgroup memory budget (90%, leaving headroom for non-heap memory), so the GC paces allocation against the container budget instead of against live-heap-times-GOGC. No-op when `GOMEMLIMIT` is set by the operator, when no cgroup limit is readable (local dev), or on non-Linux.
- Touches **zero deriver logic**, so re-derive stays byte-identical by construction. On a synthetic 2000-node session the peak drops from ~5.5 GB to ~3.1 GB (its live set) with identical output.
- Scoped to the derive worker; the API, proxy, ingest, and embed workers have different memory profiles.

## How it works

`ApplySoftMemoryLimit` reads the container's cgroup memory limit (v2 `memory.max`, falling back to v1), and sets `debug.SetMemoryLimit` to 90% of it. The runtime then runs the GC more often as the heap approaches the ceiling, capping the transient peak near the live set rather than letting it grow to ~2× before collecting. An operator-set `GOMEMLIMIT` takes precedence (the worker leaves the runtime's value untouched), and an unconstrained or non-Linux environment is a clean no-op.

## Test plan

- [x] Unit tests: cgroup v2/v1 limit parsing + the apply/override/no-op logic
- [x] Synthetic growing-session regression: derives correctly under a tight soft ceiling; plus a `TAPES_MEMPROBE`-gated sampled-peak demonstration
- [x] `make format`, `go vet`, `go build`, derive + worker suites green locally
- [ ] CI: dagger build / e2e / smoke

Fixes PCC-767.
