### PR TITLE
✨ feat: (api) add GET /v1/stats/skills skill-invocation aggregate (PCC-852)

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -80,6 +80,7 @@ func NewServer(config Config, driver storage.Driver, log *slog.Logger) (*Server,
 	// span projection beneath them. Static paths are registered before
 	// parameterised ones.
 	app.Get("/v1/stats", s.handleStats)
+	app.Get("/v1/stats/skills", s.handleSkillUsageStats)
 	app.Get("/v1/sessions", s.handleListSessions)
 	app.Get("/v1/sessions/:id/traces", s.handleGetSessionTraces)
 	app.Get("/v1/sessions/:id/raw_turns", s.handleListSessionRawTurns)

--- a/api/v1_handlers.go
+++ b/api/v1_handlers.go
@@ -124,6 +124,70 @@ func (s *Server) handleStats(c *fiber.Ctx) error {
 	})
 }
 
+// SkillUsageItem is one skill's invocation rollup in the
+// /v1/stats/skills response. Skill is the name string the harness
+// invoked (tool_input.skill) — it is not guaranteed to match a skills
+// record; consumers join on slug and tolerate unmatched names.
+type SkillUsageItem struct {
+	Skill                 string    `json:"skill"`
+	Invocations           int       `json:"invocations"`
+	ErrorCount            int       `json:"error_count"`
+	SessionCount          int       `json:"session_count"`
+	CompletedSessionCount int       `json:"completed_session_count"`
+	LastUsedAt            time.Time `json:"last_used_at"`
+}
+
+// SkillUsageResponse is the response for GET /v1/stats/skills.
+type SkillUsageResponse struct {
+	Skills           []SkillUsageItem `json:"skills"`
+	TotalInvocations int              `json:"total_invocations"`
+}
+
+// handleSkillUsageStats handles GET /v1/stats/skills.
+//
+//	@Summary		Get skill invocation stats
+//	@Description	Returns skill invocations grouped by skill name for the window, ordered by invocation count. An invocation is a Skill tool call captured in the span projection; counts are per unique tool_use, so re-sent conversation history never inflates them. Each row carries the sessions the skill appeared in and how many of those sessions completed, so usage reads against session outcomes. Skill names are the strings harnesses invoked and may not match a skills-library record.
+//	@Tags			sessions
+//	@Produce		json
+//	@Param			since	query		string	false	"Only include invocations at or after this RFC3339 timestamp"	format(date-time)
+//	@Param			until	query		string	false	"Only include invocations before this RFC3339 timestamp"		format(date-time)
+//	@Success		200		{object}	SkillUsageResponse
+//	@Failure		400		{object}	llm.ErrorResponse	"Invalid query parameters"
+//	@Failure		500		{object}	llm.ErrorResponse	"Failed to compute skill usage"
+//	@Failure		501		{object}	llm.ErrorResponse	"Skill usage stats not supported by this backend"
+//	@Router			/v1/stats/skills [get]
+func (s *Server) handleSkillUsageStats(c *fiber.Ctx) error {
+	reader, ok := s.driver.(storage.SkillUsageReader)
+	if !ok {
+		return c.Status(fiber.StatusNotImplemented).JSON(llm.ErrorResponse{Error: "skill usage stats not supported by this backend"})
+	}
+
+	opts, err := parseListOpts(c)
+	if err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(llm.ErrorResponse{Error: err.Error()})
+	}
+
+	usage, err := reader.AggregateSkillUsage(c.Context(), orgIDFromCtx(c), opts.Since, opts.Until)
+	if err != nil {
+		s.logger.Error("aggregate skill usage", "error", err)
+		return c.Status(fiber.StatusInternalServerError).JSON(llm.ErrorResponse{Error: "failed to compute skill usage"})
+	}
+
+	resp := SkillUsageResponse{Skills: make([]SkillUsageItem, 0, len(usage))}
+	for _, u := range usage {
+		resp.Skills = append(resp.Skills, SkillUsageItem{
+			Skill:                 u.Skill,
+			Invocations:           u.Invocations,
+			ErrorCount:            u.ErrorCount,
+			SessionCount:          u.SessionCount,
+			CompletedSessionCount: u.CompletedSessionCount,
+			LastUsedAt:            u.LastUsedAt,
+		})
+		resp.TotalInvocations += u.Invocations
+	}
+	return c.JSON(resp)
+}
+
 // totalCostFromPerModel folds the driver's per-model token rollup into a
 // single USD total via the pricing table. Models the table doesn't price
 // (e.g. unrecognized provider strings) contribute zero — same fall-through

--- a/api/v1_handlers_test.go
+++ b/api/v1_handlers_test.go
@@ -279,3 +279,105 @@ func decodeStats(server *Server, path string) StatsResponse {
 	Expect(json.Unmarshal(raw, &body)).To(Succeed())
 	return body
 }
+
+// stubSkillUsageDriver decorates a storage.Driver with the
+// storage.SkillUsageReader capability so handler tests can exercise
+// the span-only /v1/stats/skills path without a span-projection store.
+type stubSkillUsageDriver struct {
+	storage.Driver
+	usage []storage.SkillUsage
+	since *time.Time
+	until *time.Time
+}
+
+func (d *stubSkillUsageDriver) AggregateSkillUsage(_ context.Context, _ string, since, until *time.Time) ([]storage.SkillUsage, error) {
+	d.since = since
+	d.until = until
+	return d.usage, nil
+}
+
+var _ = Describe("GET /v1/stats/skills", func() {
+	var logger = tapeslogger.NewNoop()
+
+	get := func(server *Server, path string) *http.Response {
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, path, nil)
+		Expect(err).NotTo(HaveOccurred())
+		resp, err := server.app.Test(req)
+		Expect(err).NotTo(HaveOccurred())
+		return resp
+	}
+
+	It("returns 501 when the backend lacks the skill-usage capability", func() {
+		server, err := NewServer(Config{ListenAddr: ":0"}, inmemory.NewDriver(), logger)
+		Expect(err).NotTo(HaveOccurred())
+
+		resp := get(server, "/v1/stats/skills")
+		defer resp.Body.Close()
+		Expect(resp.StatusCode).To(Equal(fiber.StatusNotImplemented))
+	})
+
+	Context("with a skill-usage-capable backend", func() {
+		var (
+			driver *stubSkillUsageDriver
+			server *Server
+		)
+
+		BeforeEach(func() {
+			driver = &stubSkillUsageDriver{Driver: inmemory.NewDriver()}
+			var err error
+			server, err = NewServer(Config{ListenAddr: ":0"}, driver, logger)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		decode := func(path string) SkillUsageResponse {
+			resp := get(server, path)
+			defer resp.Body.Close()
+			Expect(resp.StatusCode).To(Equal(fiber.StatusOK))
+			var body SkillUsageResponse
+			raw, err := io.ReadAll(resp.Body)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(json.Unmarshal(raw, &body)).To(Succeed())
+			return body
+		}
+
+		It("returns per-skill rollups and folds total_invocations", func() {
+			lastUsed := time.Date(2026, 7, 7, 12, 0, 0, 0, time.UTC)
+			driver.usage = []storage.SkillUsage{
+				{Skill: "grove-refresh", Invocations: 12, ErrorCount: 1, SessionCount: 8, CompletedSessionCount: 6, LastUsedAt: lastUsed},
+				{Skill: "dagger-check", Invocations: 3, SessionCount: 3, CompletedSessionCount: 2, LastUsedAt: lastUsed},
+			}
+
+			body := decode("/v1/stats/skills")
+			Expect(body.TotalInvocations).To(Equal(15))
+			Expect(body.Skills).To(HaveLen(2))
+			Expect(body.Skills[0].Skill).To(Equal("grove-refresh"))
+			Expect(body.Skills[0].Invocations).To(Equal(12))
+			Expect(body.Skills[0].ErrorCount).To(Equal(1))
+			Expect(body.Skills[0].SessionCount).To(Equal(8))
+			Expect(body.Skills[0].CompletedSessionCount).To(Equal(6))
+			Expect(body.Skills[0].LastUsedAt).To(Equal(lastUsed))
+			Expect(body.Skills[1].Skill).To(Equal("dagger-check"))
+		})
+
+		It("returns an empty list, not null, when no skills were invoked", func() {
+			body := decode("/v1/stats/skills")
+			Expect(body.Skills).NotTo(BeNil())
+			Expect(body.Skills).To(BeEmpty())
+			Expect(body.TotalInvocations).To(BeZero())
+		})
+
+		It("passes the since/until window through to the reader", func() {
+			decode("/v1/stats/skills?since=2026-07-01T00:00:00Z&until=2026-07-07T00:00:00Z")
+			Expect(driver.since).NotTo(BeNil())
+			Expect(driver.since.Format(time.RFC3339)).To(Equal("2026-07-01T00:00:00Z"))
+			Expect(driver.until).NotTo(BeNil())
+			Expect(driver.until.Format(time.RFC3339)).To(Equal("2026-07-07T00:00:00Z"))
+		})
+
+		It("rejects a malformed since timestamp", func() {
+			resp := get(server, "/v1/stats/skills?since=yesterday")
+			defer resp.Body.Close()
+			Expect(resp.StatusCode).To(Equal(fiber.StatusBadRequest))
+		})
+	})
+})

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -557,6 +557,60 @@ const docTemplate = `{
                 }
             }
         },
+        "/v1/stats/skills": {
+            "get": {
+                "description": "Returns skill invocations grouped by skill name for the window, ordered by invocation count. An invocation is a Skill tool call captured in the span projection; counts are per unique tool_use, so re-sent conversation history never inflates them. Each row carries the sessions the skill appeared in and how many of those sessions completed, so usage reads against session outcomes. Skill names are the strings harnesses invoked and may not match a skills-library record.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "sessions"
+                ],
+                "summary": "Get skill invocation stats",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Only include invocations at or after this RFC3339 timestamp",
+                        "name": "since",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Only include invocations before this RFC3339 timestamp",
+                        "name": "until",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.SkillUsageResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid query parameters",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_papercomputeco_tapes_pkg_llm.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Failed to compute skill usage",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_papercomputeco_tapes_pkg_llm.ErrorResponse"
+                        }
+                    },
+                    "501": {
+                        "description": "Skill usage stats not supported by this backend",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_papercomputeco_tapes_pkg_llm.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/v1/traces": {
             "get": {
                 "description": "Returns turn headers for a session — no span payloads. Fetch GET /v1/traces/{trace_id} per turn for spans and links.",
@@ -902,6 +956,43 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/api.TraceDetail"
                     }
+                }
+            }
+        },
+        "api.SkillUsageItem": {
+            "type": "object",
+            "properties": {
+                "completed_session_count": {
+                    "type": "integer"
+                },
+                "error_count": {
+                    "type": "integer"
+                },
+                "invocations": {
+                    "type": "integer"
+                },
+                "last_used_at": {
+                    "type": "string"
+                },
+                "session_count": {
+                    "type": "integer"
+                },
+                "skill": {
+                    "type": "string"
+                }
+            }
+        },
+        "api.SkillUsageResponse": {
+            "type": "object",
+            "properties": {
+                "skills": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/api.SkillUsageItem"
+                    }
+                },
+                "total_invocations": {
+                    "type": "integer"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -553,6 +553,60 @@
                 }
             }
         },
+        "/v1/stats/skills": {
+            "get": {
+                "description": "Returns skill invocations grouped by skill name for the window, ordered by invocation count. An invocation is a Skill tool call captured in the span projection; counts are per unique tool_use, so re-sent conversation history never inflates them. Each row carries the sessions the skill appeared in and how many of those sessions completed, so usage reads against session outcomes. Skill names are the strings harnesses invoked and may not match a skills-library record.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "sessions"
+                ],
+                "summary": "Get skill invocation stats",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Only include invocations at or after this RFC3339 timestamp",
+                        "name": "since",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Only include invocations before this RFC3339 timestamp",
+                        "name": "until",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.SkillUsageResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid query parameters",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_papercomputeco_tapes_pkg_llm.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Failed to compute skill usage",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_papercomputeco_tapes_pkg_llm.ErrorResponse"
+                        }
+                    },
+                    "501": {
+                        "description": "Skill usage stats not supported by this backend",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_papercomputeco_tapes_pkg_llm.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/v1/traces": {
             "get": {
                 "description": "Returns turn headers for a session — no span payloads. Fetch GET /v1/traces/{trace_id} per turn for spans and links.",
@@ -898,6 +952,43 @@
                     "items": {
                         "$ref": "#/definitions/api.TraceDetail"
                     }
+                }
+            }
+        },
+        "api.SkillUsageItem": {
+            "type": "object",
+            "properties": {
+                "completed_session_count": {
+                    "type": "integer"
+                },
+                "error_count": {
+                    "type": "integer"
+                },
+                "invocations": {
+                    "type": "integer"
+                },
+                "last_used_at": {
+                    "type": "string"
+                },
+                "session_count": {
+                    "type": "integer"
+                },
+                "skill": {
+                    "type": "string"
+                }
+            }
+        },
+        "api.SkillUsageResponse": {
+            "type": "object",
+            "properties": {
+                "skills": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/api.SkillUsageItem"
+                    }
+                },
+                "total_invocations": {
+                    "type": "integer"
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -138,6 +138,30 @@ definitions:
           $ref: '#/definitions/api.TraceDetail'
         type: array
     type: object
+  api.SkillUsageItem:
+    properties:
+      completed_session_count:
+        type: integer
+      error_count:
+        type: integer
+      invocations:
+        type: integer
+      last_used_at:
+        type: string
+      session_count:
+        type: integer
+      skill:
+        type: string
+    type: object
+  api.SkillUsageResponse:
+    properties:
+      skills:
+        items:
+          $ref: '#/definitions/api.SkillUsageItem'
+        type: array
+      total_invocations:
+        type: integer
+    type: object
   api.SpanItem:
     properties:
       children_ids:
@@ -815,6 +839,48 @@ paths:
           schema:
             $ref: '#/definitions/github_com_papercomputeco_tapes_pkg_llm.ErrorResponse'
       summary: Get aggregate session stats
+      tags:
+      - sessions
+  /v1/stats/skills:
+    get:
+      description: Returns skill invocations grouped by skill name for the window,
+        ordered by invocation count. An invocation is a Skill tool call captured in
+        the span projection; counts are per unique tool_use, so re-sent conversation
+        history never inflates them. Each row carries the sessions the skill appeared
+        in and how many of those sessions completed, so usage reads against session
+        outcomes. Skill names are the strings harnesses invoked and may not match
+        a skills-library record.
+      parameters:
+      - description: Only include invocations at or after this RFC3339 timestamp
+        format: date-time
+        in: query
+        name: since
+        type: string
+      - description: Only include invocations before this RFC3339 timestamp
+        format: date-time
+        in: query
+        name: until
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.SkillUsageResponse'
+        "400":
+          description: Invalid query parameters
+          schema:
+            $ref: '#/definitions/github_com_papercomputeco_tapes_pkg_llm.ErrorResponse'
+        "500":
+          description: Failed to compute skill usage
+          schema:
+            $ref: '#/definitions/github_com_papercomputeco_tapes_pkg_llm.ErrorResponse'
+        "501":
+          description: Skill usage stats not supported by this backend
+          schema:
+            $ref: '#/definitions/github_com_papercomputeco_tapes_pkg_llm.ErrorResponse'
+      summary: Get skill invocation stats
       tags:
       - sessions
   /v1/traces:

--- a/pkg/storage/postgres/gensqlc/spans.sql.go
+++ b/pkg/storage/postgres/gensqlc/spans.sql.go
@@ -11,6 +11,79 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const aggregateSkillUsage = `-- name: AggregateSkillUsage :many
+SELECT
+    (sp.input->0->'tool_input'->>'skill')::text             AS skill,
+    COUNT(*)::bigint                                        AS invocations,
+    COUNT(*) FILTER (WHERE sp.status = 'error')::bigint     AS error_count,
+    COUNT(DISTINCT sp.session_id)::bigint                   AS session_count,
+    COUNT(DISTINCT sp.session_id) FILTER (
+        WHERE EXISTS (
+            SELECT 1 FROM sessions s
+            WHERE s.id = sp.session_id AND s.derived_status = 'completed'
+        )
+    )::bigint                                               AS completed_session_count,
+    MAX(sp.started_at)::timestamptz                         AS last_used_at
+FROM spans_20260615 sp
+WHERE sp.org_id = $1
+  AND sp.kind = 'tool'
+  AND sp.name = 'Skill'
+  AND sp.input->0->'tool_input'->>'skill' IS NOT NULL
+  AND ($2::timestamptz IS NULL OR sp.started_at >= $2::timestamptz)
+  AND ($3::timestamptz IS NULL OR sp.started_at < $3::timestamptz)
+GROUP BY 1
+ORDER BY invocations DESC, skill ASC
+`
+
+type AggregateSkillUsageParams struct {
+	OrgID       pgtype.UUID
+	SinceFilter pgtype.Timestamptz
+	UntilFilter pgtype.Timestamptz
+}
+
+type AggregateSkillUsageRow struct {
+	Skill                 string
+	Invocations           int64
+	ErrorCount            int64
+	SessionCount          int64
+	CompletedSessionCount int64
+	LastUsedAt            pgtype.Timestamptz
+}
+
+// /v1/stats/skills: skill invocations grouped by skill name over a
+// time window (PCC-852). A Claude Code skill invocation is a tool span
+// named 'Skill' whose input block carries the skill name at
+// tool_input.skill; the deriver keys spans on tool_use_id, so counts
+// are per unique invocation and re-sent history never inflates them.
+// Sessions with derived_status = 'completed' feed the per-skill
+// completed split so usage can be read against session outcomes.
+func (q *Queries) AggregateSkillUsage(ctx context.Context, arg AggregateSkillUsageParams) ([]AggregateSkillUsageRow, error) {
+	rows, err := q.db.Query(ctx, aggregateSkillUsage, arg.OrgID, arg.SinceFilter, arg.UntilFilter)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []AggregateSkillUsageRow
+	for rows.Next() {
+		var i AggregateSkillUsageRow
+		if err := rows.Scan(
+			&i.Skill,
+			&i.Invocations,
+			&i.ErrorCount,
+			&i.SessionCount,
+			&i.CompletedSessionCount,
+			&i.LastUsedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const aggregateSpanStats = `-- name: AggregateSpanStats :one
 WITH matched AS (
     SELECT t.org_id, t.trace_id, t.session_id, t.synthetic, t.duration_ns,

--- a/pkg/storage/postgres/queries/spans.sql
+++ b/pkg/storage/postgres/queries/spans.sql
@@ -267,3 +267,33 @@ SELECT
        AND (sqlc.narg(until_filter)::timestamptz IS NULL OR sp.started_at < sqlc.narg(until_filter)::timestamptz)
     )::bigint                                               AS tool_calls
 FROM matched;
+
+-- name: AggregateSkillUsage :many
+-- /v1/stats/skills: skill invocations grouped by skill name over a
+-- time window (PCC-852). A Claude Code skill invocation is a tool span
+-- named 'Skill' whose input block carries the skill name at
+-- tool_input.skill; the deriver keys spans on tool_use_id, so counts
+-- are per unique invocation and re-sent history never inflates them.
+-- Sessions with derived_status = 'completed' feed the per-skill
+-- completed split so usage can be read against session outcomes.
+SELECT
+    (sp.input->0->'tool_input'->>'skill')::text             AS skill,
+    COUNT(*)::bigint                                        AS invocations,
+    COUNT(*) FILTER (WHERE sp.status = 'error')::bigint     AS error_count,
+    COUNT(DISTINCT sp.session_id)::bigint                   AS session_count,
+    COUNT(DISTINCT sp.session_id) FILTER (
+        WHERE EXISTS (
+            SELECT 1 FROM sessions s
+            WHERE s.id = sp.session_id AND s.derived_status = 'completed'
+        )
+    )::bigint                                               AS completed_session_count,
+    MAX(sp.started_at)::timestamptz                         AS last_used_at
+FROM spans_20260615 sp
+WHERE sp.org_id = sqlc.arg(org_id)
+  AND sp.kind = 'tool'
+  AND sp.name = 'Skill'
+  AND sp.input->0->'tool_input'->>'skill' IS NOT NULL
+  AND (sqlc.narg(since_filter)::timestamptz IS NULL OR sp.started_at >= sqlc.narg(since_filter)::timestamptz)
+  AND (sqlc.narg(until_filter)::timestamptz IS NULL OR sp.started_at < sqlc.narg(until_filter)::timestamptz)
+GROUP BY 1
+ORDER BY invocations DESC, skill ASC;

--- a/pkg/storage/postgres/skill_usage_test.go
+++ b/pkg/storage/postgres/skill_usage_test.go
@@ -1,0 +1,162 @@
+package postgres_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/papercomputeco/tapes/pkg/sessions"
+	"github.com/papercomputeco/tapes/pkg/storage"
+	"github.com/papercomputeco/tapes/pkg/storage/postgres"
+)
+
+var _ = Describe("Driver.AggregateSkillUsage", func() {
+	var (
+		driver *postgres.Driver
+		ctx    context.Context
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		dsn, err := testPostgresDSN()
+		Expect(err).NotTo(HaveOccurred())
+
+		driver, err = postgres.NewDriver(ctx, dsn)
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = driver.DB().Exec(ctx, "TRUNCATE TABLE raw_turns RESTART IDENTITY")
+		Expect(err).NotTo(HaveOccurred())
+		_, err = driver.DB().Exec(ctx, "TRUNCATE TABLE nodes")
+		Expect(err).NotTo(HaveOccurred())
+		_, err = driver.DB().Exec(ctx, "TRUNCATE TABLE sessions CASCADE")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		if driver != nil {
+			driver.Close()
+		}
+	})
+
+	// mintSession creates the sessions row for the harness identity the
+	// way production ingest does — the span projection only writes rows
+	// for resolved sessions, so raw turns alone are not enough.
+	mintSession := func(orgID, harnessSessionID string) {
+		ingester, ok := storage.Driver(driver).(storage.SessionIngester)
+		Expect(ok).To(BeTrue(), "postgres driver must satisfy SessionIngester")
+		_, err := ingester.IngestTurn(ctx, storage.IngestTurnRequest{
+			Session: &sessions.IngestEnvelope{
+				OrgID:            orgID,
+				AuthSubject:      "subject-skill-usage",
+				HarnessID:        "claude-code",
+				HarnessSessionID: harnessSessionID,
+			},
+			Nodes: sessionFixture("skill usage seed " + harnessSessionID),
+		})
+		Expect(err).NotTo(HaveOccurred())
+	}
+
+	// seedSkillTurn captures one wire turn whose assistant response
+	// invokes the Skill tool (plus a Bash call as non-skill noise), the
+	// same reduced ChatResponse shape the extproc dispatches. Spans are
+	// projected from these rows by RederiveFromRaw below — the same
+	// path production takes — so the assertions cover both the
+	// emitter's Skill span contract and the aggregate SQL.
+	seedSkillTurn := func(orgID, harnessSessionID, requestID, toolUseID, skill string) {
+		response := fmt.Sprintf(`{"model":"claude-test","message":{"role":"assistant","content":[`+
+			`{"type":"text","text":"invoking the skill"},`+
+			`{"type":"tool_use","tool_use_id":%q,"tool_name":"Skill","tool_input":{"skill":%q}},`+
+			`{"type":"tool_use","tool_use_id":"%s_noise","tool_name":"Bash","tool_input":{"command":"ls"}}`+
+			`]},"stop_reason":"tool_use"}`, toolUseID, skill, toolUseID)
+		envelope := fmt.Sprintf(`{"org_id":%q,"harness_id":"claude-code","harness_session_id":%q}`, orgID, harnessSessionID)
+
+		inserted, err := driver.PutRawTurn(ctx, storage.RawTurnRecord{
+			OrgID:            orgID,
+			Source:           storage.RawTurnSourceWire,
+			Provider:         "anthropic",
+			AgentName:        "claude",
+			HarnessID:        "claude-code",
+			HarnessSessionID: harnessSessionID,
+			RequestID:        requestID,
+			// stream + a non-empty tool set classify the call as a main
+			// conversation turn (ClassifyCall) so the span projection
+			// covers it — the same shape a real harness call has.
+			RawRequest:       json.RawMessage(`{"model":"claude-test","max_tokens":4096,"stream":true,"tools":[{"name":"Skill","description":"Execute a skill","input_schema":{"type":"object"}},{"name":"Bash","description":"Run a command","input_schema":{"type":"object"}}],"messages":[{"role":"user","content":"please run the skill"}]}`),
+			Response:         json.RawMessage(response),
+			Meta:             json.RawMessage(`{"request_id":"` + requestID + `","model":"claude-test","stream":"false","upstream_status":200}`),
+			SessionEnvelope:  json.RawMessage(envelope),
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(inserted).To(BeTrue())
+	}
+
+	It("groups Skill invocations by skill name, scoped to org and window", func() {
+		orgA := newTestOrgID()
+		orgB := newTestOrgID()
+
+		// Org A: two grove-refresh invocations in one session, one
+		// dagger-check in another. Org B: one grove-refresh.
+		mintSession(orgA, "sess-a1")
+		mintSession(orgA, "sess-a2")
+		mintSession(orgB, "sess-b1")
+		seedSkillTurn(orgA, "sess-a1", "req-a1", "toolu_a1", "grove-refresh")
+		seedSkillTurn(orgA, "sess-a1", "req-a2", "toolu_a2", "grove-refresh")
+		seedSkillTurn(orgA, "sess-a2", "req-a3", "toolu_a3", "dagger-check")
+		seedSkillTurn(orgB, "sess-b1", "req-b1", "toolu_b1", "grove-refresh")
+
+		_, err := driver.RederiveFromRaw(ctx, "")
+		Expect(err).NotTo(HaveOccurred())
+
+		usage, err := driver.AggregateSkillUsage(ctx, orgA, nil, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(usage).To(HaveLen(2), "Bash noise spans and org B rows must not leak in")
+
+		Expect(usage[0].Skill).To(Equal("grove-refresh"), "most-invoked skill first")
+		Expect(usage[0].Invocations).To(Equal(2))
+		Expect(usage[0].SessionCount).To(Equal(1))
+		Expect(usage[0].LastUsedAt).NotTo(BeZero())
+
+		Expect(usage[1].Skill).To(Equal("dagger-check"))
+		Expect(usage[1].Invocations).To(Equal(1))
+		Expect(usage[1].SessionCount).To(Equal(1))
+
+		// Org isolation: org B sees only its own invocation.
+		usageB, err := driver.AggregateSkillUsage(ctx, orgB, nil, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(usageB).To(HaveLen(1))
+		Expect(usageB[0].Skill).To(Equal("grove-refresh"))
+		Expect(usageB[0].Invocations).To(Equal(1))
+
+		// Window filtering: a window entirely in the future is empty, a
+		// broad window returns everything.
+		future := time.Now().Add(time.Hour)
+		empty, err := driver.AggregateSkillUsage(ctx, orgA, &future, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(empty).To(BeEmpty())
+
+		past := time.Now().Add(-time.Hour)
+		windowed, err := driver.AggregateSkillUsage(ctx, orgA, &past, &future)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(windowed).To(HaveLen(2))
+	})
+
+	It("is idempotent across re-derives — counts stay per unique invocation", func() {
+		orgID := newTestOrgID()
+		mintSession(orgID, "sess-1")
+		seedSkillTurn(orgID, "sess-1", "req-1", "toolu_1", "grove-refresh")
+
+		_, err := driver.RederiveFromRaw(ctx, "")
+		Expect(err).NotTo(HaveOccurred())
+		_, err = driver.RederiveFromRaw(ctx, "")
+		Expect(err).NotTo(HaveOccurred())
+
+		usage, err := driver.AggregateSkillUsage(ctx, orgID, nil, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(usage).To(HaveLen(1))
+		Expect(usage[0].Invocations).To(Equal(1), "re-derive must upsert, not duplicate")
+	})
+})

--- a/pkg/storage/postgres/spans.go
+++ b/pkg/storage/postgres/spans.go
@@ -506,6 +506,42 @@ func (d *Driver) AggregateSpanStats(ctx context.Context, orgID string, since, un
 	return stats, nil
 }
 
+// AggregateSkillUsage groups Skill tool spans by invoked skill name
+// over a time window — the aggregate behind /v1/stats/skills.
+// Implements storage.SkillUsageReader.
+func (d *Driver) AggregateSkillUsage(ctx context.Context, orgID string, since, until *time.Time) ([]storage.SkillUsage, error) {
+	if d == nil || d.conn == nil {
+		return nil, errors.New("postgres driver not open")
+	}
+	org, err := orgIDFromString(orgKeyForLookup(orgID))
+	if err != nil {
+		return nil, fmt.Errorf("decode org_id: %w", err)
+	}
+	rows, err := d.q.AggregateSkillUsage(ctx, gensqlc.AggregateSkillUsageParams{
+		OrgID:       org,
+		SinceFilter: nullTimePtr(since),
+		UntilFilter: nullTimePtr(until),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("aggregate skill usage: %w", err)
+	}
+	usage := make([]storage.SkillUsage, 0, len(rows))
+	for _, row := range rows {
+		u := storage.SkillUsage{
+			Skill:                 row.Skill,
+			Invocations:           int(row.Invocations),
+			ErrorCount:            int(row.ErrorCount),
+			SessionCount:          int(row.SessionCount),
+			CompletedSessionCount: int(row.CompletedSessionCount),
+		}
+		if row.LastUsedAt.Valid {
+			u.LastUsedAt = row.LastUsedAt.Time
+		}
+		usage = append(usage, u)
+	}
+	return usage, nil
+}
+
 // ListRawTurnHeaders returns the wire log for one session: capture
 // identity and payload sizes, no blobs. Implements
 // storage.SpanModelReader.

--- a/pkg/storage/span_model.go
+++ b/pkg/storage/span_model.go
@@ -126,3 +126,24 @@ type SpanStats struct {
 type SpanStatsReader interface {
 	AggregateSpanStats(ctx context.Context, orgID string, since, until *time.Time) (SpanStats, error)
 }
+
+// SkillUsage is one skill's invocation rollup behind /v1/stats/skills:
+// tool spans named 'Skill' grouped by the invoked skill name over a
+// time window. Skill is the name string the harness invoked
+// (tool_input.skill) — it is not guaranteed to match a skills-table
+// record; callers join on slug and tolerate unmatched names.
+type SkillUsage struct {
+	Skill                 string
+	Invocations           int
+	ErrorCount            int
+	SessionCount          int
+	CompletedSessionCount int
+	LastUsedAt            time.Time
+}
+
+// SkillUsageReader is the capability interface for skill-invocation
+// stats. Only span-projection backends can serve it: skill invocations
+// are tool spans, so there is no node-layer fallback.
+type SkillUsageReader interface {
+	AggregateSkillUsage(ctx context.Context, orgID string, since, until *time.Time) ([]SkillUsage, error)
+}


### PR DESCRIPTION
## What

Adds the read-side aggregate for skill-usage insights ([PCC-852](https://linear.app/paper-compute-co/issue/PCC-852/skill-insights)): `GET /v1/stats/skills?since&until` returns skill invocations grouped by skill name for the org's window, ordered by invocation count.

```json
{
  "skills": [
    {"skill": "grove-refresh", "invocations": 12, "error_count": 1,
     "session_count": 8, "completed_session_count": 6,
     "last_used_at": "2026-07-07T12:00:00Z"}
  ],
  "total_invocations": 15
}
```

## How

Skill invocations are already captured: a Claude Code skill call is a tool span with `name='Skill'` and the skill name at `input->0->'tool_input'->>'skill'` (`pkg/derive/spans.go` emit path). This PR adds no capture or derive changes — detection is query-time only, so it works over all history retroactively.

- **sqlc query** `AggregateSkillUsage` (`queries/spans.sql`): groups Skill tool spans by skill name; per-skill invocations, error count (span `status='error'`), distinct sessions, sessions with `derived_status='completed'`, and last-used timestamp. Counts are per unique `tool_use` — the span layer dedups re-sent history, so raw-turn replay never inflates them.
- **storage**: `SkillUsage` + `SkillUsageReader` capability interface (`span_model.go`), implemented by the postgres driver. Span-projection backends only; there is no node-layer fallback, so non-capable backends get 501 from the handler.
- **api**: `handleSkillUsageStats` + route, following the `/v1/stats` handler shape (org from context, RFC3339 `since`/`until`). Swagger regenerated.

Skill names are the strings harnesses invoked and are **not** guaranteed to match a `/v1/skills` record — consumers should join on slug and tolerate unmatched names (that unmatched set is itself the "off-paper skills" discovery signal). The durable skill-ID association is follow-up work on PCC-852.

## Tests

- Handler specs: 501 on non-capable backend, response shape + `total_invocations` fold, empty-list (not null), since/until pass-through, 400 on malformed timestamps.
- Postgres integration specs drive the **real pipeline** — `PutRawTurn` (wire-shaped raw request/response with Skill + Bash tool_use blocks) → `RederiveFromRaw` → `AggregateSkillUsage` — asserting grouping, ordering, org isolation, window filtering, non-Skill tool exclusion, and idempotency across re-derives. This also pins the emitter contract the feature depends on (Skill tool_use → span named `Skill` with `tool_input.skill`).
- Ran against local pgvector postgres: 93/94 suite specs pass. The one failure is the pre-existing flaky `skills_test.go` "orders the list by most-downloaded" spec — it fails intermittently in full-suite runs on unrelated commits and passes 3/3 focused; not touched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)