### PR TITLE
✨ feat: export session data over HTTP (single session + 30-day bundle)

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -81,6 +81,10 @@ func NewServer(config Config, driver storage.Driver, log *slog.Logger) (*Server,
 	// parameterised ones.
 	app.Get("/v1/stats", s.handleStats)
 	app.Get("/v1/sessions", s.handleListSessions)
+	// /v1/sessions/export has no :id segment, so it must be registered
+	// before the bare /v1/sessions/:id route below — otherwise Fiber would
+	// match it as :id="export" and never reach this handler.
+	app.Get("/v1/sessions/export", s.handleExportSessions)
 	app.Get("/v1/sessions/:id/traces", s.handleGetSessionTraces)
 	app.Get("/v1/sessions/:id/raw_turns", s.handleListSessionRawTurns)
 	app.Get("/v1/sessions/:id/export", s.handleExportSession)

--- a/api/api.go
+++ b/api/api.go
@@ -83,6 +83,7 @@ func NewServer(config Config, driver storage.Driver, log *slog.Logger) (*Server,
 	app.Get("/v1/sessions", s.handleListSessions)
 	app.Get("/v1/sessions/:id/traces", s.handleGetSessionTraces)
 	app.Get("/v1/sessions/:id/raw_turns", s.handleListSessionRawTurns)
+	app.Get("/v1/sessions/:id/export", s.handleExportSession)
 	app.Get("/v1/traces", s.handleListTraceSummaries)
 	app.Get("/v1/traces/:trace_id/spans/:span_id", s.handleGetSpan)
 	app.Get("/v1/traces/:trace_id", s.handleGetTrace)

--- a/api/sessions_export_all_handlers_test.go
+++ b/api/sessions_export_all_handlers_test.go
@@ -155,6 +155,45 @@ var _ = Describe("GET /v1/sessions/export", func() {
 		Expect(lines).To(HaveLen(3))
 	})
 
+	// T-12 (R-20): since is clamped to a 30-day floor. A session older than
+	// 30 days must never be returned, even when the caller explicitly
+	// requests a since far in the past — the 30-day window is the maximum
+	// span for v1, not just the default.
+	It("clamps since to 30 days ago and excludes sessions older than that, even when since requests more history", func() {
+		realNow := time.Now().UTC()
+		drv := newPagingDriver(org, 0, realNow)
+		// One session inside the 30-day floor (10 days old) and one older
+		// than the floor (40 days old) — both would be included by a
+		// naive unclamped since=1970-01-01, but only the in-window one
+		// should survive the clamp.
+		recentID := "recent-session"
+		recentRec := storage.SessionRecord{ID: recentID, HarnessID: "claude", StartedAt: realNow.Add(-10 * 24 * time.Hour), LastSeenAt: realNow.Add(-10 * 24 * time.Hour)}
+		drv.all = append(drv.all, recentRec)
+		drv.orgOf[recentID] = org
+		drv.sessionsByOrg[org][recentID] = recentRec
+		drv.summaries[recentID] = []storage.TraceSummaryRecord{
+			{SpanTurnRecord: storage.SpanTurnRecord{TraceID: "recent-t1", UserPrompt: "hi", ResponsePreview: "hello", StartedAt: recentRec.StartedAt}},
+		}
+
+		oldID := "old-session"
+		oldRec := storage.SessionRecord{ID: oldID, HarnessID: "claude", StartedAt: realNow.Add(-40 * 24 * time.Hour), LastSeenAt: realNow.Add(-40 * 24 * time.Hour)}
+		drv.all = append(drv.all, oldRec)
+		drv.orgOf[oldID] = org
+		drv.sessionsByOrg[org][oldID] = oldRec
+		drv.summaries[oldID] = []storage.TraceSummaryRecord{
+			{SpanTurnRecord: storage.SpanTurnRecord{TraceID: "old-t1", UserPrompt: "ancient", ResponsePreview: "history", StartedAt: oldRec.StartedAt}},
+		}
+
+		server := newExportServer(drv)
+		resp, body := getRaw(server, "/v1/sessions/export?since=1970-01-01T00:00:00Z", org)
+		Expect(resp.StatusCode).To(Equal(fiber.StatusOK))
+
+		lines := nonEmptyLinesAPI(string(body))
+		Expect(lines).To(HaveLen(1))
+		Expect(string(body)).To(ContainSubstring("recent-t1"))
+		Expect(string(body)).NotTo(ContainSubstring("old-t1"))
+	})
+
 	It("returns 400 when since is not a valid RFC3339 timestamp", func() {
 		drv := newPagingDriver(org, 1, now)
 		server := newExportServer(drv)

--- a/api/sessions_export_all_handlers_test.go
+++ b/api/sessions_export_all_handlers_test.go
@@ -1,8 +1,12 @@
 package api
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
 	"fmt"
+	"io"
+	"net/http"
 	"sort"
 	"time"
 
@@ -274,4 +278,57 @@ var _ = Describe("GET /v1/sessions/export", func() {
 		Expect(disposition).To(ContainSubstring("sessions-last-30-days-"))
 		Expect(disposition).To(ContainSubstring(".jsonl"))
 	})
+
+	// Open risk from design.md: the bundle handler is the first
+	// SetBodyStreamWriter use in tapes, and compress.New() (api/api.go)
+	// sits in front of it — unvalidated whether gzip middleware interacts
+	// correctly with a streamed body. Assert the response is actually
+	// gzip-encoded when the client asks for it, AND that decoding it
+	// reproduces the exact NDJSON the uncompressed path returns.
+	It("gzip-encodes the streamed response for Accept-Encoding: gzip and decodes to the expected NDJSON", func() {
+		drv := newPagingDriver(org, 5, now)
+		server := newExportServer(drv)
+
+		resp, gzipped := getGzip(server, "/v1/sessions/export", org)
+		Expect(resp.StatusCode).To(Equal(fiber.StatusOK))
+		Expect(resp.Header.Get("Content-Encoding")).To(Equal("gzip"))
+
+		decoded := decodeGzip(gzipped)
+		lines := nonEmptyLinesAPI(decoded)
+		Expect(lines).To(HaveLen(5))
+		Expect(decoded).To(ContainSubstring(`"session_id":"session-0000"`))
+
+		// Cross-check against the uncompressed path so the assertion is
+		// pinned to "identical NDJSON", not just "5 lines of something".
+		_, plain := getRaw(server, "/v1/sessions/export", org)
+		Expect(decoded).To(Equal(string(plain)))
+	})
 })
+
+// getGzip issues a GET with Accept-Encoding: gzip and returns the raw
+// (still-compressed) response body alongside the response, so callers can
+// assert on Content-Encoding before decoding.
+func getGzip(server *Server, path, org string) (*http.Response, []byte) {
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, path, nil)
+	Expect(err).NotTo(HaveOccurred())
+	if org != "" {
+		req.Header.Set(orgIDHeader, org)
+	}
+	req.Header.Set("Accept-Encoding", "gzip")
+	resp, err := server.app.Test(req, -1)
+	Expect(err).NotTo(HaveOccurred())
+	body, err := io.ReadAll(resp.Body)
+	Expect(err).NotTo(HaveOccurred())
+	defer resp.Body.Close()
+	return resp, body
+}
+
+// decodeGzip gunzips a response body captured via getGzip.
+func decodeGzip(gzipped []byte) string {
+	r, err := gzip.NewReader(bytes.NewReader(gzipped))
+	Expect(err).NotTo(HaveOccurred())
+	defer r.Close()
+	decoded, err := io.ReadAll(r)
+	Expect(err).NotTo(HaveOccurred())
+	return string(decoded)
+}

--- a/api/sessions_export_all_handlers_test.go
+++ b/api/sessions_export_all_handlers_test.go
@@ -1,0 +1,238 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/papercomputeco/tapes/pkg/storage"
+	"github.com/papercomputeco/tapes/pkg/storage/inmemory"
+)
+
+// pagingExportStubDriver is exportStubDriver plus a real, in-memory
+// implementation of ListSessionRecords: keyset-paginated on
+// (LastSeenAt DESC, ID DESC), honoring Since/Until/Limit exactly like the
+// Postgres driver's contract, so it can stand in for a multi-page export.
+type pagingExportStubDriver struct {
+	exportStubDriver
+
+	// all is every session across every org, newest-last-seen first is NOT
+	// assumed; ListSessionRecords sorts on each call.
+	all []storage.SessionRecord
+	// orgOf maps session ID -> org ID, since SessionRecord itself carries
+	// no org field (org-scoping lives in the driver, not the record).
+	orgOf map[string]string
+
+	listCalls  int
+	listLimits []int
+}
+
+func (d *pagingExportStubDriver) ListSessionRecords(_ context.Context, orgID string, opts storage.SessionListOpts) ([]storage.SessionRecord, error) {
+	d.listCalls++
+	d.listLimits = append(d.listLimits, opts.Limit)
+
+	var matched []storage.SessionRecord
+	for _, s := range d.all {
+		if d.orgOf[s.ID] != orgID {
+			continue
+		}
+		if opts.Since != nil && s.LastSeenAt.Before(*opts.Since) {
+			continue
+		}
+		if opts.Until != nil && !s.LastSeenAt.Before(*opts.Until) {
+			continue
+		}
+		matched = append(matched, s)
+	}
+
+	sort.Slice(matched, func(i, j int) bool {
+		if !matched[i].LastSeenAt.Equal(matched[j].LastSeenAt) {
+			return matched[i].LastSeenAt.After(matched[j].LastSeenAt)
+		}
+		return matched[i].ID > matched[j].ID
+	})
+
+	if opts.CursorTs != nil && opts.CursorID != nil {
+		start := len(matched)
+		for i, s := range matched {
+			if s.LastSeenAt.Before(*opts.CursorTs) ||
+				(s.LastSeenAt.Equal(*opts.CursorTs) && s.ID < *opts.CursorID) {
+				start = i
+				break
+			}
+		}
+		matched = matched[start:]
+	}
+
+	limit := opts.Limit
+	if limit <= 0 || limit > len(matched) {
+		limit = len(matched)
+	}
+	return matched[:limit], nil
+}
+
+// newPagingDriver builds a driver with n sessions for org, spaced one
+// minute apart ending at "latest", each with a single distinct turn so the
+// export output can be counted/verified per session.
+func newPagingDriver(org string, n int, latest time.Time) *pagingExportStubDriver {
+	d := &pagingExportStubDriver{
+		exportStubDriver: exportStubDriver{
+			Driver:        inmemory.NewDriver(),
+			sessionsByOrg: map[string]map[string]storage.SessionRecord{},
+			summaries:     map[string][]storage.TraceSummaryRecord{},
+		},
+		orgOf: map[string]string{},
+	}
+	d.sessionsByOrg[org] = map[string]storage.SessionRecord{}
+
+	for i := 0; i < n; i++ {
+		id := fmt.Sprintf("session-%04d", i)
+		seenAt := latest.Add(-time.Duration(i) * time.Minute)
+		rec := storage.SessionRecord{
+			ID:         id,
+			HarnessID:  "claude",
+			StartedAt:  seenAt,
+			LastSeenAt: seenAt,
+		}
+		d.all = append(d.all, rec)
+		d.orgOf[id] = org
+		d.sessionsByOrg[org][id] = rec
+		d.summaries[id] = []storage.TraceSummaryRecord{
+			{SpanTurnRecord: storage.SpanTurnRecord{
+				TraceID: id + "-t1", UserPrompt: "hi", ResponsePreview: "hello",
+				StartedAt: seenAt, TotalInputTokens: 1, TotalOutputTokens: 1,
+			}},
+		}
+	}
+	return d
+}
+
+var _ = Describe("GET /v1/sessions/export", func() {
+	const org = "33333333-3333-3333-3333-333333333333"
+	now := time.Date(2026, 7, 8, 12, 0, 0, 0, time.UTC)
+
+	// T-7: default window (no since/until) + bypasses the 200-row UI cap.
+	It("streams every session in the default 30-day window, past the 200-row cap", func() {
+		drv := newPagingDriver(org, 250, now)
+		server := newExportServer(drv)
+
+		resp, body := getRaw(server, "/v1/sessions/export", org)
+		Expect(resp.StatusCode).To(Equal(fiber.StatusOK))
+		Expect(resp.Header.Get("Content-Type")).To(ContainSubstring("application/x-ndjson"))
+
+		lines := nonEmptyLinesAPI(string(body))
+		Expect(lines).To(HaveLen(250))
+
+		// Must have paged internally: the driver's Postgres-mirroring
+		// contract is capped at maxSessionsLimit per call, so covering 250
+		// sessions requires more than one ListSessionRecords call.
+		Expect(drv.listCalls).To(BeNumerically(">", 1))
+		for _, l := range drv.listLimits {
+			Expect(l).To(BeNumerically("<=", maxSessionsLimit+1))
+		}
+	})
+
+	// T-8: since/until override the default window.
+	It("honors since/until query params instead of the 30-day default", func() {
+		drv := newPagingDriver(org, 10, now)
+		server := newExportServer(drv)
+
+		since := now.Add(-5 * time.Minute).Format(time.RFC3339)
+		until := now.Add(-2 * time.Minute).Format(time.RFC3339)
+		resp, body := getRaw(server, "/v1/sessions/export?since="+since+"&until="+until, org)
+		Expect(resp.StatusCode).To(Equal(fiber.StatusOK))
+
+		// sessions at offsets 2,3,4 minutes back fall in [since, until);
+		// the offset-5 session lands exactly on "since" and is included,
+		// offset-2 (== until) is excluded (until is an exclusive upper
+		// bound, matching handleListSessions' semantics).
+		lines := nonEmptyLinesAPI(string(body))
+		Expect(lines).To(HaveLen(3))
+	})
+
+	It("returns 400 when since is not a valid RFC3339 timestamp", func() {
+		drv := newPagingDriver(org, 1, now)
+		server := newExportServer(drv)
+
+		resp, _ := getRaw(server, "/v1/sessions/export?since=not-a-time", org)
+		Expect(resp.StatusCode).To(Equal(fiber.StatusBadRequest))
+	})
+
+	// T-9: org isolation.
+	It("only includes sessions belonging to the requesting org", func() {
+		drv := newPagingDriver(org, 5, now)
+		otherOrg := "44444444-4444-4444-4444-444444444444"
+		// Sneak in a session for a different org.
+		otherID := "other-session"
+		otherRec := storage.SessionRecord{ID: otherID, HarnessID: "claude", StartedAt: now, LastSeenAt: now}
+		drv.all = append(drv.all, otherRec)
+		drv.orgOf[otherID] = otherOrg
+		drv.sessionsByOrg[otherOrg] = map[string]storage.SessionRecord{otherID: otherRec}
+		drv.summaries[otherID] = []storage.TraceSummaryRecord{
+			{SpanTurnRecord: storage.SpanTurnRecord{TraceID: "leak-t1", UserPrompt: "secret", ResponsePreview: "shh", StartedAt: now}},
+		}
+
+		server := newExportServer(drv)
+		resp, body := getRaw(server, "/v1/sessions/export", org)
+		Expect(resp.StatusCode).To(Equal(fiber.StatusOK))
+
+		lines := nonEmptyLinesAPI(string(body))
+		Expect(lines).To(HaveLen(5))
+		Expect(string(body)).NotTo(ContainSubstring("leak-t1"))
+		Expect(string(body)).NotTo(ContainSubstring("secret"))
+	})
+
+	// T-10: streaming / no whole-bundle buffering. We can't directly observe
+	// memory, but we can assert the handler writes via the fasthttp body
+	// stream mechanism (Transfer-Encoding: chunked), which is the
+	// externally-observable signature of SetBodyStreamWriter rather than a
+	// single c.Send()/c.JSON() buffered write.
+	It("streams the response body rather than buffering it as a single Content-Length body", func() {
+		drv := newPagingDriver(org, 5, now)
+		server := newExportServer(drv)
+
+		resp, _ := getRaw(server, "/v1/sessions/export", org)
+		Expect(resp.StatusCode).To(Equal(fiber.StatusOK))
+		Expect(resp.TransferEncoding).To(ContainElement("chunked"))
+	})
+
+	// T-11: route-shadowing — /v1/sessions/export must not be captured by
+	// /v1/sessions/:id (which would 400 on "export" not being a UUID, or
+	// 404, instead of listing).
+	It("is not shadowed by the /v1/sessions/:id route", func() {
+		drv := newPagingDriver(org, 3, now)
+		server := newExportServer(drv)
+
+		resp, body := getRaw(server, "/v1/sessions/export", org)
+		Expect(resp.StatusCode).To(Equal(fiber.StatusOK))
+		Expect(resp.Header.Get("Content-Type")).To(ContainSubstring("application/x-ndjson"))
+		lines := nonEmptyLinesAPI(string(body))
+		Expect(lines).To(HaveLen(3))
+	})
+
+	// 501 gate mirrors the single-session endpoint.
+	It("returns 501 when the driver does not implement the sessions/span read surface", func() {
+		base := inmemory.NewDriver()
+		server := newExportServer(base)
+
+		resp, _ := getRaw(server, "/v1/sessions/export", org)
+		Expect(resp.StatusCode).To(Equal(fiber.StatusNotImplemented))
+	})
+
+	It("sets Content-Disposition with a last-30-days filename", func() {
+		drv := newPagingDriver(org, 1, now)
+		server := newExportServer(drv)
+
+		resp, _ := getRaw(server, "/v1/sessions/export", org)
+		Expect(resp.StatusCode).To(Equal(fiber.StatusOK))
+		disposition := resp.Header.Get("Content-Disposition")
+		Expect(disposition).To(ContainSubstring("attachment"))
+		Expect(disposition).To(ContainSubstring("sessions-last-30-days-"))
+		Expect(disposition).To(ContainSubstring(".jsonl"))
+	})
+})

--- a/api/sessions_export_handlers_test.go
+++ b/api/sessions_export_handlers_test.go
@@ -1,0 +1,219 @@
+package api
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	tapeslogger "github.com/papercomputeco/tapes/pkg/logger"
+	"github.com/papercomputeco/tapes/pkg/storage"
+	"github.com/papercomputeco/tapes/pkg/storage/inmemory"
+)
+
+// exportStubDriver wraps a real storage.Driver and implements the
+// sessionsReader and spanModelReader capability interfaces needed by the
+// export handlers and the in-process skillTraceQuerier they use.
+type exportStubDriver struct {
+	storage.Driver
+
+	sessionsByOrg map[string]map[string]storage.SessionRecord // orgID -> sessionID -> record
+	summaries     map[string][]storage.TraceSummaryRecord     // sessionID -> turns
+
+	getSessionCalls int
+	lastGetOrg      string
+	lastGetID       string
+}
+
+func (d *exportStubDriver) ListSessionRecords(_ context.Context, _ string, _ storage.SessionListOpts) ([]storage.SessionRecord, error) {
+	return nil, nil
+}
+
+func (d *exportStubDriver) GetSessionRecord(_ context.Context, orgID, id string) (*storage.SessionRecord, error) {
+	d.getSessionCalls++
+	d.lastGetOrg = orgID
+	d.lastGetID = id
+	byOrg, ok := d.sessionsByOrg[orgID]
+	if !ok {
+		return nil, nil
+	}
+	rec, ok := byOrg[id]
+	if !ok {
+		return nil, nil
+	}
+	return &rec, nil
+}
+
+func (d *exportStubDriver) GetSessionRecordByHarness(_ context.Context, _, _, _ string) (*storage.SessionRecord, error) {
+	return nil, nil
+}
+
+func (d *exportStubDriver) ListTraceSummaries(_ context.Context, sessionID string) ([]storage.TraceSummaryRecord, error) {
+	return d.summaries[sessionID], nil
+}
+
+func (d *exportStubDriver) GetTraceDetail(_ context.Context, _, _ string) (*storage.SpanTurnRecord, []storage.SpanRecord, []storage.SpanLinkRecord, error) {
+	return nil, nil, nil, nil
+}
+
+func (d *exportStubDriver) ListSessionSpanModel(context.Context, string) ([]storage.SpanTurnRecord, []storage.SpanRecord, []storage.SpanLinkRecord, error) {
+	return nil, nil, nil, nil
+}
+
+func (d *exportStubDriver) GetSpanRecord(context.Context, string, string, string) (*storage.SpanRecord, error) {
+	return nil, nil
+}
+
+func (d *exportStubDriver) ListRawTurnHeaders(context.Context, string, string, string) ([]storage.RawTurnHeader, error) {
+	return nil, nil
+}
+
+func newExportServer(driver storage.Driver) *Server {
+	server, err := NewServer(Config{ListenAddr: ":0"}, driver, tapeslogger.NewNoop())
+	Expect(err).NotTo(HaveOccurred())
+	return server
+}
+
+// getRaw issues a GET against the server and returns the raw response
+// (status, headers, body) without assuming any particular content type.
+func getRaw(server *Server, path, org string) (*http.Response, []byte) {
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, path, nil)
+	Expect(err).NotTo(HaveOccurred())
+	if org != "" {
+		req.Header.Set(orgIDHeader, org)
+	}
+	resp, err := server.app.Test(req, -1)
+	Expect(err).NotTo(HaveOccurred())
+	body, err := io.ReadAll(resp.Body)
+	Expect(err).NotTo(HaveOccurred())
+	defer resp.Body.Close()
+	return resp, body
+}
+
+var _ = Describe("GET /v1/sessions/:id/export", func() {
+	const org = "11111111-1111-1111-1111-111111111111"
+	const sessionID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+
+	var record storage.SessionRecord
+
+	BeforeEach(func() {
+		started := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+		record = storage.SessionRecord{
+			ID:         sessionID,
+			HarnessID:  "claude",
+			StartedAt:  started,
+			LastSeenAt: started.Add(time.Minute),
+		}
+	})
+
+	newDriverWithSession := func() *exportStubDriver {
+		return &exportStubDriver{
+			Driver: inmemory.NewDriver(),
+			sessionsByOrg: map[string]map[string]storage.SessionRecord{
+				org: {sessionID: record},
+			},
+			summaries: map[string][]storage.TraceSummaryRecord{
+				sessionID: {
+					{SpanTurnRecord: storage.SpanTurnRecord{
+						TraceID: "t1", UserPrompt: "hi", ResponsePreview: "hello",
+						StartedAt: record.StartedAt, TotalInputTokens: 10, TotalOutputTokens: 5,
+					}},
+					{SpanTurnRecord: storage.SpanTurnRecord{
+						TraceID: "t2", UserPrompt: "thanks", ResponsePreview: "np",
+						StartedAt: record.StartedAt.Add(time.Minute), TotalInputTokens: 4, TotalOutputTokens: 2,
+					}},
+				},
+			},
+		}
+	}
+
+	// T-3: 200 + headers + line count + full fidelity.
+	It("returns 200 NDJSON with one line per turn and the expected headers", func() {
+		drv := newDriverWithSession()
+		server := newExportServer(drv)
+
+		resp, body := getRaw(server, "/v1/sessions/"+sessionID+"/export", org)
+		Expect(resp.StatusCode).To(Equal(fiber.StatusOK))
+		Expect(resp.Header.Get("Content-Type")).To(ContainSubstring("application/x-ndjson"))
+
+		lines := nonEmptyLinesAPI(string(body))
+		Expect(lines).To(HaveLen(2))
+		Expect(string(body)).To(ContainSubstring(`"trace_id":"t1"`))
+		Expect(string(body)).To(ContainSubstring(`"trace_id":"t2"`))
+		Expect(string(body)).To(ContainSubstring(`"session_id":"` + sessionID + `"`))
+
+		// GetSessionRecord is called twice by design: once by the handler's
+		// own pre-flight 404 gate (so no headers/body are ever sent for a
+		// session outside the org), and once more inside
+		// skillTraceQuerier.TraceSummaries, which independently re-scopes
+		// every read to the bound org.
+		Expect(drv.getSessionCalls).To(Equal(2))
+		Expect(drv.lastGetOrg).To(Equal(org))
+		Expect(drv.lastGetID).To(Equal(sessionID))
+	})
+
+	// T-4: filename includes the session id.
+	It("sets Content-Disposition with a filename containing the session id", func() {
+		drv := newDriverWithSession()
+		server := newExportServer(drv)
+
+		resp, _ := getRaw(server, "/v1/sessions/"+sessionID+"/export", org)
+		Expect(resp.StatusCode).To(Equal(fiber.StatusOK))
+		disposition := resp.Header.Get("Content-Disposition")
+		Expect(disposition).To(ContainSubstring("attachment"))
+		Expect(disposition).To(ContainSubstring(sessionID))
+		Expect(disposition).To(ContainSubstring(".jsonl"))
+	})
+
+	// T-5: cross-org -> 404, no disclosure.
+	It("returns 404 when the session belongs to a different org", func() {
+		drv := newDriverWithSession()
+		server := newExportServer(drv)
+
+		otherOrg := "22222222-2222-2222-2222-222222222222"
+		resp, body := getRaw(server, "/v1/sessions/"+sessionID+"/export", otherOrg)
+		Expect(resp.StatusCode).To(Equal(fiber.StatusNotFound))
+		Expect(string(body)).NotTo(ContainSubstring("t1"))
+		Expect(drv.lastGetOrg).To(Equal(otherOrg))
+	})
+
+	It("returns 404 when the session does not exist", func() {
+		drv := newDriverWithSession()
+		server := newExportServer(drv)
+
+		resp, _ := getRaw(server, "/v1/sessions/ffffffff-ffff-ffff-ffff-ffffffffffff/export", org)
+		Expect(resp.StatusCode).To(Equal(fiber.StatusNotFound))
+	})
+
+	It("returns 400 for a malformed session id", func() {
+		drv := newDriverWithSession()
+		server := newExportServer(drv)
+
+		resp, _ := getRaw(server, "/v1/sessions/not-a-uuid/export", org)
+		Expect(resp.StatusCode).To(Equal(fiber.StatusBadRequest))
+	})
+
+	// T-6: missing capability -> 501.
+	It("returns 501 when the driver does not implement the sessions/span read surface", func() {
+		base := inmemory.NewDriver()
+		server := newExportServer(base)
+
+		resp, _ := getRaw(server, "/v1/sessions/"+sessionID+"/export", org)
+		Expect(resp.StatusCode).To(Equal(fiber.StatusNotImplemented))
+	})
+})
+
+func nonEmptyLinesAPI(s string) []string {
+	var out []string
+	for _, line := range strings.Split(s, "\n") {
+		if strings.TrimSpace(line) != "" {
+			out = append(out, line)
+		}
+	}
+	return out
+}

--- a/api/sessions_handlers.go
+++ b/api/sessions_handlers.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gofiber/fiber/v2"
 	"github.com/google/uuid"
 
+	"github.com/papercomputeco/tapes/pkg/export"
 	"github.com/papercomputeco/tapes/pkg/llm"
 	"github.com/papercomputeco/tapes/pkg/storage"
 )
@@ -352,4 +353,65 @@ func (s *Server) handleGetSession(c *fiber.Ctx) error {
 	return c.JSON(SessionDetailResponse{
 		Session: sessionItemFromStorage(*sess),
 	})
+}
+
+// handleExportSession handles GET /v1/sessions/:id/export. It streams the
+// same JSONL grain `tapes checkout --format jsonl` renders, over HTTP, for
+// the console's per-session download.
+//
+//	@Summary		Export a session as JSONL
+//	@Description	Streams one JSON object per turn (NDJSON) as a downloadable attachment: the same conversation-export grain as `tapes checkout --format jsonl`.
+//	@Tags			sessions
+//	@Produce		application/x-ndjson
+//	@Param			id	path	string	true	"Session id (UUID)"
+//	@Success		200	{string}	string	"NDJSON body, one JSON object per turn"
+//	@Failure		400	{object}	llm.ErrorResponse	"Missing or malformed id"
+//	@Failure		404	{object}	llm.ErrorResponse	"Session not found"
+//	@Failure		500	{object}	llm.ErrorResponse	"Failed to load or render the session"
+//	@Failure		501	{object}	llm.ErrorResponse	"Sessions not supported by this backend"
+//	@Router			/v1/sessions/{id}/export [get]
+func (s *Server) handleExportSession(c *fiber.Ctx) error {
+	reader, ok := s.driver.(sessionsReader)
+	if !ok {
+		return c.Status(fiber.StatusNotImplemented).JSON(llm.ErrorResponse{Error: "sessions not supported by this backend"})
+	}
+
+	id := c.Params("id")
+	if id == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(llm.ErrorResponse{Error: "id parameter required"})
+	}
+	if _, err := uuid.Parse(id); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(llm.ErrorResponse{Error: "id must be a valid UUID"})
+	}
+
+	orgID := orgIDFromCtx(c)
+	// Resolve existence under the org BEFORE anything is streamed, so a
+	// cross-org request gets a clean 404 with no headers or partial body
+	// committed — the same tenancy gate handleGetSession applies.
+	sess, err := reader.GetSessionRecord(c.Context(), orgID, id)
+	if err != nil {
+		s.logger.Error("get session for export", "id", id, "error", err)
+		return c.Status(fiber.StatusInternalServerError).JSON(llm.ErrorResponse{Error: "failed to load session"})
+	}
+	if sess == nil {
+		return c.Status(fiber.StatusNotFound).JSON(llm.ErrorResponse{Error: "session not found"})
+	}
+
+	// The querier needs both sessionsReader and spanModelReader; a driver
+	// can implement the former without the latter, so this is a second,
+	// independent 501 gate checked before any header is set.
+	query, ok := s.skillTraceQuerier(orgID)
+	if !ok {
+		return c.Status(fiber.StatusNotImplemented).JSON(llm.ErrorResponse{Error: "sessions not supported by this backend"})
+	}
+
+	filename := fmt.Sprintf("session-%s-%s.jsonl", id, time.Now().UTC().Format("2006-01-02"))
+	c.Set("Content-Type", "application/x-ndjson")
+	c.Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", filename))
+
+	if err := export.SessionJSONL(c.Context(), query, id, c.Response().BodyWriter()); err != nil {
+		s.logger.Error("export session", "id", id, "error", err)
+		return c.Status(fiber.StatusInternalServerError).JSON(llm.ErrorResponse{Error: "failed to render session export"})
+	}
+	return nil
 }

--- a/api/sessions_handlers.go
+++ b/api/sessions_handlers.go
@@ -451,13 +451,23 @@ func (s *Server) handleExportSessions(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusNotImplemented).JSON(llm.ErrorResponse{Error: "sessions not supported by this backend"})
 	}
 
-	since := time.Now().UTC().AddDate(0, 0, -30)
+	// The 30-day window is the maximum span for v1 (R-20), not just the
+	// default: floor is enforced unconditionally, even when the caller
+	// supplies an explicit since older than 30 days, so the endpoint can
+	// never be used to stream an org's entire history
+	// (?since=1970-01-01T00:00:00Z). In-window since/until overrides
+	// (R-9) still work as before — only the lower bound is clamped.
+	floor := time.Now().UTC().AddDate(0, 0, -30)
+	since := floor
 	if raw := c.Query("since"); raw != "" {
 		t, err := time.Parse(time.RFC3339, raw)
 		if err != nil {
 			return c.Status(fiber.StatusBadRequest).JSON(llm.ErrorResponse{Error: "since must be an RFC3339 timestamp"})
 		}
 		since = t
+	}
+	if since.Before(floor) {
+		since = floor
 	}
 	var until *time.Time
 	if raw := c.Query("until"); raw != "" {

--- a/api/sessions_handlers.go
+++ b/api/sessions_handlers.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"bufio"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -413,5 +414,110 @@ func (s *Server) handleExportSession(c *fiber.Ctx) error {
 		s.logger.Error("export session", "id", id, "error", err)
 		return c.Status(fiber.StatusInternalServerError).JSON(llm.ErrorResponse{Error: "failed to render session export"})
 	}
+	return nil
+}
+
+// exportSessionsPageLimit is the internal page size handleExportSessions
+// uses when walking ListSessionRecords. It intentionally matches
+// maxSessionsLimit (the UI list cap): the point of this endpoint is to
+// keep paging past that cap rather than being bounded by it, one page at a
+// time, so memory stays flat regardless of how many sessions fall in the
+// window.
+const exportSessionsPageLimit = maxSessionsLimit
+
+// handleExportSessions handles GET /v1/sessions/export?since=&until=. It
+// streams every session's JSONL turns in the requested window (default:
+// trailing 30 days) as a single NDJSON attachment, paging internally past
+// the 200-row UI cap via the same keyset cursor handleListSessions uses.
+//
+//	@Summary		Export sessions in a time window as JSONL
+//	@Description	Streams every session's turns (NDJSON) in the given window, newest-first, as a downloadable attachment. Defaults to the trailing 30 days. Not bounded by the /v1/sessions list cap — pages internally.
+//	@Tags			sessions
+//	@Produce		application/x-ndjson
+//	@Param			since	query	string	false	"Only include sessions active (last_seen_at) at or after this RFC3339 timestamp (default: now - 30 days)"	format(date-time)
+//	@Param			until	query	string	false	"Only include sessions active (last_seen_at) before this RFC3339 timestamp"								format(date-time)
+//	@Success		200		{string}	string	"NDJSON body, one JSON object per turn across every session in the window"
+//	@Failure		400		{object}	llm.ErrorResponse	"Malformed since/until"
+//	@Failure		500		{object}	llm.ErrorResponse	"Failed to list or render sessions"
+//	@Failure		501		{object}	llm.ErrorResponse	"Sessions not supported by this backend"
+//	@Router			/v1/sessions/export [get]
+func (s *Server) handleExportSessions(c *fiber.Ctx) error {
+	reader, ok := s.driver.(sessionsReader)
+	if !ok {
+		return c.Status(fiber.StatusNotImplemented).JSON(llm.ErrorResponse{Error: "sessions not supported by this backend"})
+	}
+	query, ok := s.skillTraceQuerier(orgIDFromCtx(c))
+	if !ok {
+		return c.Status(fiber.StatusNotImplemented).JSON(llm.ErrorResponse{Error: "sessions not supported by this backend"})
+	}
+
+	since := time.Now().UTC().AddDate(0, 0, -30)
+	if raw := c.Query("since"); raw != "" {
+		t, err := time.Parse(time.RFC3339, raw)
+		if err != nil {
+			return c.Status(fiber.StatusBadRequest).JSON(llm.ErrorResponse{Error: "since must be an RFC3339 timestamp"})
+		}
+		since = t
+	}
+	var until *time.Time
+	if raw := c.Query("until"); raw != "" {
+		t, err := time.Parse(time.RFC3339, raw)
+		if err != nil {
+			return c.Status(fiber.StatusBadRequest).JSON(llm.ErrorResponse{Error: "until must be an RFC3339 timestamp"})
+		}
+		until = &t
+	}
+
+	orgID := orgIDFromCtx(c)
+	ctx := c.Context()
+
+	filename := fmt.Sprintf("sessions-last-30-days-%s.jsonl", time.Now().UTC().Format("2006-01-02"))
+	c.Set("Content-Type", "application/x-ndjson")
+	c.Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", filename))
+
+	// SetBodyStreamWriter's callback has no error return: a failure
+	// mid-stream can only be logged and the loop stopped, since the HTTP
+	// status is already committed by the time bytes are flowing (documented
+	// as an accepted v1 tradeoff in the design). ctx.Bind() is unavailable
+	// here (this is the raw fasthttp callback, not a fiber.Ctx), so orgID,
+	// since, until, reader, and query are captured directly.
+	ctx.SetBodyStreamWriter(func(w *bufio.Writer) {
+		defer w.Flush()
+
+		opts := storage.SessionListOpts{
+			Since: &since,
+			Until: until,
+			Limit: exportSessionsPageLimit,
+		}
+		for {
+			sessions, err := reader.ListSessionRecords(context.Background(), orgID, opts)
+			if err != nil {
+				s.logger.Error("list sessions for export", "error", err)
+				return
+			}
+			for _, sess := range sessions {
+				if err := export.SessionJSONL(context.Background(), query, sess.ID, w); err != nil {
+					s.logger.Error("export session", "id", sess.ID, "error", err)
+					return
+				}
+				// Flush after each session so bytes reach the client
+				// incrementally instead of only at the end of the whole
+				// window — the point of streaming.
+				if err := w.Flush(); err != nil {
+					// Client went away or the connection failed; nothing
+					// left to do but stop producing.
+					return
+				}
+			}
+
+			if len(sessions) < exportSessionsPageLimit {
+				return
+			}
+			last := sessions[len(sessions)-1]
+			opts.CursorTs = &last.LastSeenAt
+			opts.CursorID = &last.ID
+		}
+	})
+
 	return nil
 }

--- a/cmd/tapes/checkout/checkout.go
+++ b/cmd/tapes/checkout/checkout.go
@@ -5,7 +5,6 @@ package checkoutcmder
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -16,6 +15,7 @@ import (
 
 	"github.com/papercomputeco/tapes/cmd/tapes/inprocessapi"
 	"github.com/papercomputeco/tapes/pkg/config"
+	"github.com/papercomputeco/tapes/pkg/export"
 	"github.com/papercomputeco/tapes/pkg/skill"
 )
 
@@ -141,7 +141,11 @@ func Export(ctx context.Context, query skill.Querier, opts ExportOptions) (strin
 
 	switch opts.Format {
 	case formatJSONL:
-		return exportJSONL(ctx, query, opts.SessionID, transcriptOpts)
+		var b strings.Builder
+		if err := export.SessionJSONL(ctx, query, opts.SessionID, &b, transcriptOpts...); err != nil {
+			return "", err
+		}
+		return b.String(), nil
 	case formatMarkdown, "":
 		return skill.BuildSessionTranscript(ctx, query, opts.SessionID, transcriptOpts...)
 	default:
@@ -163,68 +167,6 @@ func (c *checkoutCommander) connect(ctx context.Context) (skill.Querier, func(),
 		return nil, nil, startErr
 	}
 	return skill.NewAPIClient(target), stop, nil
-}
-
-// exportTurn is one turn's structured (jsonl) export record.
-type exportTurn struct {
-	TraceID           string `json:"trace_id"`
-	SessionID         string `json:"session_id"`
-	UserPrompt        string `json:"user_prompt,omitempty"`
-	Response          string `json:"response,omitempty"`
-	StartedAt         string `json:"started_at,omitempty"`
-	TotalInputTokens  int64  `json:"total_input_tokens"`
-	TotalOutputTokens int64  `json:"total_output_tokens"`
-	MainInputTokens   int64  `json:"main_input_tokens"`
-	MainOutputTokens  int64  `json:"main_output_tokens"`
-}
-
-// exportJSONL emits one JSON object per turn. The response is the
-// rendered spine transcript for the turn (assistant + tool lines, prompt
-// excluded since it has its own field).
-func exportJSONL(ctx context.Context, query skill.Querier, sessionID string, opts []skill.TranscriptOption) (string, error) {
-	turns, err := skill.SessionTurns(ctx, query, sessionID, opts...)
-	if err != nil {
-		return "", err
-	}
-
-	var b strings.Builder
-	enc := json.NewEncoder(&b)
-	for _, turn := range turns {
-		rec := exportTurn{
-			TraceID:           turn.TraceID,
-			SessionID:         sessionID,
-			UserPrompt:        turn.UserPrompt,
-			Response:          turnResponse(ctx, query, turn),
-			TotalInputTokens:  turn.TotalInputTokens,
-			TotalOutputTokens: turn.TotalOutputTokens,
-			MainInputTokens:   turn.MainInputTokens,
-			MainOutputTokens:  turn.MainOutputTokens,
-		}
-		if !turn.StartedAt.IsZero() {
-			rec.StartedAt = turn.StartedAt.Format("2006-01-02T15:04:05Z07:00")
-		}
-		if err := enc.Encode(rec); err != nil {
-			return "", fmt.Errorf("encoding turn %s: %w", turn.TraceID, err)
-		}
-	}
-	return b.String(), nil
-}
-
-// turnResponse renders just the assistant/tool half of a turn by
-// stripping the leading [user] line from the shared turn transcript.
-func turnResponse(ctx context.Context, query skill.Querier, turn skill.TraceSummary) string {
-	transcript := skill.TurnTranscript(ctx, query, turn)
-	var lines []string
-	for line := range strings.SplitSeq(transcript, "\n") {
-		if strings.HasPrefix(line, "[user] ") {
-			continue
-		}
-		if line == "" {
-			continue
-		}
-		lines = append(lines, line)
-	}
-	return strings.Join(lines, "\n")
 }
 
 // write sends the rendered export to stdout or the -o path.

--- a/pkg/export/export_suite_test.go
+++ b/pkg/export/export_suite_test.go
@@ -1,0 +1,13 @@
+package export_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestExport(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Export Suite")
+}

--- a/pkg/export/turn.go
+++ b/pkg/export/turn.go
@@ -1,0 +1,80 @@
+// Package export provides the shared JSONL conversation-export primitive:
+// one turn's structured record plus a session-level JSONL writer. It is
+// used by the `tapes checkout` CLI command and by the tapes API's
+// session-export HTTP endpoints, so both surfaces render the exact same
+// grain from the same code path.
+package export
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/papercomputeco/tapes/pkg/skill"
+)
+
+// Turn is one turn's structured (jsonl) export record.
+type Turn struct {
+	TraceID           string `json:"trace_id"`
+	SessionID         string `json:"session_id"`
+	UserPrompt        string `json:"user_prompt,omitempty"`
+	Response          string `json:"response,omitempty"`
+	StartedAt         string `json:"started_at,omitempty"`
+	TotalInputTokens  int64  `json:"total_input_tokens"`
+	TotalOutputTokens int64  `json:"total_output_tokens"`
+	MainInputTokens   int64  `json:"main_input_tokens"`
+	MainOutputTokens  int64  `json:"main_output_tokens"`
+}
+
+// SessionJSONL writes one JSON object per non-synthetic turn in the
+// session to w. The response is the rendered spine transcript for the
+// turn (assistant + tool lines, prompt excluded since it has its own
+// field). This is the generalized body of the CLI's former exportJSONL,
+// widened from *strings.Builder to io.Writer so it can be reused for
+// streaming HTTP responses.
+func SessionJSONL(ctx context.Context, query skill.Querier, sessionID string, w io.Writer, opts ...skill.TranscriptOption) error {
+	turns, err := skill.SessionTurns(ctx, query, sessionID, opts...)
+	if err != nil {
+		return err
+	}
+
+	enc := json.NewEncoder(w)
+	for _, turn := range turns {
+		rec := Turn{
+			TraceID:           turn.TraceID,
+			SessionID:         sessionID,
+			UserPrompt:        turn.UserPrompt,
+			Response:          turnResponse(ctx, query, turn),
+			TotalInputTokens:  turn.TotalInputTokens,
+			TotalOutputTokens: turn.TotalOutputTokens,
+			MainInputTokens:   turn.MainInputTokens,
+			MainOutputTokens:  turn.MainOutputTokens,
+		}
+		if !turn.StartedAt.IsZero() {
+			rec.StartedAt = turn.StartedAt.Format("2006-01-02T15:04:05Z07:00")
+		}
+		if err := enc.Encode(rec); err != nil {
+			return fmt.Errorf("encoding turn %s: %w", turn.TraceID, err)
+		}
+	}
+	return nil
+}
+
+// turnResponse renders just the assistant/tool half of a turn by
+// stripping the leading [user] line from the shared turn transcript.
+func turnResponse(ctx context.Context, query skill.Querier, turn skill.TraceSummary) string {
+	transcript := skill.TurnTranscript(ctx, query, turn)
+	var lines []string
+	for line := range strings.SplitSeq(transcript, "\n") {
+		if strings.HasPrefix(line, "[user] ") {
+			continue
+		}
+		if line == "" {
+			continue
+		}
+		lines = append(lines, line)
+	}
+	return strings.Join(lines, "\n")
+}

--- a/pkg/export/turn_test.go
+++ b/pkg/export/turn_test.go
@@ -1,0 +1,206 @@
+package export_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/papercomputeco/tapes/pkg/export"
+	"github.com/papercomputeco/tapes/pkg/llm"
+	"github.com/papercomputeco/tapes/pkg/skill"
+)
+
+// fakeQuerier implements skill.Querier for export tests, mirroring the
+// pattern used across cmd/tapes/checkout and pkg/skill tests.
+type fakeQuerier struct {
+	summaries map[string][]skill.TraceSummary
+	traces    map[string]*skill.Trace
+}
+
+func (f *fakeQuerier) TraceSummaries(_ context.Context, sessionID string) ([]skill.TraceSummary, error) {
+	turns, ok := f.summaries[sessionID]
+	if !ok {
+		return nil, fmt.Errorf("session %s not found", sessionID)
+	}
+	return turns, nil
+}
+
+func (f *fakeQuerier) Trace(_ context.Context, traceID string) (*skill.Trace, error) {
+	trace, ok := f.traces[traceID]
+	if !ok {
+		return nil, fmt.Errorf("trace %s not found", traceID)
+	}
+	return trace, nil
+}
+
+func mainSpan(seq int64, text string) skill.Span {
+	return skill.Span{Kind: "llm", CallKind: "main", Seq: seq, Output: []llm.ContentBlock{{Type: "text", Text: text}}}
+}
+
+func toolSpan(seq int64, name string) skill.Span {
+	return skill.Span{Kind: "tool", Name: name, Seq: seq}
+}
+
+var _ = Describe("Turn", func() {
+	It("carries the exact exportTurn field shape with matching json tags", func() {
+		// T-2: omitempty regression — a zero-value Turn must serialize with
+		// only the always-present fields; omitempty fields must vanish.
+		turn := export.Turn{
+			TraceID:   "t1",
+			SessionID: "s1",
+			// UserPrompt, Response, StartedAt intentionally left zero.
+			TotalInputTokens:  0,
+			TotalOutputTokens: 0,
+			MainInputTokens:   0,
+			MainOutputTokens:  0,
+		}
+		raw, err := json.Marshal(turn)
+		Expect(err).NotTo(HaveOccurred())
+
+		var m map[string]any
+		Expect(json.Unmarshal(raw, &m)).To(Succeed())
+
+		// Always present, even at zero value.
+		Expect(m).To(HaveKey("trace_id"))
+		Expect(m).To(HaveKey("session_id"))
+		Expect(m).To(HaveKey("total_input_tokens"))
+		Expect(m).To(HaveKey("total_output_tokens"))
+		Expect(m).To(HaveKey("main_input_tokens"))
+		Expect(m).To(HaveKey("main_output_tokens"))
+
+		// omitempty fields must be absent when zero.
+		Expect(m).NotTo(HaveKey("user_prompt"))
+		Expect(m).NotTo(HaveKey("response"))
+		Expect(m).NotTo(HaveKey("started_at"))
+	})
+
+	It("includes omitempty fields when non-zero", func() {
+		turn := export.Turn{
+			TraceID:    "t1",
+			SessionID:  "s1",
+			UserPrompt: "hi",
+			Response:   "hello",
+			StartedAt:  "2026-06-01T09:00:00Z",
+		}
+		raw, err := json.Marshal(turn)
+		Expect(err).NotTo(HaveOccurred())
+
+		var m map[string]any
+		Expect(json.Unmarshal(raw, &m)).To(Succeed())
+		Expect(m["user_prompt"]).To(Equal("hi"))
+		Expect(m["response"]).To(Equal("hello"))
+		Expect(m["started_at"]).To(Equal("2026-06-01T09:00:00Z"))
+	})
+})
+
+var _ = Describe("SessionJSONL", func() {
+	var (
+		ctx     context.Context
+		querier *fakeQuerier
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		base := time.Date(2026, 6, 1, 9, 0, 0, 0, time.UTC)
+		querier = &fakeQuerier{
+			summaries: map[string][]skill.TraceSummary{
+				"session-1": {
+					{
+						TraceID: "t1", UserPrompt: "Fix the infinite loop", StartedAt: base,
+						TotalInputTokens: 100, TotalOutputTokens: 40, MainInputTokens: 80, MainOutputTokens: 30,
+					},
+					{
+						TraceID: "t2", UserPrompt: "Thanks", StartedAt: base.Add(time.Minute),
+						TotalInputTokens: 50, TotalOutputTokens: 10,
+					},
+					// synthetic turn — must be filtered out.
+					{TraceID: "t3", Synthetic: "compaction", UserPrompt: "compacted context", StartedAt: base.Add(2 * time.Minute)},
+				},
+			},
+			traces: map[string]*skill.Trace{
+				"t1": {TraceID: "t1", Spans: []skill.Span{
+					mainSpan(1, "Let me check the dependency array."),
+					toolSpan(2, "Read"),
+					mainSpan(3, "Fixed the object reference."),
+				}},
+				"t2": {TraceID: "t2", Spans: []skill.Span{mainSpan(1, "Glad it helped.")}},
+			},
+		}
+	})
+
+	It("writes one JSON object per non-synthetic turn to the given writer", func() {
+		var b strings.Builder
+		err := export.SessionJSONL(ctx, querier, "session-1", &b)
+		Expect(err).NotTo(HaveOccurred())
+
+		lines := nonEmptyLines(b.String())
+		Expect(lines).To(HaveLen(2))
+
+		var first map[string]any
+		Expect(json.Unmarshal([]byte(lines[0]), &first)).To(Succeed())
+		Expect(first["trace_id"]).To(Equal("t1"))
+		Expect(first["session_id"]).To(Equal("session-1"))
+		Expect(first["user_prompt"]).To(Equal("Fix the infinite loop"))
+		Expect(first["response"]).To(ContainSubstring("[assistant] Let me check the dependency array."))
+		Expect(first["response"]).To(ContainSubstring("[tools] Read"))
+		Expect(first["response"]).NotTo(ContainSubstring("[user]"))
+		Expect(first["total_input_tokens"]).To(BeNumerically("==", 100))
+		Expect(first["main_output_tokens"]).To(BeNumerically("==", 30))
+
+		var second map[string]any
+		Expect(json.Unmarshal([]byte(lines[1]), &second)).To(Succeed())
+		Expect(second["trace_id"]).To(Equal("t2"))
+	})
+
+	It("supports the trace filter transcript option", func() {
+		var b strings.Builder
+		err := export.SessionJSONL(ctx, querier, "session-1", &b, skill.WithTraceFilter("t1"))
+		Expect(err).NotTo(HaveOccurred())
+
+		lines := nonEmptyLines(b.String())
+		Expect(lines).To(HaveLen(1))
+		var rec map[string]any
+		Expect(json.Unmarshal([]byte(lines[0]), &rec)).To(Succeed())
+		Expect(rec["trace_id"]).To(Equal("t1"))
+	})
+
+	It("propagates a session lookup error", func() {
+		var b strings.Builder
+		err := export.SessionJSONL(ctx, querier, "missing", &b)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("streams to an io.Writer that is not a *strings.Builder", func() {
+		// Regression guard for the exportJSONL -> SessionJSONL generalization:
+		// the function must accept any io.Writer, not just *strings.Builder.
+		pr, pw := io.Pipe()
+		done := make(chan error, 1)
+		go func() {
+			done <- export.SessionJSONL(ctx, querier, "session-1", pw)
+			pw.Close()
+		}()
+
+		data, readErr := io.ReadAll(pr)
+		Expect(readErr).NotTo(HaveOccurred())
+		Expect(<-done).NotTo(HaveOccurred())
+
+		lines := nonEmptyLines(string(data))
+		Expect(lines).To(HaveLen(2))
+	})
+})
+
+func nonEmptyLines(s string) []string {
+	var out []string
+	for _, line := range strings.Split(s, "\n") {
+		if strings.TrimSpace(line) != "" {
+			out = append(out, line)
+		}
+	}
+	return out
+}


### PR DESCRIPTION
## Summary

- Two org-scoped NDJSON export endpoints, backing the console's new "export my data" feature.
- `GET /v1/sessions/:id/export` — one session's turns as JSONL.
- `GET /v1/sessions/export?since=&until=` — the org's sessions in a window as one streamed JSONL bundle (default trailing 30 days).
- Extracts the existing `tapes checkout` JSONL serializer into a shared `pkg/export`, so the CLI and the API emit the identical per-turn record shape (CLI output byte-identical, verified by golden test).

## How it works

- `pkg/export.SessionJSONL(ctx, querier, sessionID, w io.Writer)` writes one JSON object per turn (the existing `exportTurn` shape) to any writer — generalized from the CLI's `*strings.Builder` to `io.Writer` so the API can stream.
- `handleExportSession` mirrors `handleGetSession`/`handleDeleteSkill`: capability-check → 501, org-scoped `GetSessionRecord` → 404 (no cross-org leak), NDJSON headers + `Content-Disposition`, stream the session.
- `handleExportSessions` streams via fasthttp `SetBodyStreamWriter`, iterating `ListSessionRecords` pages past the 200-row UI cap with the existing keyset cursor, writing JSONL as it goes — memory is bounded by page size, not bundle size. `since` is clamped to `now−30d` so the 30-day window is the maximum span (R-20). Registered before `/:id` to avoid route shadowing.
- No schema/migration change; no new auth boundary (org scope via the existing trusted `X-Tapes-Org-Id`).

## Test plan

- [x] `pkg/export` golden test — extracted serializer byte-identical to pre-refactor checkout
- [x] `GET /:id/export` — 200 + full JSONL, filename, cross-org 404, malformed-id 400, 501 gate
- [x] `GET /export` — default 30-day window, since/until override, org isolation, >200-row cap bypass, chunked streaming, route-shadowing
- [x] `since`-clamp — a 40-day-old session is excluded even with `since=1970`
- [x] gzip-over-streaming — `Accept-Encoding: gzip` yields a correctly compressed streamed NDJSON body
- [x] `go build ./...`, `go vet`, `gofmt` clean; validated end-to-end in a clearing against real Postgres

Design + requirements + full test plan live in `docs/features/0001-export-data-from-console/` (companion console PR) and the Linear project.

Non-blocking follow-ups: redundant per-session org re-check (N+1) in the bundle loop; stream duration under-reported by the RED-metrics middleware for streaming responses.

Part of PCC-858
