### PR TITLE
🧹 chore(skills): make download-sort test deterministic

### DIFF
--- a/pkg/storage/postgres/skills_test.go
+++ b/pkg/storage/postgres/skills_test.go
@@ -184,7 +184,7 @@ var _ = Describe("Driver skills persistence", func() {
 		// download-sorted query falls back to its id tiebreak, which is a
 		// random UUID — making this assertion a coin flip.
 		Expect(pgDriver.IncrementSkillDownloads(ctx, org, low.ID)).To(Succeed())
-		for i := 0; i < 5; i++ {
+		for range 5 {
 			Expect(pgDriver.IncrementSkillDownloads(ctx, org, high.ID)).To(Succeed())
 		}
 

--- a/pkg/storage/postgres/skills_test.go
+++ b/pkg/storage/postgres/skills_test.go
@@ -171,14 +171,22 @@ var _ = Describe("Driver skills persistence", func() {
 		org := newTestOrgID()
 		low := newRec()
 		low.Name = "Low"
-		low.DownloadCount = 1
 		_, err := pgDriver.UpsertSkill(ctx, org, low)
 		Expect(err).NotTo(HaveOccurred())
 		high := newRec()
 		high.Name = "High"
-		high.DownloadCount = 9
 		_, err = pgDriver.UpsertSkill(ctx, org, high)
 		Expect(err).NotTo(HaveOccurred())
+
+		// download_count is owned by the counter, not UpsertSkill (which
+		// ignores the field), so bump the real counter to give High strictly
+		// more downloads than Low. Without this both rows tie at 0 and the
+		// download-sorted query falls back to its id tiebreak, which is a
+		// random UUID — making this assertion a coin flip.
+		Expect(pgDriver.IncrementSkillDownloads(ctx, org, low.ID)).To(Succeed())
+		for i := 0; i < 5; i++ {
+			Expect(pgDriver.IncrementSkillDownloads(ctx, org, high.ID)).To(Succeed())
+		}
 
 		list, err := pgDriver.ListSkills(ctx, org, storage.SkillListOpts{Sort: storage.SkillSortDownloads})
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
## Summary
Noticed the flakyness on PR #243

The `pkg/storage/postgres` spec **"orders the list by most-downloaded when asked"** is flaky on `main` — it fails **~25–30%** of `tapes:test` runs (measured 5/20 on main, 6/20 on PR-243, fresh isolated DBs). Since `tapes:test` runs the whole `go test ./...` in one gate, it randomly reds CI for **any** PR. It's why #243's `tapes:test` errored twice while #241/#242 passed — coin-flip luck, not a diff-specific bug (#241's description already disclosed the symptom).

## Root cause

The test set `low.DownloadCount = 1` / `high.DownloadCount = 9` on the record and upserted, but `UpsertSkill`'s INSERT has **no `download_count`** column — that field is owned solely by the `IncrementSkillDownloads` counter. Both rows persisted `download_count = 0` (confirmed by instrumentation), so `ORDER BY download_count DESC, id DESC` broke the 0-0 tie by **random UUID** (`uuid.NewString()`, v4) → a coin flip.

## Fix

Bump the real counter so `High` has strictly more downloads than `Low`, making the sort deterministic. Test-only change.

## Test plan

- [x] `go vet ./pkg/storage/postgres/` clean; gofmt clean
- [x] **0/30** failures on a fresh pg_duckdb DB after the change (was ~25–30%)
- [x] No other specs affected

Fixes PCC-854

Note: #241's disclosure also named a second intermittently-flaky spec (`GetSessionRecordByHarness`) in the same suite — not addressed here, tracked as follow-up in PCC-854.