### PR TITLE
✨ POC: detect session outcomes at derive time

### DIFF
--- a/api/sessions_handlers.go
+++ b/api/sessions_handlers.go
@@ -57,7 +57,14 @@ type SessionItem struct {
 	// count, so the UI can show "dominant model + per-model %" without a
 	// cheap-subagent fan-out skewing it. Populated on the session detail;
 	// nil until the session first derives.
-	ModelUsage      []ModelUsage   `json:"model_usage,omitempty"`
+	ModelUsage []ModelUsage `json:"model_usage,omitempty"`
+	// Outcomes is the fold of artifacts the session produced (pull
+	// requests / repos / issues), detected from tool spans at derive
+	// time and deduped by URL. Each carries trace/span provenance back
+	// to the detecting tool call. Nil until the session derives or when
+	// it produced nothing — "no outcome" is a signal the UI renders
+	// explicitly (PCC-837/PCC-840).
+	Outcomes        []Outcome      `json:"outcomes,omitempty"`
 	HarnessMetadata map[string]any `json:"harness_metadata,omitempty"`
 	Preview         string         `json:"preview,omitempty"`
 	// AuthSubject is the gateway-stamped JWT subject (WorkOS user id)
@@ -75,6 +82,21 @@ type ModelUsage struct {
 	InputTokens  int64   `json:"input_tokens"`
 	OutputTokens int64   `json:"output_tokens"`
 	CostUsd      float64 `json:"cost_usd"`
+}
+
+// Outcome is one artifact a session produced, in the API: kind is an
+// open set (pull_request / repo / issue / linear_issue today), url is
+// the artifact's identity, and trace_id/span_id point back at the
+// detecting tool span so consumers can deep-link the exact turn.
+type Outcome struct {
+	Kind       string    `json:"kind"`
+	URL        string    `json:"url"`
+	Title      string    `json:"title,omitempty"`
+	Repo       string    `json:"repo,omitempty"`
+	TraceID    string    `json:"trace_id,omitempty"`
+	SpanID     string    `json:"span_id,omitempty"`
+	DetectedBy string    `json:"detected_by,omitempty"`
+	DetectedAt time.Time `json:"detected_at,omitzero"`
 }
 
 // SessionListResponse is the response envelope for GET /v1/sessions.
@@ -109,10 +131,33 @@ func sessionItemFromStorage(s storage.SessionRecord) SessionItem {
 		DerivedStatus:     s.DerivedStatus,
 		Model:             s.Model,
 		ModelUsage:        modelUsageFromStorage(s.ModelUsage),
+		Outcomes:          outcomesFromStorage(s.Outcomes),
 		HarnessMetadata:   s.HarnessMetadata,
 		Preview:           s.Preview,
 		AuthSubject:       s.AuthSubject,
 	}
+}
+
+// outcomesFromStorage maps the storage-layer outcome fold to the API
+// shape. Nil in stays nil out (omitted from the response).
+func outcomesFromStorage(in []storage.Outcome) []Outcome {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]Outcome, len(in))
+	for i, o := range in {
+		out[i] = Outcome{
+			Kind:       o.Kind,
+			URL:        o.URL,
+			Title:      o.Title,
+			Repo:       o.Repo,
+			TraceID:    o.TraceID,
+			SpanID:     o.SpanID,
+			DetectedBy: o.DetectedBy,
+			DetectedAt: o.DetectedAt,
+		}
+	}
+	return out
 }
 
 // modelUsageFromStorage maps the storage-layer per-model breakdown to

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -733,6 +733,35 @@ const docTemplate = `{
                 }
             }
         },
+        "api.Outcome": {
+            "type": "object",
+            "properties": {
+                "detected_at": {
+                    "type": "string"
+                },
+                "detected_by": {
+                    "type": "string"
+                },
+                "kind": {
+                    "type": "string"
+                },
+                "repo": {
+                    "type": "string"
+                },
+                "span_id": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "trace_id": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                }
+            }
+        },
         "api.RawTurnHeaderItem": {
             "type": "object",
             "properties": {
@@ -835,6 +864,13 @@ const docTemplate = `{
                 },
                 "name": {
                     "type": "string"
+                },
+                "outcomes": {
+                    "description": "Outcomes is the fold of artifacts the session produced (pull\nrequests / repos / issues), detected from tool spans at derive\ntime and deduped by URL. Each carries trace/span provenance back\nto the detecting tool call. Nil until the session derives or when\nit produced nothing — \"no outcome\" is a signal the UI renders\nexplicitly (PCC-837/PCC-840).",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/api.Outcome"
+                    }
                 },
                 "parent_session_id": {
                     "type": "string"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -729,6 +729,35 @@
                 }
             }
         },
+        "api.Outcome": {
+            "type": "object",
+            "properties": {
+                "detected_at": {
+                    "type": "string"
+                },
+                "detected_by": {
+                    "type": "string"
+                },
+                "kind": {
+                    "type": "string"
+                },
+                "repo": {
+                    "type": "string"
+                },
+                "span_id": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "trace_id": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                }
+            }
+        },
         "api.RawTurnHeaderItem": {
             "type": "object",
             "properties": {
@@ -831,6 +860,13 @@
                 },
                 "name": {
                     "type": "string"
+                },
+                "outcomes": {
+                    "description": "Outcomes is the fold of artifacts the session produced (pull\nrequests / repos / issues), detected from tool spans at derive\ntime and deduped by URL. Each carries trace/span provenance back\nto the detecting tool call. Nil until the session derives or when\nit produced nothing — \"no outcome\" is a signal the UI renders\nexplicitly (PCC-837/PCC-840).",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/api.Outcome"
+                    }
                 },
                 "parent_session_id": {
                     "type": "string"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -13,6 +13,25 @@ definitions:
       output_tokens:
         type: integer
     type: object
+  api.Outcome:
+    properties:
+      detected_at:
+        type: string
+      detected_by:
+        type: string
+      kind:
+        type: string
+      repo:
+        type: string
+      span_id:
+        type: string
+      title:
+        type: string
+      trace_id:
+        type: string
+      url:
+        type: string
+    type: object
   api.RawTurnHeaderItem:
     properties:
       agent_name:
@@ -93,6 +112,17 @@ definitions:
         type: array
       name:
         type: string
+      outcomes:
+        description: |-
+          Outcomes is the fold of artifacts the session produced (pull
+          requests / repos / issues), detected from tool spans at derive
+          time and deduped by URL. Each carries trace/span provenance back
+          to the detecting tool call. Nil until the session derives or when
+          it produced nothing — "no outcome" is a signal the UI renders
+          explicitly (PCC-837/PCC-840).
+        items:
+          $ref: '#/definitions/api.Outcome'
+        type: array
       parent_session_id:
         type: string
       preview:

--- a/migrations/1781360000_session_outcomes.down.sql
+++ b/migrations/1781360000_session_outcomes.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE sessions DROP COLUMN IF EXISTS outcomes;

--- a/migrations/1781360000_session_outcomes.up.sql
+++ b/migrations/1781360000_session_outcomes.up.sql
@@ -1,0 +1,10 @@
+-- Outcomes: the artifacts a session produced (pull requests, repos,
+-- issues), detected from tool spans at derive time (PCC-840). Stored as
+-- a JSONB array of {kind, url, title, repo, trace_id, span_id,
+-- detected_by, detected_at} — url is the artifact's identity (the fold
+-- dedupes on it), trace_id/span_id point back at the detecting tool
+-- span (the memory stream's source-pointer convention), and detected_at
+-- is that span's start time so a re-derive reproduces the fold.
+-- Re-derive repopulates it; pre-migration rows carry NULL until their
+-- next derive pass. New sessions only by design — no backfill (PCC-837).
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS outcomes JSONB;

--- a/pkg/derive/spans.go
+++ b/pkg/derive/spans.go
@@ -71,6 +71,13 @@ type SpanSet struct {
 	// main-spine model (#28).
 	ModelUsage map[SessionKey][]ModelUsage
 
+	// Outcomes is the per-session fold of artifacts the session produced
+	// (pull requests / repos / issues), detected from tool spans'
+	// input/output at derive time and deduped by URL. Each outcome
+	// carries trace/span provenance and the detecting span's start time,
+	// so a re-derive reproduces the fold byte-for-byte.
+	Outcomes map[SessionKey][]sessions.Outcome
+
 	Report SpanReport
 }
 
@@ -680,6 +687,9 @@ func (em *spanEmitter) finish() {
 	// trace's llm spans below — subagent models included — then sorted
 	// into ModelUsage at the end.
 	modelFold := map[SessionKey]map[string]*ModelUsage{}
+	// Per-session outcome fold: artifacts detected from tool spans,
+	// accumulated in capture order and deduped by URL at the end.
+	outcomeFold := map[SessionKey][]sessions.Outcome{}
 	for _, turn := range em.set.Turns {
 		root := turn.Spans[0]
 		// phases append out of time order within a trace; StartedAt is
@@ -700,6 +710,16 @@ func (em *spanEmitter) finish() {
 		for _, s := range turn.Spans {
 			if end := s.StartedAt.Add(time.Duration(s.DurationNS)); end.After(turn.EndedAt) {
 				turn.EndedAt = end
+			}
+			if s.Kind == SpanKindTool {
+				for _, outcome := range detectSpanOutcomes(s) {
+					outcome.TraceID = turn.TraceID
+					outcome.SpanID = s.SpanID
+					// The detecting span's start time, never the wall
+					// clock — re-derive must reproduce the fold.
+					outcome.DetectedAt = s.StartedAt
+					outcomeFold[turn.Session] = append(outcomeFold[turn.Session], outcome)
+				}
 			}
 			if s.Kind == SpanKindLLM && s.Usage != nil {
 				turn.TotalInputTokens += int64(s.Usage.PromptTokens)
@@ -741,6 +761,35 @@ func (em *spanEmitter) finish() {
 		turn.ResponsePreview = responsePreview(turn)
 	}
 	em.foldModelUsage(modelFold)
+	em.foldOutcomes(outcomeFold)
+}
+
+// detectSpanOutcomes runs the outcome matchers over one tool span: the
+// tool_use block carries the name/input, the tool_result block (when it
+// arrived) carries the output the artifact URL is parsed from.
+func detectSpanOutcomes(s *Span) []sessions.Outcome {
+	if len(s.Input) == 0 {
+		return nil
+	}
+	use := s.Input[0]
+	var output string
+	if len(s.Output) > 0 {
+		output = s.Output[0].ToolOutput
+	}
+	return sessions.DetectToolOutcomes(use.ToolName, use.ToolInput, output)
+}
+
+// foldOutcomes flattens the per-session outcome accumulator into the
+// SpanSet, deduped by URL in capture order so a re-run create command
+// never double-counts an artifact.
+func (em *spanEmitter) foldOutcomes(fold map[SessionKey][]sessions.Outcome) {
+	if len(fold) == 0 {
+		return
+	}
+	em.set.Outcomes = map[SessionKey][]sessions.Outcome{}
+	for key, outcomes := range fold {
+		em.set.Outcomes[key] = sessions.DedupeOutcomes(outcomes)
+	}
 }
 
 // foldModelUsage flattens the per-session model accumulator into the

--- a/pkg/derive/spans_internal_test.go
+++ b/pkg/derive/spans_internal_test.go
@@ -2,12 +2,14 @@ package derive
 
 import (
 	"strings"
+	"time"
 	"unicode/utf8"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	"github.com/papercomputeco/tapes/pkg/llm"
+	"github.com/papercomputeco/tapes/pkg/sessions"
 )
 
 var _ = Describe("joinTextBlocks truncation", func() {
@@ -27,5 +29,92 @@ var _ = Describe("joinTextBlocks truncation", func() {
 	It("keeps short previews untouched", func() {
 		blocks := []llm.ContentBlock{{Type: blockText, Text: "hello ✓"}}
 		Expect(joinTextBlocks(blocks, false)).To(Equal("hello ✓"))
+	})
+})
+
+var _ = Describe("outcomes fold", func() {
+	key := SessionKey{HarnessID: "claude-code", HarnessSessionID: "sess-1"}
+
+	// A minimal turn: root agent span plus one completed Bash tool span
+	// whose output printed the created PR's URL.
+	makeTurn := func(command, output string) *SpanTurn {
+		root := &Span{SpanID: "agent_1", Kind: SpanKindAgent, StartedAt: time.Unix(100, 0)}
+		tool := &Span{
+			SpanID:    "tool_1",
+			Kind:      SpanKindTool,
+			Name:      "Bash",
+			StartedAt: time.Unix(101, 0),
+			Input: []llm.ContentBlock{{
+				Type:      blockToolUse,
+				ToolName:  "Bash",
+				ToolInput: map[string]any{"command": command},
+			}},
+			Output: []llm.ContentBlock{{
+				Type:       blockToolResult,
+				ToolOutput: output,
+			}},
+		}
+		return &SpanTurn{
+			TraceID:   "trc_test1",
+			Session:   key,
+			StartedAt: time.Unix(100, 0),
+			Spans:     []*Span{root, tool},
+		}
+	}
+
+	It("stamps provenance and folds detected outcomes per session", func() {
+		em := &spanEmitter{set: &SpanSet{Report: SpanReport{
+			SpanKinds: map[string]int{},
+			CallKinds: map[string]int{},
+			LinkKinds: map[string]int{},
+		}}}
+		em.set.Turns = []*SpanTurn{makeTurn(
+			"gh pr create --fill",
+			"https://github.com/papercomputeco/paper/pull/94\n",
+		)}
+
+		em.finish()
+
+		outcomes := em.set.Outcomes[key]
+		Expect(outcomes).To(HaveLen(1))
+		Expect(outcomes[0].Kind).To(Equal(sessions.OutcomeKindPullRequest))
+		Expect(outcomes[0].URL).To(Equal("https://github.com/papercomputeco/paper/pull/94"))
+		Expect(outcomes[0].TraceID).To(Equal("trc_test1"))
+		Expect(outcomes[0].SpanID).To(Equal("tool_1"))
+		// The detecting span's start time, never the wall clock, so a
+		// re-derive reproduces the fold.
+		Expect(outcomes[0].DetectedAt).To(Equal(time.Unix(101, 0)))
+	})
+
+	It("dedupes repeat detections of the same URL across turns", func() {
+		em := &spanEmitter{set: &SpanSet{Report: SpanReport{
+			SpanKinds: map[string]int{},
+			CallKinds: map[string]int{},
+			LinkKinds: map[string]int{},
+		}}}
+		first := makeTurn("gh pr create --fill", "https://github.com/o/r/pull/1")
+		repeat := makeTurn("gh pr create --fill", "https://github.com/o/r/pull/1")
+		repeat.TraceID = "trc_test2"
+		repeat.Spans[1].SpanID = "tool_2"
+		em.set.Turns = []*SpanTurn{first, repeat}
+
+		em.finish()
+
+		outcomes := em.set.Outcomes[key]
+		Expect(outcomes).To(HaveLen(1))
+		Expect(outcomes[0].SpanID).To(Equal("tool_1"))
+	})
+
+	It("emits no fold at all when nothing was detected", func() {
+		em := &spanEmitter{set: &SpanSet{Report: SpanReport{
+			SpanKinds: map[string]int{},
+			CallKinds: map[string]int{},
+			LinkKinds: map[string]int{},
+		}}}
+		em.set.Turns = []*SpanTurn{makeTurn("ls -la", "total 0")}
+
+		em.finish()
+
+		Expect(em.set.Outcomes).To(BeNil())
 	})
 })

--- a/pkg/sessions/outcomes.go
+++ b/pkg/sessions/outcomes.go
@@ -1,0 +1,192 @@
+package sessions
+
+import (
+	"encoding/json"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// Outcome kinds. An open set on the wire — consumers render unknown
+// kinds as text — but constants here so matchers and tests share one
+// spelling.
+const (
+	OutcomeKindPullRequest = "pull_request"
+	OutcomeKindRepo        = "repo"
+	OutcomeKindIssue       = "issue"
+	OutcomeKindLinearIssue = "linear_issue"
+)
+
+// DetectedBy values: which matcher family surfaced the outcome.
+const (
+	OutcomeDetectedByGhCli = "gh_cli"
+	OutcomeDetectedByMCP   = "mcp"
+)
+
+// Outcome is one artifact a session produced (a pull request, a repo,
+// an issue), detected from the session's tool calls at derive time. URL
+// is the outcome's identity — the fold dedupes on it. TraceID/SpanID
+// point back at the detecting tool span (the simulacrum memory stream's
+// source-pointer convention), and DetectedAt carries that span's start
+// time — never the wall clock — so a re-derive reproduces the fold
+// byte-for-byte.
+type Outcome struct {
+	Kind       string    `json:"kind"`
+	URL        string    `json:"url"`
+	Title      string    `json:"title,omitempty"`
+	Repo       string    `json:"repo,omitempty"`
+	TraceID    string    `json:"trace_id,omitempty"`
+	SpanID     string    `json:"span_id,omitempty"`
+	DetectedBy string    `json:"detected_by,omitempty"`
+	DetectedAt time.Time `json:"detected_at,omitzero"`
+}
+
+// URL shapes for the artifacts the gh matchers extract. Ordered most
+// specific first where one output could match several (a PR URL also
+// matches the bare repo shape).
+var (
+	githubPullURL  = regexp.MustCompile(`https://github\.com/([\w.-]+/[\w.-]+)/pull/\d+`)
+	githubIssueURL = regexp.MustCompile(`https://github\.com/([\w.-]+/[\w.-]+)/issues/\d+`)
+	githubRepoURL  = regexp.MustCompile(`https://github\.com/([\w.-]+/[\w.-]+)`)
+	linearIssueURL = regexp.MustCompile(`https://linear\.app/([\w-]+)/issue/[\w-]+(?:/[\w-]+)?`)
+)
+
+// ghOutcomeMatcher pairs a gh CLI invocation with the URL shape its
+// stdout prints on success. The command substring gates the match; the
+// URL in the tool output is the outcome's identity — a create whose
+// output carries no URL (errored, interrupted, dry-run) yields nothing.
+type ghOutcomeMatcher struct {
+	command string
+	kind    string
+	url     *regexp.Regexp
+}
+
+// ghOutcomeMatchers is the Bash/gh matcher family. Adding an outcome
+// kind detected from a shell command is one row here.
+var ghOutcomeMatchers = []ghOutcomeMatcher{
+	{command: "gh pr create", kind: OutcomeKindPullRequest, url: githubPullURL},
+	{command: "gh repo create", kind: OutcomeKindRepo, url: githubRepoURL},
+	{command: "gh issue create", kind: OutcomeKindIssue, url: githubIssueURL},
+}
+
+// linearIssueToolNames gates the MCP matcher family: Linear MCP tool
+// invocations that create (or update) an issue. Matched as lowercase
+// substrings of the tool name so harness-specific prefixes
+// (mcp__linear-server__save_issue, mcp__claude_ai_Linear__create_issue)
+// all hit.
+var linearIssueToolNames = []string{"save_issue", "create_issue"}
+
+// DetectToolOutcomes inspects one completed tool call — its name, its
+// tool_use input, and its tool_result output text — and returns the
+// outcomes it produced. Pure; the derive fold stamps trace/span
+// provenance and timestamps onto the results. Conservative by design:
+// no URL in the output means no outcome, so failed creates never count.
+func DetectToolOutcomes(toolName string, input map[string]any, output string) []Outcome {
+	if output == "" {
+		return nil
+	}
+	if toolName == "Bash" {
+		return detectGhOutcomes(input, output)
+	}
+	if isLinearIssueTool(toolName) {
+		return detectLinearIssueOutcome(output)
+	}
+	return nil
+}
+
+// detectGhOutcomes runs the Bash/gh matcher family over one shell tool
+// call. Each matcher fires at most once per call: a `gh pr create`
+// prints exactly one PR URL, and dedup-by-URL upstream makes repeats
+// harmless anyway.
+func detectGhOutcomes(input map[string]any, output string) []Outcome {
+	cmd, _ := input["command"].(string)
+	if cmd == "" {
+		return nil
+	}
+	lower := strings.ToLower(cmd)
+	var outcomes []Outcome
+	for _, m := range ghOutcomeMatchers {
+		if !strings.Contains(lower, m.command) {
+			continue
+		}
+		match := m.url.FindStringSubmatch(output)
+		if match == nil {
+			continue
+		}
+		outcomes = append(outcomes, Outcome{
+			Kind:       m.kind,
+			URL:        match[0],
+			Repo:       match[1],
+			DetectedBy: OutcomeDetectedByGhCli,
+		})
+	}
+	return outcomes
+}
+
+func isLinearIssueTool(toolName string) bool {
+	lower := strings.ToLower(toolName)
+	if !strings.Contains(lower, "linear") {
+		return false
+	}
+	for _, name := range linearIssueToolNames {
+		if strings.Contains(lower, name) {
+			return true
+		}
+	}
+	return false
+}
+
+// linearIssuePayload is the slice of a Linear MCP issue-create result
+// the matcher reads. The result is JSON text; unknown fields are
+// ignored, and a non-JSON result falls back to a bare URL scan.
+type linearIssuePayload struct {
+	URL   string `json:"url"`
+	Title string `json:"title"`
+}
+
+// detectLinearIssueOutcome extracts the created issue's canonical URL
+// (and title when the payload parses) from a Linear MCP tool result.
+func detectLinearIssueOutcome(output string) []Outcome {
+	outcome := Outcome{
+		Kind:       OutcomeKindLinearIssue,
+		DetectedBy: OutcomeDetectedByMCP,
+	}
+	var payload linearIssuePayload
+	if err := json.Unmarshal([]byte(output), &payload); err == nil && payload.URL != "" {
+		if linearIssueURL.MatchString(payload.URL) {
+			outcome.URL = payload.URL
+			outcome.Title = payload.Title
+		}
+	}
+	if outcome.URL == "" {
+		outcome.URL = linearIssueURL.FindString(output)
+	}
+	if outcome.URL == "" {
+		return nil
+	}
+	if match := linearIssueURL.FindStringSubmatch(outcome.URL); match != nil {
+		// The workspace slug is the closest analogue to owner/name.
+		outcome.Repo = match[1]
+	}
+	return []Outcome{outcome}
+}
+
+// DedupeOutcomes drops repeat detections of the same artifact, keyed by
+// URL, keeping the first occurrence (capture order — the detection
+// closest to the creating call). Re-running a create command or
+// re-printing a URL never double-counts an outcome.
+func DedupeOutcomes(outcomes []Outcome) []Outcome {
+	if len(outcomes) < 2 {
+		return outcomes
+	}
+	seen := make(map[string]struct{}, len(outcomes))
+	deduped := make([]Outcome, 0, len(outcomes))
+	for _, o := range outcomes {
+		if _, dup := seen[o.URL]; dup {
+			continue
+		}
+		seen[o.URL] = struct{}{}
+		deduped = append(deduped, o)
+	}
+	return deduped
+}

--- a/pkg/sessions/outcomes_test.go
+++ b/pkg/sessions/outcomes_test.go
@@ -1,0 +1,149 @@
+package sessions_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/papercomputeco/tapes/pkg/sessions"
+)
+
+var _ = Describe("DetectToolOutcomes", func() {
+	Describe("the gh CLI matcher family", func() {
+		It("detects a pull request from gh pr create stdout", func() {
+			outcomes := sessions.DetectToolOutcomes(
+				"Bash",
+				map[string]any{"command": `gh pr create --title "fix" --body "..."`},
+				"Creating pull request for fix into main\nhttps://github.com/papercomputeco/paper/pull/94\n",
+			)
+			Expect(outcomes).To(HaveLen(1))
+			Expect(outcomes[0].Kind).To(Equal(sessions.OutcomeKindPullRequest))
+			Expect(outcomes[0].URL).To(Equal("https://github.com/papercomputeco/paper/pull/94"))
+			Expect(outcomes[0].Repo).To(Equal("papercomputeco/paper"))
+			Expect(outcomes[0].DetectedBy).To(Equal(sessions.OutcomeDetectedByGhCli))
+		})
+
+		It("detects a repo from gh repo create stdout", func() {
+			outcomes := sessions.DetectToolOutcomes(
+				"Bash",
+				map[string]any{"command": "gh repo create papercomputeco/outcome-detector --private"},
+				"✓ Created repository papercomputeco/outcome-detector on GitHub\nhttps://github.com/papercomputeco/outcome-detector\n",
+			)
+			Expect(outcomes).To(HaveLen(1))
+			Expect(outcomes[0].Kind).To(Equal(sessions.OutcomeKindRepo))
+			Expect(outcomes[0].URL).To(Equal("https://github.com/papercomputeco/outcome-detector"))
+			Expect(outcomes[0].Repo).To(Equal("papercomputeco/outcome-detector"))
+		})
+
+		It("detects an issue from gh issue create stdout", func() {
+			outcomes := sessions.DetectToolOutcomes(
+				"Bash",
+				map[string]any{"command": `gh issue create --title "bug"`},
+				"https://github.com/papercomputeco/tapes/issues/212\n",
+			)
+			Expect(outcomes).To(HaveLen(1))
+			Expect(outcomes[0].Kind).To(Equal(sessions.OutcomeKindIssue))
+			Expect(outcomes[0].Repo).To(Equal("papercomputeco/tapes"))
+		})
+
+		It("matches the command case-insensitively but keeps the URL verbatim", func() {
+			outcomes := sessions.DetectToolOutcomes(
+				"Bash",
+				map[string]any{"command": "GH PR CREATE --fill"},
+				"https://github.com/papercomputeco/paper/pull/95",
+			)
+			Expect(outcomes).To(HaveLen(1))
+			Expect(outcomes[0].URL).To(Equal("https://github.com/papercomputeco/paper/pull/95"))
+		})
+
+		It("yields nothing when the create printed no URL (errored run)", func() {
+			outcomes := sessions.DetectToolOutcomes(
+				"Bash",
+				map[string]any{"command": "gh pr create --fill"},
+				"pull request create failed: GraphQL: was submitted too quickly",
+			)
+			Expect(outcomes).To(BeEmpty())
+		})
+
+		It("yields nothing for unrelated shell commands that merely print a PR URL", func() {
+			outcomes := sessions.DetectToolOutcomes(
+				"Bash",
+				map[string]any{"command": "gh pr view 94"},
+				"https://github.com/papercomputeco/paper/pull/94",
+			)
+			Expect(outcomes).To(BeEmpty())
+		})
+
+		It("yields nothing for a Bash call without a command string", func() {
+			Expect(sessions.DetectToolOutcomes("Bash", map[string]any{}, "output")).To(BeEmpty())
+		})
+	})
+
+	Describe("the MCP matcher family", func() {
+		It("detects a Linear issue from a save_issue result payload", func() {
+			outcomes := sessions.DetectToolOutcomes(
+				"mcp__linear-server__save_issue",
+				map[string]any{"team": "Engineering"},
+				`{"id":"PCC-837","title":"Explore: Outcomes as a feature","url":"https://linear.app/paper-compute-co/issue/PCC-837/explore-outcomes"}`,
+			)
+			Expect(outcomes).To(HaveLen(1))
+			Expect(outcomes[0].Kind).To(Equal(sessions.OutcomeKindLinearIssue))
+			Expect(outcomes[0].URL).To(Equal("https://linear.app/paper-compute-co/issue/PCC-837/explore-outcomes"))
+			Expect(outcomes[0].Title).To(Equal("Explore: Outcomes as a feature"))
+			Expect(outcomes[0].Repo).To(Equal("paper-compute-co"))
+			Expect(outcomes[0].DetectedBy).To(Equal(sessions.OutcomeDetectedByMCP))
+		})
+
+		It("falls back to a bare URL scan when the result is not JSON", func() {
+			outcomes := sessions.DetectToolOutcomes(
+				"mcp__claude_ai_Linear__create_issue",
+				nil,
+				"Created https://linear.app/paper-compute-co/issue/PCC-845 for you.",
+			)
+			Expect(outcomes).To(HaveLen(1))
+			Expect(outcomes[0].URL).To(Equal("https://linear.app/paper-compute-co/issue/PCC-845"))
+		})
+
+		It("yields nothing for non-issue Linear tools", func() {
+			outcomes := sessions.DetectToolOutcomes(
+				"mcp__linear-server__list_issues",
+				nil,
+				`[{"url":"https://linear.app/paper-compute-co/issue/PCC-1"}]`,
+			)
+			Expect(outcomes).To(BeEmpty())
+		})
+
+		It("yields nothing when the result carries no linear issue URL", func() {
+			outcomes := sessions.DetectToolOutcomes(
+				"mcp__linear-server__save_issue",
+				nil,
+				`{"error":"unauthorized"}`,
+			)
+			Expect(outcomes).To(BeEmpty())
+		})
+	})
+
+	It("yields nothing for empty output or unmatched tools", func() {
+		Expect(sessions.DetectToolOutcomes("Bash", map[string]any{"command": "gh pr create"}, "")).To(BeEmpty())
+		Expect(sessions.DetectToolOutcomes("Edit", map[string]any{"file_path": "x"}, "ok")).To(BeEmpty())
+	})
+})
+
+var _ = Describe("DedupeOutcomes", func() {
+	It("drops repeat URLs keeping the first occurrence", func() {
+		first := sessions.Outcome{Kind: sessions.OutcomeKindPullRequest, URL: "https://github.com/o/r/pull/1", SpanID: "tool_1"}
+		repeat := sessions.Outcome{Kind: sessions.OutcomeKindPullRequest, URL: "https://github.com/o/r/pull/1", SpanID: "tool_2"}
+		other := sessions.Outcome{Kind: sessions.OutcomeKindIssue, URL: "https://github.com/o/r/issues/2"}
+
+		deduped := sessions.DedupeOutcomes([]sessions.Outcome{first, repeat, other})
+
+		Expect(deduped).To(HaveLen(2))
+		Expect(deduped[0].SpanID).To(Equal("tool_1"))
+		Expect(deduped[1].URL).To(Equal("https://github.com/o/r/issues/2"))
+	})
+
+	It("passes short slices through untouched", func() {
+		one := []sessions.Outcome{{URL: "u"}}
+		Expect(sessions.DedupeOutcomes(one)).To(Equal(one))
+		Expect(sessions.DedupeOutcomes(nil)).To(BeNil())
+	})
+})

--- a/pkg/storage/postgres/gensqlc/models.go
+++ b/pkg/storage/postgres/gensqlc/models.go
@@ -97,6 +97,7 @@ type Session struct {
 	DerivedTitle      pgtype.Text
 	DerivedModel      string
 	ModelUsage        []byte
+	Outcomes          []byte
 }
 
 type Skill struct {

--- a/pkg/storage/postgres/gensqlc/sessions.sql.go
+++ b/pkg/storage/postgres/gensqlc/sessions.sql.go
@@ -12,7 +12,7 @@ import (
 )
 
 const getSessionByNaturalKey = `-- name: GetSessionByNaturalKey :one
-SELECT id, org_id, auth_subject, harness_id, harness_session_id, name, cwd, harness_version, parent_session_id, started_at, last_seen_at, ended_at, harness_metadata, total_input_tokens, total_output_tokens, total_cost_usd, turn_count, derived_status, has_git_activity, tool_result_count, tool_error_count, derived_title, derived_model, model_usage FROM sessions
+SELECT id, org_id, auth_subject, harness_id, harness_session_id, name, cwd, harness_version, parent_session_id, started_at, last_seen_at, ended_at, harness_metadata, total_input_tokens, total_output_tokens, total_cost_usd, turn_count, derived_status, has_git_activity, tool_result_count, tool_error_count, derived_title, derived_model, model_usage, outcomes FROM sessions
 WHERE org_id = $1
   AND harness_id = $2
   AND harness_session_id = $3
@@ -56,12 +56,13 @@ func (q *Queries) GetSessionByNaturalKey(ctx context.Context, arg GetSessionByNa
 		&i.DerivedTitle,
 		&i.DerivedModel,
 		&i.ModelUsage,
+		&i.Outcomes,
 	)
 	return i, err
 }
 
 const getSessionRecord = `-- name: GetSessionRecord :one
-SELECT id, org_id, auth_subject, harness_id, harness_session_id, name, cwd, harness_version, parent_session_id, started_at, last_seen_at, ended_at, harness_metadata, total_input_tokens, total_output_tokens, total_cost_usd, turn_count, derived_status, has_git_activity, tool_result_count, tool_error_count, derived_title, derived_model, model_usage FROM sessions
+SELECT id, org_id, auth_subject, harness_id, harness_session_id, name, cwd, harness_version, parent_session_id, started_at, last_seen_at, ended_at, harness_metadata, total_input_tokens, total_output_tokens, total_cost_usd, turn_count, derived_status, has_git_activity, tool_result_count, tool_error_count, derived_title, derived_model, model_usage, outcomes FROM sessions
 WHERE org_id = $1 AND id = $2
 `
 
@@ -98,6 +99,7 @@ func (q *Queries) GetSessionRecord(ctx context.Context, arg GetSessionRecordPara
 		&i.DerivedTitle,
 		&i.DerivedModel,
 		&i.ModelUsage,
+		&i.Outcomes,
 	)
 	return i, err
 }
@@ -216,7 +218,7 @@ func (q *Queries) ListNodesBySession(ctx context.Context, sessionID pgtype.UUID)
 }
 
 const listSessionRecords = `-- name: ListSessionRecords :many
-SELECT id, org_id, auth_subject, harness_id, harness_session_id, name, cwd, harness_version, parent_session_id, started_at, last_seen_at, ended_at, harness_metadata, total_input_tokens, total_output_tokens, total_cost_usd, turn_count, derived_status, has_git_activity, tool_result_count, tool_error_count, derived_title, derived_model, model_usage FROM sessions
+SELECT id, org_id, auth_subject, harness_id, harness_session_id, name, cwd, harness_version, parent_session_id, started_at, last_seen_at, ended_at, harness_metadata, total_input_tokens, total_output_tokens, total_cost_usd, turn_count, derived_status, has_git_activity, tool_result_count, tool_error_count, derived_title, derived_model, model_usage, outcomes FROM sessions
 WHERE org_id = $1
   AND ($2::timestamptz IS NULL OR last_seen_at >= $2::timestamptz)
   AND ($3::timestamptz IS NULL OR last_seen_at < $3::timestamptz)
@@ -292,6 +294,7 @@ func (q *Queries) ListSessionRecords(ctx context.Context, arg ListSessionRecords
 			&i.DerivedTitle,
 			&i.DerivedModel,
 			&i.ModelUsage,
+			&i.Outcomes,
 		); err != nil {
 			return nil, err
 		}
@@ -395,6 +398,25 @@ func (q *Queries) UpdateSessionModelUsage(ctx context.Context, arg UpdateSession
 	return err
 }
 
+const updateSessionOutcomes = `-- name: UpdateSessionOutcomes :exec
+UPDATE sessions SET outcomes = $1 WHERE id = $2
+`
+
+type UpdateSessionOutcomesParams struct {
+	Outcomes []byte
+	ID       pgtype.UUID
+}
+
+// Fold the detected outcomes (artifacts the session produced) onto the
+// session (PCC-840). Matched from tool spans in Go at derive time — the
+// matcher registry lives there, not in SQL — so the deriver writes it
+// directly as a JSONB array, deduped by URL. Re-derive overwrites it
+// idempotently.
+func (q *Queries) UpdateSessionOutcomes(ctx context.Context, arg UpdateSessionOutcomesParams) error {
+	_, err := q.db.Exec(ctx, updateSessionOutcomes, arg.Outcomes, arg.ID)
+	return err
+}
+
 const updateSessionStatus = `-- name: UpdateSessionStatus :exec
 UPDATE sessions
    SET has_git_activity  = $1,
@@ -466,7 +488,7 @@ SET last_seen_at     = $10,
     cwd              = COALESCE($7, sessions.cwd),
     harness_version  = COALESCE($8, sessions.harness_version),
     parent_session_id = COALESCE($9, sessions.parent_session_id)
-RETURNING id, org_id, auth_subject, harness_id, harness_session_id, name, cwd, harness_version, parent_session_id, started_at, last_seen_at, ended_at, harness_metadata, total_input_tokens, total_output_tokens, total_cost_usd, turn_count, derived_status, has_git_activity, tool_result_count, tool_error_count, derived_title, derived_model, model_usage
+RETURNING id, org_id, auth_subject, harness_id, harness_session_id, name, cwd, harness_version, parent_session_id, started_at, last_seen_at, ended_at, harness_metadata, total_input_tokens, total_output_tokens, total_cost_usd, turn_count, derived_status, has_git_activity, tool_result_count, tool_error_count, derived_title, derived_model, model_usage, outcomes
 `
 
 type UpsertSessionParams struct {
@@ -539,6 +561,7 @@ func (q *Queries) UpsertSession(ctx context.Context, arg UpsertSessionParams) (S
 		&i.DerivedTitle,
 		&i.DerivedModel,
 		&i.ModelUsage,
+		&i.Outcomes,
 	)
 	return i, err
 }

--- a/pkg/storage/postgres/queries/sessions.sql
+++ b/pkg/storage/postgres/queries/sessions.sql
@@ -178,3 +178,11 @@ UPDATE sessions SET derived_title = sqlc.arg(derived_title) WHERE id = sqlc.arg(
 -- SQL — so the deriver writes it directly as a JSONB array. Re-derive
 -- overwrites it idempotently.
 UPDATE sessions SET model_usage = sqlc.arg(model_usage) WHERE id = sqlc.arg(id);
+
+-- name: UpdateSessionOutcomes :exec
+-- Fold the detected outcomes (artifacts the session produced) onto the
+-- session (PCC-840). Matched from tool spans in Go at derive time — the
+-- matcher registry lives there, not in SQL — so the deriver writes it
+-- directly as a JSONB array, deduped by URL. Re-derive overwrites it
+-- idempotently.
+UPDATE sessions SET outcomes = sqlc.arg(outcomes) WHERE id = sqlc.arg(id);

--- a/pkg/storage/postgres/session_reads.go
+++ b/pkg/storage/postgres/session_reads.go
@@ -267,6 +267,12 @@ func sessionRecordFromRow(row gensqlc.Session) storage.SessionRecord {
 			s.ModelUsage = mu
 		}
 	}
+	if len(row.Outcomes) > 0 {
+		var outcomes []storage.Outcome
+		if err := json.Unmarshal(row.Outcomes, &outcomes); err == nil {
+			s.Outcomes = outcomes
+		}
+	}
 	if row.TotalCostUsd.Valid {
 		if f, err := row.TotalCostUsd.Float64Value(); err == nil && f.Valid {
 			s.TotalCostUsd = f.Float64

--- a/pkg/storage/postgres/spans.go
+++ b/pkg/storage/postgres/spans.go
@@ -217,6 +217,26 @@ func writeSpanSet(
 			return fmt.Errorf("update session model usage: %w", err)
 		}
 	}
+
+	// Detected outcomes (PCC-840): matched from tool spans in Go at
+	// derive time — the matcher registry lives there, not in SQL — so
+	// the fold writes directly as a JSONB array, mirroring ModelUsage.
+	for key, outcomes := range spans.Outcomes {
+		sid, ok := sessionIDs[key]
+		if !ok || !sid.Valid {
+			continue
+		}
+		payload, err := json.Marshal(outcomes)
+		if err != nil {
+			return fmt.Errorf("marshal outcomes: %w", err)
+		}
+		if err := qtx.UpdateSessionOutcomes(ctx, gensqlc.UpdateSessionOutcomesParams{
+			ID:       sid,
+			Outcomes: payload,
+		}); err != nil {
+			return fmt.Errorf("update session outcomes: %w", err)
+		}
+	}
 	return nil
 }
 

--- a/pkg/storage/session_record.go
+++ b/pkg/storage/session_record.go
@@ -34,7 +34,13 @@ type SessionRecord struct {
 	// share reflects spend rather than call count. Nil until the session
 	// derives; ordered dominant-model-first (by cost).
 	ModelUsage []ModelUsage
-	Preview    string // first user turn text, truncated; empty when unavailable
+	// Outcomes is the fold of artifacts the session produced (pull
+	// requests / repos / issues), detected from tool spans at derive
+	// time (sessions.outcomes), deduped by URL with trace/span
+	// provenance. Nil until the session derives (or when it produced
+	// nothing).
+	Outcomes []Outcome
+	Preview  string // first user turn text, truncated; empty when unavailable
 	// AuthSubject is the gateway-stamped JWT subject (the WorkOS user id)
 	// captured at ingest. Empty for rows captured before the edge began
 	// stamping the x-paper-auth-subject header.
@@ -51,6 +57,23 @@ type ModelUsage struct {
 	InputTokens  int64   `json:"input_tokens"`
 	OutputTokens int64   `json:"output_tokens"`
 	CostUSD      float64 `json:"cost_usd"`
+}
+
+// Outcome is one artifact a session produced, as stored on the session
+// row (sessions.outcomes). URL is the artifact's identity; trace/span
+// ids point back at the detecting tool span, and detected_at carries
+// that span's start time so re-derive is reproducible. JSON tags mirror
+// pkg/sessions.Outcome — the deriver marshals that type into the column
+// this one unmarshals.
+type Outcome struct {
+	Kind       string    `json:"kind"`
+	URL        string    `json:"url"`
+	Title      string    `json:"title,omitempty"`
+	Repo       string    `json:"repo,omitempty"`
+	TraceID    string    `json:"trace_id,omitempty"`
+	SpanID     string    `json:"span_id,omitempty"`
+	DetectedBy string    `json:"detected_by,omitempty"`
+	DetectedAt time.Time `json:"detected_at,omitzero"`
 }
 
 // SessionListOpts parameterizes the sessions-list read: keyset cursor


### PR DESCRIPTION
Sessions now carry the artifacts they produced — **pull requests, repos, GitHub issues, Linear issues** — folded from tool spans at derive time. Implements [PCC-840](https://linear.app/paper-compute-co/issue/PCC-840/outcome-model-matcher-registry-in-tapes), the keystone of the [PCC-837](https://linear.app/paper-compute-co/issue/PCC-837/explore-outcomes-as-a-feature-detecting-whether-a-session-produced) outcomes exploration ("did this long/expensive session produce anything?").

## Design

- **Matcher registry** (`pkg/sessions/outcomes.go`), two families:
  - **Bash/`gh`**: `gh pr create` / `gh repo create` / `gh issue create`, gated on the command string, artifact URL parsed from the tool output. Conservative: no URL in output (errored/interrupted create) → no outcome. `gh pr view` printing a URL doesn't count.
  - **MCP**: Linear issue-create tools (`*linear*save_issue`/`create_issue`), URL + title from the result payload, JSON-first with a bare-URL fallback.
  - `kind` is an open set; adding a detected artifact type is one table row.
- **Fold mirrors `model_usage`**: `EmitSpans` folds per-session outcomes (deduped by URL, capture order) into the `SpanSet`; `writeSpanSet` persists `sessions.outcomes JSONB`; `SessionRecord` → `SessionItem` expose it on `GET /v1/sessions[{id}]`.
- **Provenance**: each outcome carries `trace_id`/`span_id` of the detecting tool span — deliberately matching the simulacrum memory stream's source-pointer convention (pcc-labs/tapes-simulacrum) so a future observation/dream can cite "this session shipped PR X" with evidence. `detected_at` is the detecting span's start time, **never the wall clock**, so re-derive reproduces the fold byte-for-byte.
- **No backfill by design** (PCC-837 decision): pre-migration rows carry NULL until their next organic derive pass; the admin re-derive endpoint can opt a session in.

## Consumers already speaking this shape

- `paper recap <trace_id>` CLI + paperd (control-proto v17) decode `session.outcomes` with tolerant defaults — outcomes light up there the moment this merges.
- Console `OutcomesSection`/`RecapCard` (console.papercompute.com#146/#147) render the same wire shape, including the explicit "No outcome recorded" empty state.

## Test plan

- `go test ./pkg/sessions/ ./pkg/derive/ ./api/` — new Ginkgo specs cover every matcher (success, errored create, case-insensitivity, non-create commands, JSON + bare-URL Linear payloads, non-issue Linear tools), URL dedup, and the derive fold's provenance stamping + cross-turn dedup + empty-fold case.
- Postgres integration suites run in CI via the Dagger services environment (`make test`) — locally confirmed pre-existing-green packages stay green; `sqlc generate` + `make swag` outputs committed.
- Migration follows the `derived_model`/`model_usage` additive-JSONB pattern; down migration drops the column.

part of PCC-837 · implements PCC-840

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Moncs7rC9gx5gWnCNgWyz5