### PR TITLE
✨ feat: nest session exports with trace/span granularity

### DIFF
--- a/api/sessions_export_all_handlers_test.go
+++ b/api/sessions_export_all_handlers_test.go
@@ -231,6 +231,29 @@ var _ = Describe("GET /v1/sessions/export", func() {
 		Entry("when until is before since", now.Add(-2*time.Minute), now.Add(-5*time.Minute)),
 	)
 
+	// detail=traces: one header-only line per session, grain in the filename.
+	It("exports turn headers per session at detail=traces", func() {
+		drv := newPagingDriver(org, 3, now)
+		server := newExportServer(drv)
+
+		resp, body := getRaw(server, "/v1/sessions/export?detail=traces", org)
+		Expect(resp.StatusCode).To(Equal(fiber.StatusOK))
+		Expect(resp.Header.Get("Content-Disposition")).To(ContainSubstring("-traces.jsonl"))
+
+		lines := nonEmptyLinesAPI(string(body))
+		Expect(lines).To(HaveLen(3))
+		Expect(string(body)).To(ContainSubstring(`"trace_id":"session-0000-t1"`))
+		Expect(string(body)).NotTo(ContainSubstring(`"spans"`))
+	})
+
+	It("returns 400 for an unrecognized detail value", func() {
+		drv := newPagingDriver(org, 1, now)
+		server := newExportServer(drv)
+
+		resp, _ := getRaw(server, "/v1/sessions/export?detail=bogus", org)
+		Expect(resp.StatusCode).To(Equal(fiber.StatusBadRequest))
+	})
+
 	// T-9: org isolation.
 	It("only includes sessions belonging to the requesting org", func() {
 		drv := newPagingDriver(org, 5, now)

--- a/api/sessions_export_handlers_test.go
+++ b/api/sessions_export_handlers_test.go
@@ -202,6 +202,45 @@ var _ = Describe("GET /v1/sessions/:id/export", func() {
 		Expect(drv.lastGetID).To(Equal(sessionID))
 	})
 
+	// detail=traces: turn headers only, no span payloads loaded.
+	It("exports turn headers without spans or links at detail=traces", func() {
+		drv := newDriverWithSession()
+		server := newExportServer(drv)
+
+		resp, body := getRaw(server, "/v1/sessions/"+sessionID+"/export?detail=traces", org)
+		Expect(resp.StatusCode).To(Equal(fiber.StatusOK))
+		Expect(resp.Header.Get("Content-Disposition")).To(ContainSubstring("-traces.jsonl"))
+
+		lines := nonEmptyLinesAPI(string(body))
+		Expect(lines).To(HaveLen(1))
+
+		var line map[string]json.RawMessage
+		Expect(json.Unmarshal([]byte(lines[0]), &line)).To(Succeed())
+		Expect(line).To(HaveKey("session"))
+		Expect(line).NotTo(HaveKey("tasks"))
+		Expect(line).NotTo(HaveKey("kind_counts"))
+
+		var traces []map[string]json.RawMessage
+		Expect(json.Unmarshal(line["traces"], &traces)).To(Succeed())
+		Expect(traces).To(HaveLen(2))
+		for _, td := range traces {
+			Expect(td).To(HaveKey("trace"))
+			Expect(td).NotTo(HaveKey("spans"))
+			Expect(td).NotTo(HaveKey("links"))
+		}
+		// Header content survives; span payloads do not.
+		Expect(lines[0]).To(ContainSubstring(`"trace_id":"t1"`))
+		Expect(lines[0]).NotTo(ContainSubstring(`"span_id"`))
+	})
+
+	It("returns 400 for an unrecognized detail value", func() {
+		drv := newDriverWithSession()
+		server := newExportServer(drv)
+
+		resp, _ := getRaw(server, "/v1/sessions/"+sessionID+"/export?detail=bogus", org)
+		Expect(resp.StatusCode).To(Equal(fiber.StatusBadRequest))
+	})
+
 	// T-4: filename includes the session id.
 	It("sets Content-Disposition with a filename containing the session id", func() {
 		drv := newDriverWithSession()

--- a/api/sessions_export_handlers_test.go
+++ b/api/sessions_export_handlers_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"strings"
@@ -17,13 +18,14 @@ import (
 )
 
 // exportStubDriver wraps a real storage.Driver and implements the
-// sessionsReader and spanModelReader capability interfaces needed by the
-// export handlers and the in-process skillTraceQuerier they use.
+// sessionsReader and spanModelReader capability interfaces the export
+// handlers need.
 type exportStubDriver struct {
 	storage.Driver
 
 	sessionsByOrg map[string]map[string]storage.SessionRecord // orgID -> sessionID -> record
 	summaries     map[string][]storage.TraceSummaryRecord     // sessionID -> turns
+	spans         map[string][]storage.SpanRecord             // sessionID -> spans
 
 	getSessionCalls int
 	lastGetOrg      string
@@ -61,8 +63,16 @@ func (d *exportStubDriver) GetTraceDetail(_ context.Context, _, _ string) (*stor
 	return nil, nil, nil, nil
 }
 
-func (d *exportStubDriver) ListSessionSpanModel(context.Context, string) ([]storage.SpanTurnRecord, []storage.SpanRecord, []storage.SpanLinkRecord, error) {
-	return nil, nil, nil, nil
+// ListSessionSpanModel serves the fixture turns/spans for a session. Like
+// the real driver's rows, every returned record carries its session id.
+func (d *exportStubDriver) ListSessionSpanModel(_ context.Context, sessionID string) ([]storage.SpanTurnRecord, []storage.SpanRecord, []storage.SpanLinkRecord, error) {
+	turns := make([]storage.SpanTurnRecord, 0, len(d.summaries[sessionID]))
+	for _, t := range d.summaries[sessionID] {
+		turn := t.SpanTurnRecord
+		turn.SessionID = sessionID
+		turns = append(turns, turn)
+	}
+	return turns, d.spans[sessionID], nil, nil
 }
 
 func (d *exportStubDriver) GetSpanRecord(context.Context, string, string, string) (*storage.SpanRecord, error) {
@@ -129,11 +139,32 @@ var _ = Describe("GET /v1/sessions/:id/export", func() {
 					}},
 				},
 			},
+			spans: map[string][]storage.SpanRecord{
+				sessionID: {
+					{
+						TraceID: "t1", SpanID: "s1", Kind: "llm", Status: "ok",
+						CallKind: "main", Model: "claude-test", Seq: 1,
+						StartedAt: record.StartedAt,
+						Input:     []byte(`[{"type":"text","text":"hi"}]`),
+						Output:    []byte(`[{"type":"text","text":"hello"}]`),
+						Usage:     []byte(`{"input_tokens":10,"output_tokens":5}`),
+					},
+					{
+						TraceID: "t2", SpanID: "s2", Kind: "llm", Status: "ok",
+						CallKind: "main", Model: "claude-test", Seq: 1,
+						StartedAt: record.StartedAt.Add(time.Minute),
+						Input:     []byte(`[{"type":"text","text":"thanks"}]`),
+						Output:    []byte(`[{"type":"text","text":"np"}]`),
+						Usage:     []byte(`{"input_tokens":4,"output_tokens":2}`),
+					},
+				},
+			},
 		}
 	}
 
-	// T-3: 200 + headers + line count + full fidelity.
-	It("returns 200 NDJSON with one line per turn and the expected headers", func() {
+	// T-3: 200 + headers + the nested session → traces → spans grain on a
+	// single JSONL line.
+	It("returns 200 with one JSONL line nesting the session's traces and their spans", func() {
 		drv := newDriverWithSession()
 		server := newExportServer(drv)
 
@@ -142,17 +173,31 @@ var _ = Describe("GET /v1/sessions/:id/export", func() {
 		Expect(resp.Header.Get("Content-Type")).To(ContainSubstring("application/x-ndjson"))
 
 		lines := nonEmptyLinesAPI(string(body))
-		Expect(lines).To(HaveLen(2))
-		Expect(string(body)).To(ContainSubstring(`"trace_id":"t1"`))
-		Expect(string(body)).To(ContainSubstring(`"trace_id":"t2"`))
-		Expect(string(body)).To(ContainSubstring(`"session_id":"` + sessionID + `"`))
+		Expect(lines).To(HaveLen(1))
 
-		// GetSessionRecord is called twice by design: once by the handler's
-		// own pre-flight 404 gate (so no headers/body are ever sent for a
-		// session outside the org), and once more inside
-		// skillTraceQuerier.TraceSummaries, which independently re-scopes
-		// every read to the bound org.
-		Expect(drv.getSessionCalls).To(Equal(2))
+		// The line is the same nested shape GET /v1/sessions/{id}/traces
+		// serves: the session object, its traces, and each trace's spans
+		// with full payloads.
+		var line SessionTracesResponse
+		Expect(json.Unmarshal([]byte(lines[0]), &line)).To(Succeed())
+		Expect(line.Session.ID).To(Equal(sessionID))
+		Expect(line.Traces).To(HaveLen(2))
+		Expect(line.Traces[0].Trace.TraceID).To(Equal("t1"))
+		Expect(line.Traces[0].Trace.SessionID).To(Equal(sessionID))
+		Expect(line.Traces[0].Spans).To(HaveLen(1))
+		Expect(line.Traces[0].Spans[0].SpanID).To(Equal("s1"))
+		Expect(line.Traces[0].Spans[0].Metadata).To(HaveKeyWithValue("model", "claude-test"))
+		Expect(line.Traces[1].Trace.TraceID).To(Equal("t2"))
+		Expect(line.Traces[1].Spans).To(HaveLen(1))
+		Expect(line.Traces[1].Spans[0].SpanID).To(Equal("s2"))
+		// Full payload mode: span input/output content is embedded verbatim.
+		Expect(lines[0]).To(ContainSubstring(`"text":"hello"`))
+		Expect(lines[0]).To(ContainSubstring(`"input_tokens":10`))
+
+		// GetSessionRecord is called exactly once, by the handler's
+		// pre-flight 404 gate, so no headers/body are ever sent for a
+		// session outside the org.
+		Expect(drv.getSessionCalls).To(Equal(1))
 		Expect(drv.lastGetOrg).To(Equal(org))
 		Expect(drv.lastGetID).To(Equal(sessionID))
 	})

--- a/api/sessions_handlers.go
+++ b/api/sessions_handlers.go
@@ -8,13 +8,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"strconv"
 	"time"
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/google/uuid"
 
-	"github.com/papercomputeco/tapes/pkg/export"
 	"github.com/papercomputeco/tapes/pkg/llm"
 	"github.com/papercomputeco/tapes/pkg/storage"
 )
@@ -401,16 +401,33 @@ func (s *Server) handleGetSession(c *fiber.Ctx) error {
 	})
 }
 
-// handleExportSession handles GET /v1/sessions/:id/export. It streams the
-// same JSONL grain `tapes checkout --format jsonl` renders, over HTTP, for
-// the console's per-session download.
+// exportSessionLine renders one session's export record: the same
+// nested session → traces → spans projection GET /v1/sessions/{id}/traces
+// serves (full payloads), encoded as a single JSON line. Both export
+// endpoints emit this grain, so a bulk export is exactly a concatenation
+// of per-session exports.
+func exportSessionLine(ctx context.Context, reader spanModelReader, sess storage.SessionRecord, w io.Writer) error {
+	turns, spans, links, err := reader.ListSessionSpanModel(ctx, sess.ID)
+	if err != nil {
+		return fmt.Errorf("list span model for session %s: %w", sess.ID, err)
+	}
+	resp := BuildSessionTraces(sessionItemFromStorage(sess), turns, spans, links, PayloadFull)
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		return fmt.Errorf("encoding session %s: %w", sess.ID, err)
+	}
+	return nil
+}
+
+// handleExportSession handles GET /v1/sessions/:id/export. It renders the
+// session's full trace/span projection as one JSONL line, for the
+// console's per-session download.
 //
 //	@Summary		Export a session as JSONL
-//	@Description	Streams one JSON object per turn (NDJSON) as a downloadable attachment: the same conversation-export grain as `tapes checkout --format jsonl`.
+//	@Description	Returns the session as a single JSON line (downloadable attachment): the session object with its traces, each trace carrying its full spans — the same shape as GET /v1/sessions/{id}/traces with payload=full.
 //	@Tags			sessions
 //	@Produce		application/x-ndjson
 //	@Param			id	path	string	true	"Session id (UUID)"
-//	@Success		200	{string}	string	"NDJSON body, one JSON object per turn"
+//	@Success		200	{string}	string	"JSONL body, one session object with nested traces and spans"
 //	@Failure		400	{object}	llm.ErrorResponse	"Missing or malformed id"
 //	@Failure		404	{object}	llm.ErrorResponse	"Session not found"
 //	@Failure		500	{object}	llm.ErrorResponse	"Failed to load or render the session"
@@ -420,6 +437,13 @@ func (s *Server) handleExportSession(c *fiber.Ctx) error {
 	reader, ok := s.driver.(sessionsReader)
 	if !ok {
 		return c.Status(fiber.StatusNotImplemented).JSON(llm.ErrorResponse{Error: "sessions not supported by this backend"})
+	}
+	// The export needs both sessionsReader and spanModelReader; a driver
+	// can implement the former without the latter, so this is a second,
+	// independent 501 gate checked before any header is set.
+	spanReader, ok := s.driver.(spanModelReader)
+	if !ok {
+		return c.Status(fiber.StatusNotImplemented).JSON(llm.ErrorResponse{Error: "span traces not supported by this backend"})
 	}
 
 	id := c.Params("id")
@@ -443,14 +467,6 @@ func (s *Server) handleExportSession(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusNotFound).JSON(llm.ErrorResponse{Error: "session not found"})
 	}
 
-	// The querier needs both sessionsReader and spanModelReader; a driver
-	// can implement the former without the latter, so this is a second,
-	// independent 501 gate checked before any header is set.
-	query, ok := s.skillTraceQuerier(orgID)
-	if !ok {
-		return c.Status(fiber.StatusNotImplemented).JSON(llm.ErrorResponse{Error: "sessions not supported by this backend"})
-	}
-
 	// Render into a buffer first so the NDJSON/attachment headers are only
 	// committed once the export succeeds. A single session is bounded, so
 	// buffering is cheap — and it means a mid-render failure returns a clean
@@ -459,7 +475,7 @@ func (s *Server) handleExportSession(c *fiber.Ctx) error {
 	// happened. (The streaming bulk endpoint can't do this; a single session
 	// can.)
 	var buf bytes.Buffer
-	if err := export.SessionJSONL(c.Context(), query, id, &buf); err != nil {
+	if err := exportSessionLine(c.Context(), spanReader, *sess, &buf); err != nil {
 		s.logger.Error("export session", "id", id, "error", err)
 		return c.Status(fiber.StatusInternalServerError).JSON(llm.ErrorResponse{Error: "failed to render session export"})
 	}
@@ -479,17 +495,18 @@ func (s *Server) handleExportSession(c *fiber.Ctx) error {
 const exportSessionsPageLimit = maxSessionsLimit
 
 // handleExportSessions handles GET /v1/sessions/export?since=&until=. It
-// streams every session's JSONL turns in the requested window (default:
-// trailing 30 days) as a single NDJSON attachment, paging internally past
-// the 200-row UI cap via the same keyset cursor handleListSessions uses.
+// streams every session in the requested window (default: trailing 30
+// days) as one nested JSON line each — session → traces → spans — paging
+// internally past the 200-row UI cap via the same keyset cursor
+// handleListSessions uses.
 //
 //	@Summary		Export sessions in a time window as JSONL
-//	@Description	Streams every session's turns (NDJSON) in the given window, newest-first, as a downloadable attachment. Defaults to the trailing 30 days. Not bounded by the /v1/sessions list cap — pages internally.
+//	@Description	Streams one JSON line per session in the given window, newest-first, as a downloadable attachment. Each line is the session object with its traces, each trace carrying its full spans — the same shape as GET /v1/sessions/{id}/traces with payload=full. Defaults to the trailing 30 days. Not bounded by the /v1/sessions list cap — pages internally.
 //	@Tags			sessions
 //	@Produce		application/x-ndjson
 //	@Param			since	query	string	false	"Only include sessions active (last_seen_at) at or after this RFC3339 timestamp (default: now - 30 days)"	format(date-time)
 //	@Param			until	query	string	false	"Only include sessions active (last_seen_at) before this RFC3339 timestamp"								format(date-time)
-//	@Success		200		{string}	string	"NDJSON body, one JSON object per turn across every session in the window"
+//	@Success		200		{string}	string	"JSONL body, one JSON object per session with nested traces and spans"
 //	@Failure		400		{object}	llm.ErrorResponse	"Malformed since/until"
 //	@Failure		500		{object}	llm.ErrorResponse	"Failed to list or render sessions"
 //	@Failure		501		{object}	llm.ErrorResponse	"Sessions not supported by this backend"
@@ -499,9 +516,9 @@ func (s *Server) handleExportSessions(c *fiber.Ctx) error {
 	if !ok {
 		return c.Status(fiber.StatusNotImplemented).JSON(llm.ErrorResponse{Error: "sessions not supported by this backend"})
 	}
-	query, ok := s.skillTraceQuerier(orgIDFromCtx(c))
+	spanReader, ok := s.driver.(spanModelReader)
 	if !ok {
-		return c.Status(fiber.StatusNotImplemented).JSON(llm.ErrorResponse{Error: "sessions not supported by this backend"})
+		return c.Status(fiber.StatusNotImplemented).JSON(llm.ErrorResponse{Error: "span traces not supported by this backend"})
 	}
 
 	// The 30-day window is the maximum span for v1 (R-20), not just the
@@ -558,7 +575,7 @@ func (s *Server) handleExportSessions(c *fiber.Ctx) error {
 	// status is already committed by the time bytes are flowing (documented
 	// as an accepted v1 tradeoff in the design). ctx.Bind() is unavailable
 	// here (this is the raw fasthttp callback, not a fiber.Ctx), so orgID,
-	// since, until, reader, and query are captured directly.
+	// since, until, reader, and spanReader are captured directly.
 	ctx.SetBodyStreamWriter(func(w *bufio.Writer) {
 		streamCtx, cancel := context.WithCancel(ctx)
 		defer cancel()
@@ -576,7 +593,7 @@ func (s *Server) handleExportSessions(c *fiber.Ctx) error {
 				return
 			}
 			for _, sess := range sessions {
-				if err := export.SessionJSONL(streamCtx, query, sess.ID, w); err != nil {
+				if err := exportSessionLine(streamCtx, spanReader, sess, w); err != nil {
 					s.logger.Error("export session", "id", sess.ID, "error", err)
 					return
 				}

--- a/api/sessions_handlers.go
+++ b/api/sessions_handlers.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/gofiber/fiber/v2"
@@ -401,12 +402,74 @@ func (s *Server) handleGetSession(c *fiber.Ctx) error {
 	})
 }
 
-// exportSessionLine renders one session's export record: the same
-// nested session → traces → spans projection GET /v1/sessions/{id}/traces
-// serves (full payloads), encoded as a single JSON line. Both export
-// endpoints emit this grain, so a bulk export is exactly a concatenation
-// of per-session exports.
-func exportSessionLine(ctx context.Context, reader spanModelReader, sess storage.SessionRecord, w io.Writer) error {
+// exportDetail selects how much of the span projection an export line
+// carries: full spans (the default) or trace headers only.
+type exportDetail string
+
+const (
+	exportDetailSpans  exportDetail = "spans"
+	exportDetailTraces exportDetail = "traces"
+)
+
+// exportDetailFromQuery maps the ?detail= query param to a grain; empty
+// defaults to the full span grain. The second return is false for an
+// unrecognized value so handlers can 400 instead of silently exporting
+// a different grain than the caller asked for.
+func exportDetailFromQuery(v string) (exportDetail, bool) {
+	switch v {
+	case "", string(exportDetailSpans):
+		return exportDetailSpans, true
+	case string(exportDetailTraces):
+		return exportDetailTraces, true
+	}
+	return "", false
+}
+
+// exportTraceHeader is one trace in a detail=traces export line: the
+// turn header alone, with no spans/links keys at all — omitting them
+// distinguishes "not exported at this grain" from "zero spans".
+type exportTraceHeader struct {
+	Trace TraceItem `json:"trace"`
+}
+
+// exportSessionTraceHeaders is a detail=traces export line: the session
+// with its turn headers. tasks/kind_counts are span-derived, so they are
+// omitted along with the spans.
+type exportSessionTraceHeaders struct {
+	Session SessionItem         `json:"session"`
+	Traces  []exportTraceHeader `json:"traces"`
+}
+
+// exportSessionLine renders one session's export record as a single JSON
+// line. At the spans grain (default) it is the same nested session →
+// traces → spans projection GET /v1/sessions/{id}/traces serves (full
+// payloads); at the traces grain it is the session with turn headers
+// only, read via ListTraceSummaries so span payloads are never loaded.
+// Both export endpoints emit these grains, so a bulk export is exactly a
+// concatenation of per-session exports.
+func exportSessionLine(ctx context.Context, reader spanModelReader, sess storage.SessionRecord, detail exportDetail, w io.Writer) error {
+	if detail == exportDetailTraces {
+		rows, err := reader.ListTraceSummaries(ctx, sess.ID)
+		if err != nil {
+			return fmt.Errorf("list trace summaries for session %s: %w", sess.ID, err)
+		}
+		item := sessionItemFromStorage(sess)
+		line := exportSessionTraceHeaders{
+			Session: item,
+			Traces:  make([]exportTraceHeader, 0, len(rows)),
+		}
+		for _, row := range rows {
+			ti := traceItemFromTurn(row.SpanTurnRecord, row.SpanCount)
+			ti.HarnessID = item.HarnessID
+			ti.HarnessSessionID = item.HarnessSessionID
+			line.Traces = append(line.Traces, exportTraceHeader{Trace: ti})
+		}
+		if err := json.NewEncoder(w).Encode(line); err != nil {
+			return fmt.Errorf("encoding session %s: %w", sess.ID, err)
+		}
+		return nil
+	}
+
 	turns, spans, links, err := reader.ListSessionSpanModel(ctx, sess.ID)
 	if err != nil {
 		return fmt.Errorf("list span model for session %s: %w", sess.ID, err)
@@ -418,20 +481,30 @@ func exportSessionLine(ctx context.Context, reader spanModelReader, sess storage
 	return nil
 }
 
+// exportFilename appends the non-default grain to an export filename so
+// a traces-grain download is distinguishable from a full one on disk.
+func exportFilename(base string, detail exportDetail) string {
+	if detail == exportDetailTraces {
+		return strings.TrimSuffix(base, ".jsonl") + "-traces.jsonl"
+	}
+	return base
+}
+
 // handleExportSession handles GET /v1/sessions/:id/export. It renders the
 // session's full trace/span projection as one JSONL line, for the
 // console's per-session download.
 //
 //	@Summary		Export a session as JSONL
-//	@Description	Returns the session as a single JSON line (downloadable attachment): the session object with its traces, each trace carrying its full spans — the same shape as GET /v1/sessions/{id}/traces with payload=full.
+//	@Description	Returns the session as a single JSON line (downloadable attachment): the session object with its traces, each trace carrying its full spans — the same shape as GET /v1/sessions/{id}/traces with payload=full. detail=traces exports turn headers only (no spans or links).
 //	@Tags			sessions
 //	@Produce		application/x-ndjson
-//	@Param			id	path	string	true	"Session id (UUID)"
-//	@Success		200	{string}	string	"JSONL body, one session object with nested traces and spans"
-//	@Failure		400	{object}	llm.ErrorResponse	"Missing or malformed id"
-//	@Failure		404	{object}	llm.ErrorResponse	"Session not found"
-//	@Failure		500	{object}	llm.ErrorResponse	"Failed to load or render the session"
-//	@Failure		501	{object}	llm.ErrorResponse	"Sessions not supported by this backend"
+//	@Param			id		path	string	true	"Session id (UUID)"
+//	@Param			detail	query	string	false	"Export granularity: spans (default, traces with full spans) or traces (turn headers only)"	Enums(spans, traces)
+//	@Success		200		{string}	string	"JSONL body, one session object with nested traces (and spans at detail=spans)"
+//	@Failure		400		{object}	llm.ErrorResponse	"Missing or malformed id, or unrecognized detail"
+//	@Failure		404		{object}	llm.ErrorResponse	"Session not found"
+//	@Failure		500		{object}	llm.ErrorResponse	"Failed to load or render the session"
+//	@Failure		501		{object}	llm.ErrorResponse	"Sessions not supported by this backend"
 //	@Router			/v1/sessions/{id}/export [get]
 func (s *Server) handleExportSession(c *fiber.Ctx) error {
 	reader, ok := s.driver.(sessionsReader)
@@ -452,6 +525,10 @@ func (s *Server) handleExportSession(c *fiber.Ctx) error {
 	}
 	if _, err := uuid.Parse(id); err != nil {
 		return c.Status(fiber.StatusBadRequest).JSON(llm.ErrorResponse{Error: "id must be a valid UUID"})
+	}
+	detail, ok := exportDetailFromQuery(c.Query("detail"))
+	if !ok {
+		return c.Status(fiber.StatusBadRequest).JSON(llm.ErrorResponse{Error: "detail must be spans or traces"})
 	}
 
 	orgID := orgIDFromCtx(c)
@@ -475,12 +552,12 @@ func (s *Server) handleExportSession(c *fiber.Ctx) error {
 	// happened. (The streaming bulk endpoint can't do this; a single session
 	// can.)
 	var buf bytes.Buffer
-	if err := exportSessionLine(c.Context(), spanReader, *sess, &buf); err != nil {
+	if err := exportSessionLine(c.Context(), spanReader, *sess, detail, &buf); err != nil {
 		s.logger.Error("export session", "id", id, "error", err)
 		return c.Status(fiber.StatusInternalServerError).JSON(llm.ErrorResponse{Error: "failed to render session export"})
 	}
 
-	filename := fmt.Sprintf("session-%s-%s.jsonl", id, time.Now().UTC().Format("2006-01-02"))
+	filename := exportFilename(fmt.Sprintf("session-%s-%s.jsonl", id, time.Now().UTC().Format("2006-01-02")), detail)
 	c.Set("Content-Type", "application/x-ndjson")
 	c.Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", filename))
 	return c.Send(buf.Bytes())
@@ -501,13 +578,14 @@ const exportSessionsPageLimit = maxSessionsLimit
 // handleListSessions uses.
 //
 //	@Summary		Export sessions in a time window as JSONL
-//	@Description	Streams one JSON line per session in the given window, newest-first, as a downloadable attachment. Each line is the session object with its traces, each trace carrying its full spans — the same shape as GET /v1/sessions/{id}/traces with payload=full. Defaults to the trailing 30 days. Not bounded by the /v1/sessions list cap — pages internally.
+//	@Description	Streams one JSON line per session in the given window, newest-first, as a downloadable attachment. Each line is the session object with its traces, each trace carrying its full spans — the same shape as GET /v1/sessions/{id}/traces with payload=full. detail=traces exports turn headers only (no spans or links). Defaults to the trailing 30 days. Not bounded by the /v1/sessions list cap — pages internally.
 //	@Tags			sessions
 //	@Produce		application/x-ndjson
 //	@Param			since	query	string	false	"Only include sessions active (last_seen_at) at or after this RFC3339 timestamp (default: now - 30 days)"	format(date-time)
 //	@Param			until	query	string	false	"Only include sessions active (last_seen_at) before this RFC3339 timestamp"								format(date-time)
-//	@Success		200		{string}	string	"JSONL body, one JSON object per session with nested traces and spans"
-//	@Failure		400		{object}	llm.ErrorResponse	"Malformed since/until"
+//	@Param			detail	query	string	false	"Export granularity: spans (default, traces with full spans) or traces (turn headers only)"				Enums(spans, traces)
+//	@Success		200		{string}	string	"JSONL body, one JSON object per session with nested traces (and spans at detail=spans)"
+//	@Failure		400		{object}	llm.ErrorResponse	"Malformed since/until, or unrecognized detail"
 //	@Failure		500		{object}	llm.ErrorResponse	"Failed to list or render sessions"
 //	@Failure		501		{object}	llm.ErrorResponse	"Sessions not supported by this backend"
 //	@Router			/v1/sessions/export [get]
@@ -519,6 +597,10 @@ func (s *Server) handleExportSessions(c *fiber.Ctx) error {
 	spanReader, ok := s.driver.(spanModelReader)
 	if !ok {
 		return c.Status(fiber.StatusNotImplemented).JSON(llm.ErrorResponse{Error: "span traces not supported by this backend"})
+	}
+	detail, ok := exportDetailFromQuery(c.Query("detail"))
+	if !ok {
+		return c.Status(fiber.StatusBadRequest).JSON(llm.ErrorResponse{Error: "detail must be spans or traces"})
 	}
 
 	// The 30-day window is the maximum span for v1 (R-20), not just the
@@ -567,6 +649,7 @@ func (s *Server) handleExportSessions(c *fiber.Ctx) error {
 		}
 		filename = fmt.Sprintf("sessions-%s-to-%s.jsonl", since.UTC().Format("2006-01-02"), end)
 	}
+	filename = exportFilename(filename, detail)
 	c.Set("Content-Type", "application/x-ndjson")
 	c.Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", filename))
 
@@ -593,7 +676,7 @@ func (s *Server) handleExportSessions(c *fiber.Ctx) error {
 				return
 			}
 			for _, sess := range sessions {
-				if err := exportSessionLine(streamCtx, spanReader, sess, w); err != nil {
+				if err := exportSessionLine(streamCtx, spanReader, sess, detail, w); err != nil {
 					s.logger.Error("export session", "id", sess.ID, "error", err)
 					return
 				}

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -334,7 +334,7 @@ const docTemplate = `{
         },
         "/v1/sessions/export": {
             "get": {
-                "description": "Streams one JSON line per session in the given window, newest-first, as a downloadable attachment. Each line is the session object with its traces, each trace carrying its full spans — the same shape as GET /v1/sessions/{id}/traces with payload=full. Defaults to the trailing 30 days. Not bounded by the /v1/sessions list cap — pages internally.",
+                "description": "Streams one JSON line per session in the given window, newest-first, as a downloadable attachment. Each line is the session object with its traces, each trace carrying its full spans — the same shape as GET /v1/sessions/{id}/traces with payload=full. detail=traces exports turn headers only (no spans or links). Defaults to the trailing 30 days. Not bounded by the /v1/sessions list cap — pages internally.",
                 "produces": [
                     "application/x-ndjson"
                 ],
@@ -356,17 +356,27 @@ const docTemplate = `{
                         "description": "Only include sessions active (last_seen_at) before this RFC3339 timestamp",
                         "name": "until",
                         "in": "query"
+                    },
+                    {
+                        "enum": [
+                            "spans",
+                            "traces"
+                        ],
+                        "type": "string",
+                        "description": "Export granularity: spans (default, traces with full spans) or traces (turn headers only)",
+                        "name": "detail",
+                        "in": "query"
                     }
                 ],
                 "responses": {
                     "200": {
-                        "description": "JSONL body, one JSON object per session with nested traces and spans",
+                        "description": "JSONL body, one JSON object per session with nested traces (and spans at detail=spans)",
                         "schema": {
                             "type": "string"
                         }
                     },
                     "400": {
-                        "description": "Malformed since/until",
+                        "description": "Malformed since/until, or unrecognized detail",
                         "schema": {
                             "$ref": "#/definitions/github_com_papercomputeco_tapes_pkg_llm.ErrorResponse"
                         }
@@ -486,7 +496,7 @@ const docTemplate = `{
         },
         "/v1/sessions/{id}/export": {
             "get": {
-                "description": "Returns the session as a single JSON line (downloadable attachment): the session object with its traces, each trace carrying its full spans — the same shape as GET /v1/sessions/{id}/traces with payload=full.",
+                "description": "Returns the session as a single JSON line (downloadable attachment): the session object with its traces, each trace carrying its full spans — the same shape as GET /v1/sessions/{id}/traces with payload=full. detail=traces exports turn headers only (no spans or links).",
                 "produces": [
                     "application/x-ndjson"
                 ],
@@ -501,17 +511,27 @@ const docTemplate = `{
                         "name": "id",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "enum": [
+                            "spans",
+                            "traces"
+                        ],
+                        "type": "string",
+                        "description": "Export granularity: spans (default, traces with full spans) or traces (turn headers only)",
+                        "name": "detail",
+                        "in": "query"
                     }
                 ],
                 "responses": {
                     "200": {
-                        "description": "JSONL body, one session object with nested traces and spans",
+                        "description": "JSONL body, one session object with nested traces (and spans at detail=spans)",
                         "schema": {
                             "type": "string"
                         }
                     },
                     "400": {
-                        "description": "Missing or malformed id",
+                        "description": "Missing or malformed id, or unrecognized detail",
                         "schema": {
                             "$ref": "#/definitions/github_com_papercomputeco_tapes_pkg_llm.ErrorResponse"
                         }

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -237,7 +237,7 @@ const docTemplate = `{
         },
         "/v1/sessions": {
             "get": {
-                "description": "Returns one row per harness session from the sessions table, newest first (last_seen_at desc), cursor-paginated.",
+                "description": "Returns one row per harness session from the sessions table, cursor-paginated. Default order is last_active (last_seen_at) desc; override with the sort and direction query params.",
                 "produces": [
                     "application/json"
                 ],
@@ -257,6 +257,18 @@ const docTemplate = `{
                         "type": "string",
                         "description": "Opaque pagination cursor returned by a previous response",
                         "name": "cursor",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Sort column: last_active|started_at|turn_count|total_cost_usd|total_tokens|duration_ns|derived_status|auth_subject (default last_active)",
+                        "name": "sort",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Sort direction: asc|desc (default desc)",
+                        "name": "direction",
                         "in": "query"
                     },
                     {
@@ -322,7 +334,7 @@ const docTemplate = `{
         },
         "/v1/sessions/export": {
             "get": {
-                "description": "Streams every session's turns (NDJSON) in the given window, newest-first, as a downloadable attachment. Defaults to the trailing 30 days. Not bounded by the /v1/sessions list cap — pages internally.",
+                "description": "Streams one JSON line per session in the given window, newest-first, as a downloadable attachment. Each line is the session object with its traces, each trace carrying its full spans — the same shape as GET /v1/sessions/{id}/traces with payload=full. Defaults to the trailing 30 days. Not bounded by the /v1/sessions list cap — pages internally.",
                 "produces": [
                     "application/x-ndjson"
                 ],
@@ -348,7 +360,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                        "description": "NDJSON body, one JSON object per turn across every session in the window",
+                        "description": "JSONL body, one JSON object per session with nested traces and spans",
                         "schema": {
                             "type": "string"
                         }
@@ -474,7 +486,7 @@ const docTemplate = `{
         },
         "/v1/sessions/{id}/export": {
             "get": {
-                "description": "Streams one JSON object per turn (NDJSON) as a downloadable attachment: the same conversation-export grain as ` + "`" + `tapes checkout --format jsonl` + "`" + `.",
+                "description": "Returns the session as a single JSON line (downloadable attachment): the session object with its traces, each trace carrying its full spans — the same shape as GET /v1/sessions/{id}/traces with payload=full.",
                 "produces": [
                     "application/x-ndjson"
                 ],
@@ -493,7 +505,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                        "description": "NDJSON body, one JSON object per turn",
+                        "description": "JSONL body, one session object with nested traces and spans",
                         "schema": {
                             "type": "string"
                         }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -330,7 +330,7 @@
         },
         "/v1/sessions/export": {
             "get": {
-                "description": "Streams one JSON line per session in the given window, newest-first, as a downloadable attachment. Each line is the session object with its traces, each trace carrying its full spans — the same shape as GET /v1/sessions/{id}/traces with payload=full. Defaults to the trailing 30 days. Not bounded by the /v1/sessions list cap — pages internally.",
+                "description": "Streams one JSON line per session in the given window, newest-first, as a downloadable attachment. Each line is the session object with its traces, each trace carrying its full spans — the same shape as GET /v1/sessions/{id}/traces with payload=full. detail=traces exports turn headers only (no spans or links). Defaults to the trailing 30 days. Not bounded by the /v1/sessions list cap — pages internally.",
                 "produces": [
                     "application/x-ndjson"
                 ],
@@ -352,17 +352,27 @@
                         "description": "Only include sessions active (last_seen_at) before this RFC3339 timestamp",
                         "name": "until",
                         "in": "query"
+                    },
+                    {
+                        "enum": [
+                            "spans",
+                            "traces"
+                        ],
+                        "type": "string",
+                        "description": "Export granularity: spans (default, traces with full spans) or traces (turn headers only)",
+                        "name": "detail",
+                        "in": "query"
                     }
                 ],
                 "responses": {
                     "200": {
-                        "description": "JSONL body, one JSON object per session with nested traces and spans",
+                        "description": "JSONL body, one JSON object per session with nested traces (and spans at detail=spans)",
                         "schema": {
                             "type": "string"
                         }
                     },
                     "400": {
-                        "description": "Malformed since/until",
+                        "description": "Malformed since/until, or unrecognized detail",
                         "schema": {
                             "$ref": "#/definitions/github_com_papercomputeco_tapes_pkg_llm.ErrorResponse"
                         }
@@ -482,7 +492,7 @@
         },
         "/v1/sessions/{id}/export": {
             "get": {
-                "description": "Returns the session as a single JSON line (downloadable attachment): the session object with its traces, each trace carrying its full spans — the same shape as GET /v1/sessions/{id}/traces with payload=full.",
+                "description": "Returns the session as a single JSON line (downloadable attachment): the session object with its traces, each trace carrying its full spans — the same shape as GET /v1/sessions/{id}/traces with payload=full. detail=traces exports turn headers only (no spans or links).",
                 "produces": [
                     "application/x-ndjson"
                 ],
@@ -497,17 +507,27 @@
                         "name": "id",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "enum": [
+                            "spans",
+                            "traces"
+                        ],
+                        "type": "string",
+                        "description": "Export granularity: spans (default, traces with full spans) or traces (turn headers only)",
+                        "name": "detail",
+                        "in": "query"
                     }
                 ],
                 "responses": {
                     "200": {
-                        "description": "JSONL body, one session object with nested traces and spans",
+                        "description": "JSONL body, one session object with nested traces (and spans at detail=spans)",
                         "schema": {
                             "type": "string"
                         }
                     },
                     "400": {
-                        "description": "Missing or malformed id",
+                        "description": "Missing or malformed id, or unrecognized detail",
                         "schema": {
                             "$ref": "#/definitions/github_com_papercomputeco_tapes_pkg_llm.ErrorResponse"
                         }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -233,7 +233,7 @@
         },
         "/v1/sessions": {
             "get": {
-                "description": "Returns one row per harness session from the sessions table, newest first (last_seen_at desc), cursor-paginated.",
+                "description": "Returns one row per harness session from the sessions table, cursor-paginated. Default order is last_active (last_seen_at) desc; override with the sort and direction query params.",
                 "produces": [
                     "application/json"
                 ],
@@ -253,6 +253,18 @@
                         "type": "string",
                         "description": "Opaque pagination cursor returned by a previous response",
                         "name": "cursor",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Sort column: last_active|started_at|turn_count|total_cost_usd|total_tokens|duration_ns|derived_status|auth_subject (default last_active)",
+                        "name": "sort",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Sort direction: asc|desc (default desc)",
+                        "name": "direction",
                         "in": "query"
                     },
                     {
@@ -318,7 +330,7 @@
         },
         "/v1/sessions/export": {
             "get": {
-                "description": "Streams every session's turns (NDJSON) in the given window, newest-first, as a downloadable attachment. Defaults to the trailing 30 days. Not bounded by the /v1/sessions list cap — pages internally.",
+                "description": "Streams one JSON line per session in the given window, newest-first, as a downloadable attachment. Each line is the session object with its traces, each trace carrying its full spans — the same shape as GET /v1/sessions/{id}/traces with payload=full. Defaults to the trailing 30 days. Not bounded by the /v1/sessions list cap — pages internally.",
                 "produces": [
                     "application/x-ndjson"
                 ],
@@ -344,7 +356,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "NDJSON body, one JSON object per turn across every session in the window",
+                        "description": "JSONL body, one JSON object per session with nested traces and spans",
                         "schema": {
                             "type": "string"
                         }
@@ -470,7 +482,7 @@
         },
         "/v1/sessions/{id}/export": {
             "get": {
-                "description": "Streams one JSON object per turn (NDJSON) as a downloadable attachment: the same conversation-export grain as `tapes checkout --format jsonl`.",
+                "description": "Returns the session as a single JSON line (downloadable attachment): the session object with its traces, each trace carrying its full spans — the same shape as GET /v1/sessions/{id}/traces with payload=full.",
                 "produces": [
                     "application/x-ndjson"
                 ],
@@ -489,7 +501,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "NDJSON body, one JSON object per turn",
+                        "description": "JSONL body, one session object with nested traces and spans",
                         "schema": {
                             "type": "string"
                         }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -584,8 +584,9 @@ paths:
       - search
   /v1/sessions:
     get:
-      description: Returns one row per harness session from the sessions table, newest
-        first (last_seen_at desc), cursor-paginated.
+      description: Returns one row per harness session from the sessions table, cursor-paginated.
+        Default order is last_active (last_seen_at) desc; override with the sort and
+        direction query params.
       parameters:
       - description: Maximum number of sessions to return (default 50, max 200)
         in: query
@@ -595,6 +596,15 @@ paths:
       - description: Opaque pagination cursor returned by a previous response
         in: query
         name: cursor
+        type: string
+      - description: 'Sort column: last_active|started_at|turn_count|total_cost_usd|total_tokens|duration_ns|derived_status|auth_subject
+          (default last_active)'
+        in: query
+        name: sort
+        type: string
+      - description: 'Sort direction: asc|desc (default desc)'
+        in: query
+        name: direction
         type: string
       - description: Only include sessions active (last_seen_at) at or after this
           RFC3339 timestamp
@@ -719,8 +729,9 @@ paths:
       - sessions
   /v1/sessions/{id}/export:
     get:
-      description: 'Streams one JSON object per turn (NDJSON) as a downloadable attachment:
-        the same conversation-export grain as `tapes checkout --format jsonl`.'
+      description: 'Returns the session as a single JSON line (downloadable attachment):
+        the session object with its traces, each trace carrying its full spans — the
+        same shape as GET /v1/sessions/{id}/traces with payload=full.'
       parameters:
       - description: Session id (UUID)
         in: path
@@ -731,7 +742,7 @@ paths:
       - application/x-ndjson
       responses:
         "200":
-          description: NDJSON body, one JSON object per turn
+          description: JSONL body, one session object with nested traces and spans
           schema:
             type: string
         "400":
@@ -834,9 +845,11 @@ paths:
       - sessions
   /v1/sessions/export:
     get:
-      description: Streams every session's turns (NDJSON) in the given window, newest-first,
-        as a downloadable attachment. Defaults to the trailing 30 days. Not bounded
-        by the /v1/sessions list cap — pages internally.
+      description: Streams one JSON line per session in the given window, newest-first,
+        as a downloadable attachment. Each line is the session object with its traces,
+        each trace carrying its full spans — the same shape as GET /v1/sessions/{id}/traces
+        with payload=full. Defaults to the trailing 30 days. Not bounded by the /v1/sessions
+        list cap — pages internally.
       parameters:
       - description: 'Only include sessions active (last_seen_at) at or after this
           RFC3339 timestamp (default: now - 30 days)'
@@ -854,8 +867,8 @@ paths:
       - application/x-ndjson
       responses:
         "200":
-          description: NDJSON body, one JSON object per turn across every session
-            in the window
+          description: JSONL body, one JSON object per session with nested traces
+            and spans
           schema:
             type: string
         "400":

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -731,22 +731,32 @@ paths:
     get:
       description: 'Returns the session as a single JSON line (downloadable attachment):
         the session object with its traces, each trace carrying its full spans — the
-        same shape as GET /v1/sessions/{id}/traces with payload=full.'
+        same shape as GET /v1/sessions/{id}/traces with payload=full. detail=traces
+        exports turn headers only (no spans or links).'
       parameters:
       - description: Session id (UUID)
         in: path
         name: id
         required: true
         type: string
+      - description: 'Export granularity: spans (default, traces with full spans)
+          or traces (turn headers only)'
+        enum:
+        - spans
+        - traces
+        in: query
+        name: detail
+        type: string
       produces:
       - application/x-ndjson
       responses:
         "200":
-          description: JSONL body, one session object with nested traces and spans
+          description: JSONL body, one session object with nested traces (and spans
+            at detail=spans)
           schema:
             type: string
         "400":
-          description: Missing or malformed id
+          description: Missing or malformed id, or unrecognized detail
           schema:
             $ref: '#/definitions/github_com_papercomputeco_tapes_pkg_llm.ErrorResponse'
         "404":
@@ -848,8 +858,9 @@ paths:
       description: Streams one JSON line per session in the given window, newest-first,
         as a downloadable attachment. Each line is the session object with its traces,
         each trace carrying its full spans — the same shape as GET /v1/sessions/{id}/traces
-        with payload=full. Defaults to the trailing 30 days. Not bounded by the /v1/sessions
-        list cap — pages internally.
+        with payload=full. detail=traces exports turn headers only (no spans or links).
+        Defaults to the trailing 30 days. Not bounded by the /v1/sessions list cap
+        — pages internally.
       parameters:
       - description: 'Only include sessions active (last_seen_at) at or after this
           RFC3339 timestamp (default: now - 30 days)'
@@ -863,16 +874,24 @@ paths:
         in: query
         name: until
         type: string
+      - description: 'Export granularity: spans (default, traces with full spans)
+          or traces (turn headers only)'
+        enum:
+        - spans
+        - traces
+        in: query
+        name: detail
+        type: string
       produces:
       - application/x-ndjson
       responses:
         "200":
           description: JSONL body, one JSON object per session with nested traces
-            and spans
+            (and spans at detail=spans)
           schema:
             type: string
         "400":
-          description: Malformed since/until
+          description: Malformed since/until, or unrecognized detail
           schema:
             $ref: '#/definitions/github_com_papercomputeco_tapes_pkg_llm.ErrorResponse'
         "500":


### PR DESCRIPTION
## Summary

- Reworks both export endpoints (`GET /v1/sessions/:id/export`, `GET /v1/sessions/export?since=&until=`) from one flat JSONL line per turn to **one line per session**, nesting each session's traces and each trace's full spans.
- Each spans-grain line is byte-identical to `GET /v1/sessions/{id}/traces?payload=full`, rendered through a shared `exportSessionLine` helper — a bulk export is exactly a concatenation of single-session exports, and the export surface cannot drift from the session-detail API.
- Adds `?detail=traces|spans` to both endpoints: `spans` (default) carries the full projection; `traces` exports turn headers only, read via `ListTraceSummaries` so span payloads are never loaded server-side. Header-only lines omit `spans`/`links`/`tasks`/`kind_counts` keys entirely (absent = "not exported at this grain", never "empty"). Unrecognized values 400.
- `tapes checkout --format jsonl` intentionally keeps its flat transcript grain; `pkg/export` is now checkout-only.

## How it works

The handlers now read the span model directly (`ListSessionSpanModel` / `ListTraceSummaries`) instead of going through the skill querier's narrowed span view, which carries no payloads or usage. The single-session path still buffers before committing attachment headers (clean JSON errors on failure); the bulk path still streams via `SetBodyStreamWriter` with keyset paging past the 200-row list cap, flushing per session. Org-scoped 404 preflight, dual 501 capability gates, and the 30-day window clamp are unchanged.

## Behavior

| Request | Before | After |
|---|---|---|
| `/v1/sessions/{id}/export` | N flat turn lines | 1 nested session line (full spans) |
| `/v1/sessions/{id}/export?detail=traces` | n/a | 1 session line, turn headers only, `-traces.jsonl` filename |
| `/v1/sessions/export` | turn lines across sessions | 1 nested line per session, streamed |
| `/v1/sessions/export?detail=bogus` | n/a | 400 |

## Test plan

- [x] `make test` (Dagger) — export suites rework: nested-line shape asserted by unmarshalling into `SessionTracesResponse`; traces-grain key omission; 400s; org isolation; paging/clamp/gzip/streaming unchanged
- [x] `make e2e-test` (Dagger)
- [x] Live validation in a grove clearing: real captured Claude session exported at both grains, old-vs-new comparison against the v0.22.0 release image
- [ ] Console download surface (separate PCC-858 follow-up)

Related to PCC-858

🤖 Generated with [Claude Code](https://claude.com/claude-code)