### PR TITLE
🔧 fix(spanembed): strip harness tags from the embed render

### DIFF
--- a/pkg/merkle/projection.go
+++ b/pkg/merkle/projection.go
@@ -163,6 +163,15 @@ func StripHarnessTags(text string) string {
 	return text
 }
 
+// NormalizeForEmbed strips harness-tag spans and folds away whitespace
+// drift, producing the canonical prose used for span embedding. It
+// composes StripHarnessTags with the same whitespace normalization
+// ProjectContent applies to chain-hash text, so embed render and chain
+// hash treat harness noise and whitespace identically.
+func NormalizeForEmbed(text string) string {
+	return normalizeWhitespace(StripHarnessTags(text))
+}
+
 // stripTaggedSpan removes every <tag>…</tag> span from text. An
 // unterminated open tag is treated as swallowing the rest of the
 // string, matching the behavior of sessions.StripTaggedSection.

--- a/pkg/merkle/projection.go
+++ b/pkg/merkle/projection.go
@@ -74,7 +74,7 @@ func ProjectContent(blocks []llm.ContentBlock) []llm.ContentBlock {
 	out := make([]llm.ContentBlock, 0, len(blocks))
 	for _, b := range blocks {
 		if b.Text != "" {
-			projected := normalizeWhitespace(stripHarnessTags(b.Text))
+			projected := normalizeWhitespace(StripHarnessTags(b.Text))
 			if projected == "" {
 				continue
 			}
@@ -93,7 +93,7 @@ func ProjectContent(blocks []llm.ContentBlock) []llm.ContentBlock {
 		// otherwise hash apart and fork the chain. This was the bulk
 		// of the measured join-residual on the golden sessions.
 		if b.ToolOutput != "" {
-			b.ToolOutput = normalizeWhitespace(stripHarnessTags(b.ToolOutput))
+			b.ToolOutput = normalizeWhitespace(StripHarnessTags(b.ToolOutput))
 		}
 		out = append(out, b)
 	}
@@ -151,7 +151,12 @@ func isZeroValue(v any) bool {
 	}
 }
 
-func stripHarnessTags(text string) string {
+// StripHarnessTags removes every <tag>…</tag> span whose tag is in
+// HarnessTags from text. Exported for consumers that need the same
+// harness-noise removal outside chain-hash projection — e.g. the span
+// embedding render, where a several-KB <system-reminder> block would
+// otherwise dominate the vector and flatten semantic search ranking.
+func StripHarnessTags(text string) string {
 	for _, tag := range HarnessTags {
 		text = stripTaggedSpan(text, tag)
 	}

--- a/pkg/spanembed/pass_test.go
+++ b/pkg/spanembed/pass_test.go
@@ -482,4 +482,13 @@ var _ = Describe("RenderSpanText", func() {
 	It("renders undecodable payloads as empty", func() {
 		Expect(spanembed.RenderSpanText(json.RawMessage(`{not json`), nil)).To(Equal(""))
 	})
+
+	It("strips harness tag spans so boilerplate cannot dominate the vector", func() {
+		input := json.RawMessage(`[
+			{"type":"text","text":"<system-reminder>\nSessionStart hook: several KB of skill instructions\n</system-reminder>Explain autovacuum tuning"},
+			{"type":"text","text":"<system-reminder>only noise</system-reminder>"}
+		]`)
+		output := textBlocks("Set scale factors low.")
+		Expect(spanembed.RenderSpanText(input, output)).To(Equal("Explain autovacuum tuning\nSet scale factors low."))
+	})
 })

--- a/pkg/spanembed/spanembed.go
+++ b/pkg/spanembed/spanembed.go
@@ -229,7 +229,11 @@ func appendBlocks(sb *strings.Builder, raw json.RawMessage) {
 			continue
 		}
 		// A block that is nothing but harness noise contributes nothing.
-		text := strings.TrimSpace(merkle.StripHarnessTags(b.Text))
+		// normalizeWhitespace mirrors what ProjectContent does after
+		// StripHarnessTags: collapse CRLF, trailing line-space, and
+		// consecutive blank lines so the same prose always hashes the
+		// same way regardless of whitespace drift around stripped tags.
+		text := merkle.NormalizeForEmbed(b.Text)
 		if text == "" {
 			continue
 		}

--- a/pkg/spanembed/spanembed.go
+++ b/pkg/spanembed/spanembed.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/papercomputeco/tapes/pkg/llm"
+	"github.com/papercomputeco/tapes/pkg/merkle"
 )
 
 // Candidate is one main llm span considered for embedding, joined with
@@ -195,6 +196,14 @@ func ContentHash(text string) string {
 // by the text blocks of the output. Tool payloads, thinking, and
 // images are deliberately excluded — they are structured data, not
 // prose, and they drown the signal the search exists for.
+//
+// Harness tag spans (<system-reminder>, hook context, command framing —
+// see merkle.HarnessTags) are stripped for the same reason the chain
+// hash strips them: they are volatile harness metadata, not user
+// intent. Left in, a several-KB session-start reminder embeds every
+// first turn of every session to a near-identical vector and flattens
+// search ranking (observed as three unrelated sessions all scoring
+// within noise of each other).
 func RenderSpanText(input, output json.RawMessage) string {
 	var sb strings.Builder
 	appendBlocks(&sb, input)
@@ -203,9 +212,10 @@ func RenderSpanText(input, output json.RawMessage) string {
 }
 
 // appendBlocks appends the text blocks of one stored content-block
-// array. Undecodable payloads contribute nothing: the raw layer is the
-// source of truth and a malformed projection row will be rewritten by
-// the next derive.
+// array, harness-tag-stripped and trimmed; blocks that are pure harness
+// noise contribute nothing. Undecodable payloads also contribute
+// nothing: the raw layer is the source of truth and a malformed
+// projection row will be rewritten by the next derive.
 func appendBlocks(sb *strings.Builder, raw json.RawMessage) {
 	if len(raw) == 0 {
 		return
@@ -218,9 +228,14 @@ func appendBlocks(sb *strings.Builder, raw json.RawMessage) {
 		if b.Type != "text" || b.Text == "" {
 			continue
 		}
+		// A block that is nothing but harness noise contributes nothing.
+		text := strings.TrimSpace(merkle.StripHarnessTags(b.Text))
+		if text == "" {
+			continue
+		}
 		if sb.Len() > 0 {
 			sb.WriteString("\n")
 		}
-		sb.WriteString(b.Text)
+		sb.WriteString(text)
 	}
 }


### PR DESCRIPTION
## Summary

- The span embedding render included harness metadata spans (`<system-reminder>` hook context, command framing) verbatim. A several-KB session-start reminder embeds every first turn of every session to a near-identical vector, flattening semantic search ranking — observed as three unrelated sessions all scoring 0.35 ± 0.02 for any query.
- The chain hash already strips these tags for exactly this volatility (PCC-562); the embed text now applies the same projection: `merkle.StripHarnessTags` is exported and applied per text block in `RenderSpanText`, with blocks that strip to pure noise contributing nothing.
- No migration needed: the content hash covers the rendered text, so the embed worker re-embeds affected spans automatically on its next pass.

## How it works

`appendBlocks` strips + trims each text block before appending. Exporting from `merkle` (not reusing `sessions.StripTaggedSection`) is deliberate: `pkg/sessions` already imports `pkg/merkle`, so the reverse import would cycle, and merkle owns the canonical `HarnessTags` list. Derive is a pure function of the raw layer, so hashes can't flap — the one-time re-embed is the intended remedy.

Measured on a local clearing: correct top hit for all three test queries with 2–3× score separation (0.61–0.67 vs 0.19–0.38), where before every hit tied at ~0.35 in arbitrary order.

## Test plan

- [x] New render spec proving tag spans strip and noise-only blocks drop (`pass_test.go`)
- [x] `go test ./pkg/merkle/... ./pkg/spanembed/...` + gofmt clean
- [x] `dagger call test`: my touched packages pass. **Disclosure:** the run fails 1/92 in the shared `pkg/storage/postgres` ginkgo suite (skills ordering) — pristine `main` fails the identical gate 1/92 on a *different* spec (`GetSessionRecordByHarness`), so the suite is flaky on main independent of this diff.
- [x] End-to-end on a clearing: capture → derive → auto re-embed → differentiated `paper search` ranking

Part of PCC-836
Refs PCC-835