### PR TITLE
:sparkles: feat(pricing): price GPT-5.6 model tiers

### DIFF
--- a/pkg/sessions/pricing.go
+++ b/pkg/sessions/pricing.go
@@ -10,14 +10,15 @@ import (
 
 // DefaultPricing returns hardcoded pricing per million tokens for supported models.
 //
-// Last verified: 2026-07-01
+// Last verified: 2026-07-09
 // Sources:
 //   - Anthropic: https://platform.claude.com/docs/en/about-claude/pricing
 //   - OpenAI:    https://platform.openai.com/docs/pricing
 //   - DeepSeek:  https://api-docs.deepseek.com/quick_start/pricing
 //
 // Anthropic cache multipliers: CacheWrite = 1.25x input, CacheRead = 0.10x input.
-// OpenAI cache: CacheWrite = 1x input (no surcharge), CacheRead = 0.50x input (except o3-mini).
+// OpenAI cache: CacheWrite = 1x input and CacheRead = 0.50x input for older models;
+// GPT-5.6+ uses CacheWrite = 1.25x input and CacheRead = 0.10x input.
 //
 // To override at runtime, pass a JSON file path to LoadPricing.
 func DefaultPricing() PricingTable {
@@ -51,6 +52,9 @@ func DefaultPricing() PricingTable {
 		"o3":                {Input: 2.00, Output: 8.00, CacheRead: 0.50, CacheWrite: 2.00},
 		"o3-mini":           {Input: 1.10, Output: 4.40, CacheRead: 0.55, CacheWrite: 1.10},
 		"o4-mini":           {Input: 1.10, Output: 4.40, CacheRead: 0.275, CacheWrite: 1.10},
+		"gpt-5.6-sol":       {Input: 5.00, Output: 30.00, CacheRead: 0.50, CacheWrite: 6.25},
+		"gpt-5.6-terra":     {Input: 2.50, Output: 15.00, CacheRead: 0.25, CacheWrite: 3.125},
+		"gpt-5.6-luna":      {Input: 1.00, Output: 6.00, CacheRead: 0.10, CacheWrite: 1.25},
 		"gpt-5.5":           {Input: 5.00, Output: 30.00, CacheRead: 0.50, CacheWrite: 5.00},
 		"gpt-5.4":           {Input: 2.50, Output: 15.00, CacheRead: 0.25, CacheWrite: 2.50},
 		"gpt-5.3-codex":     {Input: 1.75, Output: 14.00, CacheRead: 0.175, CacheWrite: 1.75},
@@ -150,6 +154,7 @@ func NormalizeModel(model string) string {
 	// Strip OpenAI-style date suffix: -YYYY-MM-DD
 	normalized = stripOpenAIDateSuffix(normalized)
 
+	normalized = strings.ReplaceAll(normalized, "-5-6", "-5.6")
 	normalized = strings.ReplaceAll(normalized, "-5-5", "-5.5")
 	normalized = strings.ReplaceAll(normalized, "-5-4", "-5.4")
 	normalized = strings.ReplaceAll(normalized, "-5-3", "-5.3")

--- a/pkg/sessions/status_pricing_test.go
+++ b/pkg/sessions/status_pricing_test.go
@@ -84,6 +84,8 @@ var _ = Describe("NormalizeModel", func() {
 	It("strips OpenAI-style date suffix", func() {
 		Expect(sessions.NormalizeModel("gpt-4o-2024-08-06")).To(Equal("gpt-4o"))
 		// Codex default model id as seen on the Responses wire.
+		Expect(sessions.NormalizeModel("gpt-5.6-sol-2026-07-09")).To(Equal("gpt-5.6-sol"))
+		Expect(sessions.NormalizeModel("gpt-5-6-sol-2026-07-09")).To(Equal("gpt-5.6-sol"))
 		Expect(sessions.NormalizeModel("gpt-5.5-2026-04-23")).To(Equal("gpt-5.5"))
 		Expect(sessions.NormalizeModel("gpt-5-5-2026-04-23")).To(Equal("gpt-5.5"))
 	})
@@ -127,6 +129,25 @@ var _ = Describe("NormalizeModel", func() {
 			api := strings.ReplaceAll(key, ".", "-")
 			Expect(sessions.NormalizeModel(api)).To(Equal(key), "bare API form %q", api)
 			Expect(sessions.NormalizeModel(api+"-20260101")).To(Equal(key), "dated API form %q", api+"-20260101")
+		}
+	})
+	It("resolves GPT-5.6 tier pricing and cache multipliers", func() {
+		pricing := sessions.DefaultPricing()
+		for _, p := range []struct {
+			api                             string
+			input, output, read, cacheWrite float64
+		}{
+			{"gpt-5.6-sol", 5.00, 30.00, 0.50, 6.25},
+			{"gpt-5.6-terra", 2.50, 15.00, 0.25, 3.125},
+			{"gpt-5.6-luna", 1.00, 6.00, 0.10, 1.25},
+			{"gpt-5-6-sol-2026-07-09", 5.00, 30.00, 0.50, 6.25},
+		} {
+			price, ok := sessions.PricingForModel(pricing, p.api)
+			Expect(ok).To(BeTrue(), "PricingForModel(%q)", p.api)
+			Expect(price.Input).To(BeNumerically("==", p.input), "input $/MTok for %q", p.api)
+			Expect(price.Output).To(BeNumerically("==", p.output), "output $/MTok for %q", p.api)
+			Expect(price.CacheRead).To(BeNumerically("==", p.read), "cache-read $/MTok for %q", p.api)
+			Expect(price.CacheWrite).To(BeNumerically("==", p.cacheWrite), "cache-write $/MTok for %q", p.api)
 		}
 	})
 	It("returns empty for empty input", func() {

--- a/pkg/sessions/status_pricing_test.go
+++ b/pkg/sessions/status_pricing_test.go
@@ -141,6 +141,8 @@ var _ = Describe("NormalizeModel", func() {
 			{"gpt-5.6-terra", 2.50, 15.00, 0.25, 3.125},
 			{"gpt-5.6-luna", 1.00, 6.00, 0.10, 1.25},
 			{"gpt-5-6-sol-2026-07-09", 5.00, 30.00, 0.50, 6.25},
+			{"gpt-5-6-terra-2026-07-09", 2.50, 15.00, 0.25, 3.125},
+			{"gpt-5-6-luna-2026-07-09", 1.00, 6.00, 0.10, 1.25},
 		} {
 			price, ok := sessions.PricingForModel(pricing, p.api)
 			Expect(ok).To(BeTrue(), "PricingForModel(%q)", p.api)


### PR DESCRIPTION
# 👨🏼

Include GPT 5.6 pricing

Refs PCC-861

# 🤖

## Summary
- Add GPT-5.6 Sol, Terra, and Luna to the default model pricing table.
- Normalize dashed GPT-5.6 API model names to the dotted pricing key form.
- Cover GPT-5.6 cache-write and cache-read pricing in tests.

## Tests
- `direnv exec "$PWD" sh -c 'cd telemetry/tapes && GOEXPERIMENT=jsonv2 go test ./pkg/sessions'`
