### PR TITLE
✨ feat(pricing): add claude-sonnet-5 model pricing

### DIFF
--- a/pkg/sessions/pricing.go
+++ b/pkg/sessions/pricing.go
@@ -10,7 +10,7 @@ import (
 
 // DefaultPricing returns hardcoded pricing per million tokens for supported models.
 //
-// Last verified: 2026-06-12
+// Last verified: 2026-07-01
 // Sources:
 //   - Anthropic: https://platform.claude.com/docs/en/about-claude/pricing
 //   - OpenAI:    https://platform.openai.com/docs/pricing
@@ -30,6 +30,7 @@ func DefaultPricing() PricingTable {
 		"claude-opus-4.5":   {Input: 5.00, Output: 25.00, CacheRead: 0.50, CacheWrite: 6.25},
 		"claude-opus-4.1":   {Input: 15.00, Output: 75.00, CacheRead: 1.50, CacheWrite: 18.75},
 		"claude-opus-4":     {Input: 15.00, Output: 75.00, CacheRead: 1.50, CacheWrite: 18.75},
+		"claude-sonnet-5":   {Input: 3.00, Output: 15.00, CacheRead: 0.30, CacheWrite: 3.75},
 		"claude-sonnet-4.6": {Input: 3.00, Output: 15.00, CacheRead: 0.30, CacheWrite: 3.75},
 		"claude-sonnet-4.5": {Input: 3.00, Output: 15.00, CacheRead: 0.30, CacheWrite: 3.75},
 		"claude-sonnet-4":   {Input: 3.00, Output: 15.00, CacheRead: 0.30, CacheWrite: 3.75},

--- a/pkg/sessions/status_pricing_test.go
+++ b/pkg/sessions/status_pricing_test.go
@@ -96,15 +96,24 @@ var _ = Describe("NormalizeModel", func() {
 		// date from the -YYYYMMDD stripper.
 		Expect(sessions.NormalizeModel("claude-sonnet-4-5-20250929[1m]")).To(Equal("claude-sonnet-4.5"))
 	})
-	It("resolves claude-fable-5 pricing in bare and 1M-context form", func() {
-		// claude-fable-5 has no minor version, so the dotted-key round-trip
-		// loop below skips it — pin its lookup explicitly.
+	It("resolves minor-less Anthropic pricing in bare and 1M-context form", func() {
+		// These keys have no minor version, so the dotted-key round-trip loop
+		// below skips them — pin their lookups explicitly.
+		type pin struct {
+			api           string
+			input, output float64
+		}
 		pricing := sessions.DefaultPricing()
-		for _, api := range []string{"claude-fable-5", "claude-fable-5[1m]"} {
-			price, ok := sessions.PricingForModel(pricing, api)
-			Expect(ok).To(BeTrue(), "PricingForModel(%q)", api)
-			Expect(price.Input).To(BeNumerically("==", 10.00), "input $/MTok for %q", api)
-			Expect(price.Output).To(BeNumerically("==", 50.00), "output $/MTok for %q", api)
+		for _, p := range []pin{
+			{"claude-fable-5", 10.00, 50.00},
+			{"claude-fable-5[1m]", 10.00, 50.00},
+			{"claude-sonnet-5", 3.00, 15.00},
+			{"claude-sonnet-5[1m]", 3.00, 15.00},
+		} {
+			price, ok := sessions.PricingForModel(pricing, p.api)
+			Expect(ok).To(BeTrue(), "PricingForModel(%q)", p.api)
+			Expect(price.Input).To(BeNumerically("==", p.input), "input $/MTok for %q", p.api)
+			Expect(price.Output).To(BeNumerically("==", p.output), "output $/MTok for %q", p.api)
 		}
 	})
 	It("every Anthropic pricing key is reachable from its canonical API form", func() {


### PR DESCRIPTION
## Summary
- Add `claude-sonnet-5` to the default model pricing table at the standard Sonnet rate: $3.00 input / $15.00 output per MTok, with 0.10x cache-read and 1.25x cache-write — matching every other Sonnet row.
- `claude-fable-5` was already priced, so this closes the gap for the newly released models.
- No `NormalizeModel` change is needed: the bare `claude-sonnet-5` id has no minor version, and date / `[1m]` suffixes are already stripped generically (same path as `claude-fable-5`).

## Note on intro pricing
Sonnet 5 has introductory pricing ($2/$10 per MTok through 2026-08-31). `DefaultPricing` tracks standard list pricing and has no time-window mechanism, so this uses the standard $3/$15, consistent with the rest of the table. The "Last verified" date is refreshed.

## Test plan
- [x] `go test ./pkg/sessions/` — extends the minor-less-model lookup test to pin `claude-sonnet-5` (bare + `[1m]`)
- [x] `gofmt`, `go vet ./pkg/sessions/`, `go build ./...`

Part of PCC-805
