### PR TITLE
✨ feat: add DELETE /v1/sessions/:id with cascading subtree removal

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -87,6 +87,7 @@ func NewServer(config Config, driver storage.Driver, log *slog.Logger) (*Server,
 	app.Get("/v1/traces/:trace_id/spans/:span_id", s.handleGetSpan)
 	app.Get("/v1/traces/:trace_id", s.handleGetTrace)
 	app.Get("/v1/sessions/:id", s.handleGetSession)
+	app.Delete("/v1/sessions/:id", s.handleDeleteSession)
 	app.Get("/v1/sessions/:id/skills", s.handleListSessionSkills)
 	app.Get("/v1/search/spans", s.handleSearchSpansEndpoint)
 

--- a/api/sessions_handlers.go
+++ b/api/sessions_handlers.go
@@ -25,6 +25,13 @@ type sessionsReader interface {
 	GetSessionRecordByHarness(ctx context.Context, orgID string, harnessID string, harnessSessionID string) (*storage.SessionRecord, error)
 }
 
+// sessionsWriter is the capability interface for mutating sessions (DELETE
+// /v1/sessions/:id). The Postgres driver implements it; the handler returns
+// 501 for drivers that don't.
+type sessionsWriter interface {
+	DeleteSession(ctx context.Context, orgID, id string) (bool, error)
+}
+
 const (
 	defaultSessionsLimit = 50
 	maxSessionsLimit     = 200
@@ -352,4 +359,44 @@ func (s *Server) handleGetSession(c *fiber.Ctx) error {
 	return c.JSON(SessionDetailResponse{
 		Session: sessionItemFromStorage(*sess),
 	})
+}
+
+// handleDeleteSession handles DELETE /v1/sessions/:id.
+//
+//	@Summary		Delete a session
+//	@Description	Permanently deletes a session and its subtree: subagent child sessions, derived nodes, and spans cascade with it. Org-scoped — any caller in the org may delete any of its sessions. The immutable raw_turns capture log is left intact.
+//	@Tags			sessions
+//	@Param			id	path	string	true	"Session id (UUID)"
+//	@Success		204	"Session deleted"
+//	@Failure		400	{object}	llm.ErrorResponse	"Missing or malformed id"
+//	@Failure		404	{object}	llm.ErrorResponse	"Session not found"
+//	@Failure		500	{object}	llm.ErrorResponse	"Failed to delete session"
+//	@Failure		501	{object}	llm.ErrorResponse	"Sessions not supported by this backend"
+//	@Router			/v1/sessions/{id} [delete]
+func (s *Server) handleDeleteSession(c *fiber.Ctx) error {
+	writer, ok := s.driver.(sessionsWriter)
+	if !ok {
+		return c.Status(fiber.StatusNotImplemented).JSON(llm.ErrorResponse{Error: "sessions not supported by this backend"})
+	}
+
+	id := c.Params("id")
+	if id == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(llm.ErrorResponse{Error: "id parameter required"})
+	}
+	if _, err := uuid.Parse(id); err != nil {
+		// A session id is a UUID; a malformed one is a client error, not a
+		// storage miss — mirrors handleGetSession's 400.
+		return c.Status(fiber.StatusBadRequest).JSON(llm.ErrorResponse{Error: "id must be a valid UUID"})
+	}
+
+	orgID := orgIDFromCtx(c)
+	deleted, err := writer.DeleteSession(c.Context(), orgID, id)
+	if err != nil {
+		s.logger.Error("delete session", "id", id, "error", err)
+		return c.Status(fiber.StatusInternalServerError).JSON(llm.ErrorResponse{Error: "failed to delete session"})
+	}
+	if !deleted {
+		return c.Status(fiber.StatusNotFound).JSON(llm.ErrorResponse{Error: "session not found"})
+	}
+	return c.SendStatus(fiber.StatusNoContent)
 }

--- a/api/sessions_handlers_test.go
+++ b/api/sessions_handlers_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"time"
@@ -43,6 +44,33 @@ type sessionsStubDriver struct {
 	lastOrgID            string
 	lastHarnessID        string
 	lastHarnessSessionID string
+
+	// DeleteSession stubbing. deletable holds the ids that exist; a hit
+	// removes the id and reports true, a miss reports false — mirroring the
+	// real driver's (deleted bool) contract.
+	deletable     map[string]bool
+	deleteErr     error
+	deleteCalls   int
+	lastDeleteOrg string
+	lastDeleteID  string
+}
+
+// errStubDelete is the canned failure the stub returns to exercise the
+// handler's 500 path.
+var errStubDelete = errors.New("stub delete failure")
+
+func (d *sessionsStubDriver) DeleteSession(_ context.Context, orgID, id string) (bool, error) {
+	d.deleteCalls++
+	d.lastDeleteOrg = orgID
+	d.lastDeleteID = id
+	if d.deleteErr != nil {
+		return false, d.deleteErr
+	}
+	if !d.deletable[id] {
+		return false, nil
+	}
+	delete(d.deletable, id)
+	return true, nil
 }
 
 func (d *sessionsStubDriver) ListSessionRecords(_ context.Context, orgID string, opts storage.SessionListOpts) ([]storage.SessionRecord, error) {
@@ -360,6 +388,70 @@ var _ = Describe("harness natural-key filter on GET /v1/sessions", func() {
 		Expect(status).To(Equal(fiber.StatusNotImplemented))
 
 		_, _, status = getSessionList(server, "/v1/sessions", "")
+		Expect(status).To(Equal(fiber.StatusNotImplemented))
+	})
+})
+
+var _ = Describe("DELETE /v1/sessions/:id", func() {
+	const (
+		validID = "dddddddd-dddd-dddd-dddd-dddddddddddd"
+		org     = "11111111-1111-1111-1111-111111111111"
+	)
+
+	newServer := func(driver storage.Driver) *Server {
+		server, err := NewServer(Config{ListenAddr: ":0"}, driver, tapeslogger.NewNoop())
+		Expect(err).NotTo(HaveOccurred())
+		return server
+	}
+
+	It("deletes an existing session and returns 204, scoped to the org", func() {
+		drv := &sessionsStubDriver{Driver: inmemory.NewDriver(), deletable: map[string]bool{validID: true}}
+		server := newServer(drv)
+
+		_, status := doJSON(server, http.MethodDelete, "/v1/sessions/"+validID, "", org, "")
+		Expect(status).To(Equal(fiber.StatusNoContent))
+		Expect(drv.deleteCalls).To(Equal(1))
+		Expect(drv.lastDeleteOrg).To(Equal(org), "the delete must be scoped to the requested tenant")
+		Expect(drv.lastDeleteID).To(Equal(validID))
+		Expect(drv.deletable).NotTo(HaveKey(validID))
+	})
+
+	It("returns 404 when the session id is absent", func() {
+		drv := &sessionsStubDriver{Driver: inmemory.NewDriver(), deletable: map[string]bool{}}
+		server := newServer(drv)
+
+		_, status := doJSON(server, http.MethodDelete, "/v1/sessions/"+validID, "", org, "")
+		Expect(status).To(Equal(fiber.StatusNotFound))
+		Expect(drv.deleteCalls).To(Equal(1), "a well-formed id reaches storage; the miss surfaces as 404")
+	})
+
+	It("returns 400 for a malformed (non-UUID) id without touching storage", func() {
+		drv := &sessionsStubDriver{Driver: inmemory.NewDriver(), deletable: map[string]bool{}}
+		server := newServer(drv)
+
+		body, status := doJSON(server, http.MethodDelete, "/v1/sessions/not-a-uuid", "", org, "")
+		Expect(status).To(Equal(fiber.StatusBadRequest))
+		Expect(body["error"]).To(ContainSubstring("UUID"))
+		Expect(drv.deleteCalls).To(BeZero(), "the parse failure must short-circuit before the driver call")
+	})
+
+	It("returns 500 when the driver fails to delete", func() {
+		drv := &sessionsStubDriver{Driver: inmemory.NewDriver(), deleteErr: errStubDelete}
+		server := newServer(drv)
+
+		_, status := doJSON(server, http.MethodDelete, "/v1/sessions/"+validID, "", org, "")
+		Expect(status).To(Equal(fiber.StatusInternalServerError))
+	})
+
+	It("returns 501 when the backend does not support session writes", func() {
+		// The bare in-memory driver implements the read surface but not
+		// sessionsWriter, so the handler must report 501.
+		base := inmemory.NewDriver()
+		_, hasWriter := storage.Driver(base).(sessionsWriter)
+		Expect(hasWriter).To(BeFalse(), "precondition: the bare inmemory driver must not implement sessionsWriter")
+
+		server := newServer(base)
+		_, status := doJSON(server, http.MethodDelete, "/v1/sessions/"+validID, "", org, "")
 		Expect(status).To(Equal(fiber.StatusNotImplemented))
 	})
 })

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -371,6 +371,51 @@ const docTemplate = `{
                         }
                     }
                 }
+            },
+            "delete": {
+                "description": "Permanently deletes a session and its subtree: subagent child sessions, derived nodes, and spans cascade with it. Org-scoped — any caller in the org may delete any of its sessions. The immutable raw_turns capture log is left intact.",
+                "tags": [
+                    "sessions"
+                ],
+                "summary": "Delete a session",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Session id (UUID)",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Session deleted"
+                    },
+                    "400": {
+                        "description": "Missing or malformed id",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_papercomputeco_tapes_pkg_llm.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Session not found",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_papercomputeco_tapes_pkg_llm.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Failed to delete session",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_papercomputeco_tapes_pkg_llm.ErrorResponse"
+                        }
+                    },
+                    "501": {
+                        "description": "Sessions not supported by this backend",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_papercomputeco_tapes_pkg_llm.ErrorResponse"
+                        }
+                    }
+                }
             }
         },
         "/v1/sessions/{id}/raw_turns": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -367,6 +367,51 @@
                         }
                     }
                 }
+            },
+            "delete": {
+                "description": "Permanently deletes a session and its subtree: subagent child sessions, derived nodes, and spans cascade with it. Org-scoped — any caller in the org may delete any of its sessions. The immutable raw_turns capture log is left intact.",
+                "tags": [
+                    "sessions"
+                ],
+                "summary": "Delete a session",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Session id (UUID)",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Session deleted"
+                    },
+                    "400": {
+                        "description": "Missing or malformed id",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_papercomputeco_tapes_pkg_llm.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Session not found",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_papercomputeco_tapes_pkg_llm.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Failed to delete session",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_papercomputeco_tapes_pkg_llm.ErrorResponse"
+                        }
+                    },
+                    "501": {
+                        "description": "Sessions not supported by this backend",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_papercomputeco_tapes_pkg_llm.ErrorResponse"
+                        }
+                    }
+                }
             }
         },
         "/v1/sessions/{id}/raw_turns": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -649,6 +649,39 @@ paths:
       tags:
       - sessions
   /v1/sessions/{id}:
+    delete:
+      description: 'Permanently deletes a session and its subtree: subagent child
+        sessions, derived nodes, and spans cascade with it. Org-scoped — any caller
+        in the org may delete any of its sessions. The immutable raw_turns capture
+        log is left intact.'
+      parameters:
+      - description: Session id (UUID)
+        in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        "204":
+          description: Session deleted
+        "400":
+          description: Missing or malformed id
+          schema:
+            $ref: '#/definitions/github_com_papercomputeco_tapes_pkg_llm.ErrorResponse'
+        "404":
+          description: Session not found
+          schema:
+            $ref: '#/definitions/github_com_papercomputeco_tapes_pkg_llm.ErrorResponse'
+        "500":
+          description: Failed to delete session
+          schema:
+            $ref: '#/definitions/github_com_papercomputeco_tapes_pkg_llm.ErrorResponse'
+        "501":
+          description: Sessions not supported by this backend
+          schema:
+            $ref: '#/definitions/github_com_papercomputeco_tapes_pkg_llm.ErrorResponse'
+      summary: Delete a session
+      tags:
+      - sessions
     get:
       description: 'Returns a single session record. The conversation content lives
         on the span model: GET /v1/sessions/{id}/traces.'

--- a/migrations/1781360000_session_delete_cascade.down.sql
+++ b/migrations/1781360000_session_delete_cascade.down.sql
@@ -1,0 +1,12 @@
+-- Restore the original NO ACTION foreign keys (no ON DELETE behavior), matching
+-- how 1779329142_session_tracking first declared them inline.
+
+ALTER TABLE nodes
+    DROP CONSTRAINT IF EXISTS nodes_session_id_fkey,
+    ADD CONSTRAINT nodes_session_id_fkey
+        FOREIGN KEY (session_id) REFERENCES sessions(id);
+
+ALTER TABLE sessions
+    DROP CONSTRAINT IF EXISTS sessions_parent_session_id_fkey,
+    ADD CONSTRAINT sessions_parent_session_id_fkey
+        FOREIGN KEY (parent_session_id) REFERENCES sessions(id);

--- a/migrations/1781360000_session_delete_cascade.up.sql
+++ b/migrations/1781360000_session_delete_cascade.up.sql
@@ -1,0 +1,25 @@
+-- Recreate the two session foreign keys with ON DELETE CASCADE so a session
+-- DELETE removes its dependent rows in one statement instead of erroring on a
+-- NO ACTION constraint. This is what makes DELETE /v1/sessions/:id possible.
+--
+-- - nodes.session_id (added in 1779329142_session_tracking) had no ON DELETE
+--   clause, so deleting a session a node points at would raise a constraint
+--   violation. CASCADE drops the session's derived nodes with it. A later
+--   re-derive re-projects those nodes from the immutable raw_turns log with
+--   NULL attribution (the deriver never re-creates the session row itself), and
+--   the product surface ignores NULL-session nodes — so the delete stays durable.
+-- - sessions.parent_session_id is self-referential; CASCADE makes deleting a
+--   parent recursively delete its subagent (child) sessions.
+--
+-- span_turns / spans / span_links already cascade on session_id
+-- (1781230000_span_model), so they are untouched here.
+
+ALTER TABLE nodes
+    DROP CONSTRAINT IF EXISTS nodes_session_id_fkey,
+    ADD CONSTRAINT nodes_session_id_fkey
+        FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE;
+
+ALTER TABLE sessions
+    DROP CONSTRAINT IF EXISTS sessions_parent_session_id_fkey,
+    ADD CONSTRAINT sessions_parent_session_id_fkey
+        FOREIGN KEY (parent_session_id) REFERENCES sessions(id) ON DELETE CASCADE;

--- a/pkg/storage/postgres/gensqlc/sessions.sql.go
+++ b/pkg/storage/postgres/gensqlc/sessions.sql.go
@@ -11,6 +11,29 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const deleteSession = `-- name: DeleteSession :execrows
+DELETE FROM sessions
+WHERE org_id = $1 AND id = $2
+`
+
+type DeleteSessionParams struct {
+	OrgID pgtype.UUID
+	ID    pgtype.UUID
+}
+
+// Remove a session by its org-scoped id. Returns the affected row count so the
+// handler can distinguish a real delete from a missing id. Dependent rows
+// (subagent child sessions, derived nodes, spans/span_turns/span_links) are
+// removed by the session_id ON DELETE CASCADE foreign keys, so this single
+// statement tears down the whole subtree.
+func (q *Queries) DeleteSession(ctx context.Context, arg DeleteSessionParams) (int64, error) {
+	result, err := q.db.Exec(ctx, deleteSession, arg.OrgID, arg.ID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const getSessionByNaturalKey = `-- name: GetSessionByNaturalKey :one
 SELECT id, org_id, auth_subject, harness_id, harness_session_id, name, cwd, harness_version, parent_session_id, started_at, last_seen_at, ended_at, harness_metadata, total_input_tokens, total_output_tokens, total_cost_usd, turn_count, derived_status, has_git_activity, tool_result_count, tool_error_count, derived_title, derived_model, model_usage FROM sessions
 WHERE org_id = $1

--- a/pkg/storage/postgres/queries/sessions.sql
+++ b/pkg/storage/postgres/queries/sessions.sql
@@ -148,6 +148,15 @@ LIMIT sqlc.arg(lim);
 SELECT * FROM sessions
 WHERE org_id = sqlc.arg(org_id) AND id = sqlc.arg(id);
 
+-- name: DeleteSession :execrows
+-- Remove a session by its org-scoped id. Returns the affected row count so the
+-- handler can distinguish a real delete from a missing id. Dependent rows
+-- (subagent child sessions, derived nodes, spans/span_turns/span_links) are
+-- removed by the session_id ON DELETE CASCADE foreign keys, so this single
+-- statement tears down the whole subtree.
+DELETE FROM sessions
+WHERE org_id = sqlc.arg(org_id) AND id = sqlc.arg(id);
+
 -- name: ListNodesBySession :many
 -- All nodes attributed to a session, ordered by capture time (chronological).
 SELECT * FROM nodes

--- a/pkg/storage/postgres/session_delete_test.go
+++ b/pkg/storage/postgres/session_delete_test.go
@@ -1,0 +1,157 @@
+package postgres_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/papercomputeco/tapes/pkg/sessions"
+	"github.com/papercomputeco/tapes/pkg/storage"
+	"github.com/papercomputeco/tapes/pkg/storage/postgres"
+)
+
+var _ = Describe("Driver.DeleteSession", func() {
+	var (
+		driver   storage.Driver
+		pgDriver *postgres.Driver
+		ingester storage.SessionIngester
+		ctx      context.Context
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		dsn, err := testPostgresDSN()
+		Expect(err).NotTo(HaveOccurred())
+
+		driver, err = postgres.NewDriver(ctx, dsn)
+		Expect(err).NotTo(HaveOccurred())
+
+		var ok bool
+		pgDriver, ok = driver.(*postgres.Driver)
+		Expect(ok).To(BeTrue())
+		_, err = pgDriver.DB().Exec(ctx, "TRUNCATE TABLE nodes")
+		Expect(err).NotTo(HaveOccurred())
+		_, err = pgDriver.DB().Exec(ctx, "TRUNCATE TABLE sessions CASCADE")
+		Expect(err).NotTo(HaveOccurred())
+
+		ingester, ok = driver.(storage.SessionIngester)
+		Expect(ok).To(BeTrue(), "postgres driver must satisfy SessionIngester")
+	})
+
+	AfterEach(func() {
+		if driver != nil {
+			driver.Close()
+		}
+	})
+
+	// seed ingests a 2-node turn under the given identity and returns the
+	// tapes-minted session UUID. A non-nil parentHarnessSessionID forks the
+	// new session off that parent (shared harness_id).
+	seed := func(orgID, harnessSessionID, text string, parentHarnessSessionID *string) string {
+		res, err := ingester.IngestTurn(ctx, storage.IngestTurnRequest{
+			Session: &sessions.IngestEnvelope{
+				OrgID:                  orgID,
+				AuthSubject:            "subject-delete",
+				HarnessID:              "claude",
+				HarnessSessionID:       harnessSessionID,
+				ParentHarnessSessionID: parentHarnessSessionID,
+			},
+			Nodes:        sessionFixture(text),
+			InputTokens:  12,
+			OutputTokens: 8,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.SessionID).NotTo(BeEmpty())
+		return res.SessionID
+	}
+
+	nodeCount := func(sessionID string) int {
+		var n int
+		err := pgDriver.DB().QueryRow(ctx,
+			"SELECT count(*) FROM nodes WHERE session_id = $1::uuid", sessionID).Scan(&n)
+		Expect(err).NotTo(HaveOccurred())
+		return n
+	}
+
+	It("deletes the session and reports it was removed", func() {
+		orgID := newTestOrgID()
+		id := seed(orgID, "sess-solo", "solo turn", nil)
+		Expect(nodeCount(id)).To(BeNumerically(">", 0), "precondition: the session owns nodes")
+
+		deleted, err := pgDriver.DeleteSession(ctx, orgID, id)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(deleted).To(BeTrue())
+
+		rec, err := pgDriver.GetSessionRecord(ctx, orgID, id)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rec).To(BeNil(), "the session row is gone")
+		Expect(nodeCount(id)).To(BeZero(), "the session's nodes cascade with it")
+	})
+
+	It("cascades to subagent child sessions and their nodes", func() {
+		orgID := newTestOrgID()
+		parentID := seed(orgID, "sess-parent", "parent turn", nil)
+		parentHarness := "sess-parent"
+		childID := seed(orgID, "sess-child", "child turn", &parentHarness)
+		Expect(childID).NotTo(Equal(parentID))
+
+		// Sanity: the child really is FK-linked to the parent.
+		child, err := pgDriver.GetSessionRecord(ctx, orgID, childID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(child).NotTo(BeNil())
+		Expect(child.ParentSessionID).To(Equal(parentID), "precondition: child forks off the parent")
+
+		deleted, err := pgDriver.DeleteSession(ctx, orgID, parentID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(deleted).To(BeTrue())
+
+		gone, err := pgDriver.GetSessionRecord(ctx, orgID, childID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(gone).To(BeNil(), "deleting the parent cascades to the child session")
+		Expect(nodeCount(parentID)).To(BeZero())
+		Expect(nodeCount(childID)).To(BeZero())
+	})
+
+	It("leaves unrelated sessions in the same org untouched", func() {
+		orgID := newTestOrgID()
+		victimID := seed(orgID, "sess-victim", "victim turn", nil)
+		survivorID := seed(orgID, "sess-survivor", "survivor turn", nil)
+
+		deleted, err := pgDriver.DeleteSession(ctx, orgID, victimID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(deleted).To(BeTrue())
+
+		survivor, err := pgDriver.GetSessionRecord(ctx, orgID, survivorID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(survivor).NotTo(BeNil(), "a sibling session must not be swept up by the delete")
+		Expect(nodeCount(survivorID)).To(BeNumerically(">", 0))
+	})
+
+	It("reports false for an absent id and never crosses orgs", func() {
+		orgA := newTestOrgID()
+		orgB := newTestOrgID()
+		idA := seed(orgA, "sess-a", "org A turn", nil)
+
+		// A random valid UUID that does not exist.
+		missing, err := pgDriver.DeleteSession(ctx, orgA, newTestOrgID())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(missing).To(BeFalse())
+
+		// orgB cannot delete orgA's session even with the right id.
+		crossOrg, err := pgDriver.DeleteSession(ctx, orgB, idA)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(crossOrg).To(BeFalse(), "the delete is org-scoped")
+
+		stillThere, err := pgDriver.GetSessionRecord(ctx, orgA, idA)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(stillThere).NotTo(BeNil(), "org A's session survives org B's delete attempt")
+	})
+
+	It("treats a malformed id as a no-op, not an error", func() {
+		orgID := newTestOrgID()
+		deleted, err := pgDriver.DeleteSession(ctx, orgID, "not-a-uuid")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(deleted).To(BeFalse())
+	})
+})

--- a/pkg/storage/postgres/session_reads.go
+++ b/pkg/storage/postgres/session_reads.go
@@ -183,6 +183,31 @@ func (d *Driver) GetSessionRecord(ctx context.Context, orgID, id string) (*stora
 	return &s, nil
 }
 
+// DeleteSession removes a session by its org-scoped id and returns whether a
+// row was actually deleted (false when the id was absent). The session_id
+// ON DELETE CASCADE foreign keys tear down the rest of the subtree in the same
+// statement: subagent child sessions (parent_session_id), the session's derived
+// nodes, and its spans/span_turns/span_links. A malformed id is treated as a
+// no-op delete, matching DeleteSkill.
+func (d *Driver) DeleteSession(ctx context.Context, orgID, id string) (bool, error) {
+	oid, err := orgIDFromString(orgID)
+	if err != nil {
+		return false, fmt.Errorf("delete session: %w", err)
+	}
+	parsed, err := uuid.Parse(id)
+	if err != nil {
+		return false, nil //nolint:nilerr // invalid id == nothing to delete
+	}
+	n, err := d.q.DeleteSession(ctx, gensqlc.DeleteSessionParams{
+		OrgID: oid,
+		ID:    pgtype.UUID{Bytes: parsed, Valid: true},
+	})
+	if err != nil {
+		return false, fmt.Errorf("delete session: %w", err)
+	}
+	return n > 0, nil
+}
+
 // GetSessionRecordByHarness returns the single session matching the
 // org-scoped natural key (org_id, harness_id, harness_session_id), or nil
 // if no row matches. The lookup is an exact-match point read on the


### PR DESCRIPTION
## Summary

- Adds `DELETE /v1/sessions/:id` — org-scoped hard delete of a session and its entire derived subtree.
- New migration adds `ON DELETE CASCADE` to the two FKs that hang the subtree off a session: `nodes.session_id` and `sessions.parent_session_id` (subagent child sessions). Spans/span_turns/span_links already cascade from nodes.
- `204` on delete, `404` when nothing matched, `400` on a malformed id — a non-UUID is a client error, not a storage miss (mirrors `handleGetSession`).
- `raw_turns` (the immutable capture log) is intentionally left intact — this removes the derived read model, not the source log. A re-derive cannot resurrect a deleted session: the deriver only attributes to existing session rows and never creates them, so re-projected nodes reappear NULL-attributed and stay invisible to the product surface.

## How it works

`DeleteSession(orgID, id)` resolves the org, parses the id, and issues a single org-scoped `DELETE` on `sessions`. The cascade FKs from `1781360000_session_delete_cascade` tear down the rest of the subtree in the same statement, so there's no multi-statement partial-delete window. The handler maps affected-rows to `204` vs `404`.

## Behavior matrix

| Request | Result |
|---|---|
| valid id, session exists in org | 204; session + nodes + spans + child sessions removed |
| valid id, no such session in org | 404 |
| malformed id | 400 (invalid UUID) |
| id belongs to another org | 404 (org-scoped) |

## Test plan

- [x] `pkg/storage/postgres` Ginkgo suite incl. `Driver.DeleteSession` cascade specs (run against Postgres locally)
- [x] `api` handler suite (in-memory + stub driver): 204/404, org threading, validation short-circuit
- [x] `gofmt`, `go build`, `go vet`, `golangci-lint v2.11`
- [x] Manually exercised `DELETE /v1/sessions/:id` against a local Postgres-backed instance — session + nodes + spans + span_turns all cascade to 0

related to PCC-806
