### PR TITLE
🔧 fix: sanitize jsonb-invalid Unicode on ingest and classify 22P05 as 4xx

### DIFF
--- a/ingest/ingest.go
+++ b/ingest/ingest.go
@@ -387,6 +387,14 @@ type transcriptMeta struct {
 	Records     int    `json:"records"`
 }
 
+// transcriptWriteProvider labels transcript-sourced writes on the shared
+// tapes_ingest_writes_total counter. The counter's "provider" dimension is
+// a wire-capture notion; a transcript has no LLM provider, so it carries
+// this sentinel instead of falling into the "unknown" bucket it would
+// otherwise share with malformed wire turns. Dashboards select
+// provider="transcript" to see this path's health in isolation.
+const transcriptWriteProvider = "transcript"
+
 // handleTranscriptIngest appends one transcript file to the raw layer.
 // Idempotent per content version: the dedup key includes a content
 // hash, so re-uploading an unchanged file is a no-op while a grown
@@ -400,26 +408,31 @@ func (s *Server) handleTranscriptIngest(c *fiber.Ctx) error {
 		})
 	}
 
+	bodySize := len(c.Body())
+
 	var payload TranscriptPayload
 	if err := c.BodyParser(&payload); err != nil {
-		s.metrics.ObserveWrite("", ResultRejectEnv, len(c.Body()))
+		s.metrics.ObserveWrite(transcriptWriteProvider, ResultRejectEnv, bodySize)
 		return c.Status(fiber.StatusBadRequest).JSON(llm.ErrorResponse{
 			Error: fmt.Sprintf("%s: %s", ErrEnvelope, err),
 		})
 	}
 	resolveGatewayIdentity(c, payload.Session)
 	if err := payload.Session.Validate(); err != nil {
+		s.metrics.ObserveWrite(transcriptWriteProvider, ResultRejectEnv, bodySize)
 		return c.Status(fiber.StatusBadRequest).JSON(llm.ErrorResponse{
 			Error: fmt.Sprintf("%s: %s", ErrEnvelope, err),
 		})
 	}
 	if payload.Session == nil || payload.Session.HarnessSessionID == "" {
+		s.metrics.ObserveWrite(transcriptWriteProvider, ResultRejectEnv, bodySize)
 		return c.Status(fiber.StatusBadRequest).JSON(llm.ErrorResponse{
 			Error: fmt.Sprintf("%s: transcript ingest requires session.harness_session_id", ErrEnvelope),
 		})
 	}
 	var records []json.RawMessage
 	if err := json.Unmarshal(payload.Records, &records); err != nil {
+		s.metrics.ObserveWrite(transcriptWriteProvider, ResultRejectEnv, bodySize)
 		return c.Status(fiber.StatusBadRequest).JSON(llm.ErrorResponse{
 			Error: fmt.Sprintf("%s: records must be a JSON array: %s", ErrEnvelope, err),
 		})
@@ -442,10 +455,12 @@ func (s *Server) handleTranscriptIngest(c *fiber.Ctx) error {
 		Records:     len(records),
 	})
 	if err != nil {
+		s.metrics.ObserveWrite(transcriptWriteProvider, ResultInternalErr, bodySize)
 		return c.Status(fiber.StatusInternalServerError).JSON(llm.ErrorResponse{Error: err.Error()})
 	}
 	sessionJSON, err := json.Marshal(payload.Session)
 	if err != nil {
+		s.metrics.ObserveWrite(transcriptWriteProvider, ResultInternalErr, bodySize)
 		return c.Status(fiber.StatusInternalServerError).JSON(llm.ErrorResponse{Error: err.Error()})
 	}
 
@@ -460,11 +475,24 @@ func (s *Server) handleTranscriptIngest(c *fiber.Ctx) error {
 		SessionEnvelope:  sessionJSON,
 	})
 	if err != nil {
+		// A content-level rejection (invalid Unicode/bytes Postgres JSONB
+		// refuses) is the client's malformed payload, not a storage outage:
+		// return 422 so it stops reading as a gateway fault, and retrying the
+		// identical bytes will never succeed. Everything else stays a 502.
+		if errors.Is(err, storage.ErrInvalidContent) {
+			s.logger.Warn("transcript ingest rejected: unstorable content", "error", err)
+			s.metrics.ObserveWrite(transcriptWriteProvider, ResultRejectParse, bodySize)
+			return c.Status(fiber.StatusUnprocessableEntity).JSON(llm.ErrorResponse{
+				Error: fmt.Sprintf("%s: %v", ErrUnprocessable, err),
+			})
+		}
 		s.logger.Error("transcript ingest failed", "error", err)
+		s.metrics.ObserveWrite(transcriptWriteProvider, ResultDownstreamErr, bodySize)
 		return c.Status(fiber.StatusBadGateway).JSON(llm.ErrorResponse{
 			Error: fmt.Sprintf("%s: %v", ErrDownstream, err),
 		})
 	}
+	s.metrics.ObserveWrite(transcriptWriteProvider, ResultAccepted, bodySize)
 	return c.Status(fiber.StatusAccepted).JSON(fiber.Map{
 		"status":   "accepted",
 		"deduped":  !inserted,

--- a/ingest/metrics.go
+++ b/ingest/metrics.go
@@ -80,6 +80,11 @@ const (
 	ResultUnknownProv   Result = "unknown_provider"
 	ResultQueueFull     Result = "queue_full"
 	ResultDownstreamErr Result = "downstream_error"
+	// ResultInternalErr covers a failure inside the handler itself (e.g. a
+	// server-side marshal that should never fail) — a 500, distinct from a bad
+	// payload or a downstream outage — so no handler exit is invisible to the
+	// writes counter.
+	ResultInternalErr Result = "internal_error"
 )
 
 // ObserveWrite increments the writes counter for a given provider/result.

--- a/ingest/transcript_test.go
+++ b/ingest/transcript_test.go
@@ -4,6 +4,9 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"sync"
@@ -28,6 +31,10 @@ type rawStoreDriver struct {
 
 	mu      sync.Mutex
 	records []storage.RawTurnRecord
+
+	// putErr, when non-nil, is returned by PutRawTurn instead of appending —
+	// lets a test drive the handler's error-classification branches.
+	putErr error
 }
 
 func newRawStoreDriver() *rawStoreDriver {
@@ -37,6 +44,9 @@ func newRawStoreDriver() *rawStoreDriver {
 func (d *rawStoreDriver) PutRawTurn(_ context.Context, rec storage.RawTurnRecord) (bool, error) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
+	if d.putErr != nil {
+		return false, d.putErr
+	}
 	if rec.RequestID != "" {
 		for _, existing := range d.records {
 			if existing.OrgID == rec.OrgID && existing.RequestID == rec.RequestID {
@@ -243,6 +253,42 @@ var _ = Describe("POST /v1/ingest/transcript", func() {
 		count, err := driver.CountRawTurns(context.Background())
 		Expect(err).NotTo(HaveOccurred())
 		Expect(count).To(Equal(int64(2)))
+	})
+
+	scrapeMetrics := func() string {
+		resp, err := client.Get(baseURL + "/metrics")
+		Expect(err).NotTo(HaveOccurred())
+		defer resp.Body.Close()
+		body, err := io.ReadAll(resp.Body)
+		Expect(err).NotTo(HaveOccurred())
+		return string(body)
+	}
+
+	It("meters an accepted transcript on writes_total{provider=transcript}", func() {
+		resp := post(transcriptBody(payloadOrg, ""), nil)
+		defer resp.Body.Close()
+		Expect(resp.StatusCode).To(Equal(http.StatusAccepted))
+		Expect(scrapeMetrics()).To(ContainSubstring(`tapes_ingest_writes_total{provider="transcript",status="accepted"}`))
+	})
+
+	It("returns 422 (not 502) and meters reject_parse when content is unstorable", func() {
+		// A content-level rejection is the client's malformed payload: the
+		// handler must classify it as unprocessable, not a downstream fault.
+		driver.putErr = fmt.Errorf("insert raw turn: %w", storage.ErrInvalidContent)
+
+		resp := post(transcriptBody(payloadOrg, ""), nil)
+		defer resp.Body.Close()
+		Expect(resp.StatusCode).To(Equal(http.StatusUnprocessableEntity))
+		Expect(scrapeMetrics()).To(ContainSubstring(`tapes_ingest_writes_total{provider="transcript",status="reject_parse"}`))
+	})
+
+	It("returns 502 and meters downstream_error on a genuine storage fault", func() {
+		driver.putErr = errors.New("connection refused")
+
+		resp := post(transcriptBody(payloadOrg, ""), nil)
+		defer resp.Body.Close()
+		Expect(resp.StatusCode).To(Equal(http.StatusBadGateway))
+		Expect(scrapeMetrics()).To(ContainSubstring(`tapes_ingest_writes_total{provider="transcript",status="downstream_error"}`))
 	})
 
 	It("returns 501 when the driver has no raw layer", func() {

--- a/pkg/storage/errors.go
+++ b/pkg/storage/errors.go
@@ -1,0 +1,17 @@
+package storage
+
+import "errors"
+
+// ErrInvalidContent signals that a write failed because the payload
+// content itself is unstorable — JSON carrying escape sequences or bytes
+// a Postgres JSONB column rejects (SQLSTATE 22P05 unsupported Unicode
+// escape, 22021 invalid byte sequence) — rather than any infrastructure
+// fault.
+//
+// The distinction drives behavior at the boundaries: an HTTP handler maps
+// it to a client 4xx (the data is the problem; retrying the identical
+// bytes will never succeed) instead of a 502 that reads as a gateway
+// outage, and the derive worker can quarantine such a row instead of
+// re-attempting it on every poll forever. Drivers wrap the underlying pg
+// error with this sentinel; callers test with errors.Is.
+var ErrInvalidContent = errors.New("invalid content for storage")

--- a/pkg/storage/postgres/raw_turns.go
+++ b/pkg/storage/postgres/raw_turns.go
@@ -46,6 +46,10 @@ func (d *Driver) PutRawTurn(ctx context.Context, rec storage.RawTurnRecord) (boo
 	defer tx.Rollback(ctx) //nolint:errcheck // commit shadows on success
 	qtx := d.q.WithTx(tx)
 
+	// Scrub the JSONB payloads of escapes/bytes Postgres cannot store
+	// (SQLSTATE 22P05 / 22021). A clean payload passes through byte-identical,
+	// so the raw layer stays verbatim for everything but the offending
+	// sequences — which could not be stored faithfully anyway.
 	rows, err := qtx.InsertRawTurn(ctx, gensqlc.InsertRawTurnParams{
 		OrgID:            orgID,
 		Source:           source,
@@ -54,13 +58,16 @@ func (d *Driver) PutRawTurn(ctx context.Context, rec storage.RawTurnRecord) (boo
 		HarnessID:        rec.HarnessID,
 		HarnessSessionID: rec.HarnessSessionID,
 		RequestID:        rec.RequestID,
-		RawRequest:       rec.RawRequest,
-		Response:         rec.Response,
-		Meta:             metaOrEmptyObject(rec.Meta),
-		SessionEnvelope:  rec.SessionEnvelope,
+		RawRequest:       sanitizeJSONB(rec.RawRequest),
+		Response:         sanitizeJSONB(rec.Response),
+		Meta:             sanitizeJSONB(metaOrEmptyObject(rec.Meta)),
+		SessionEnvelope:  sanitizeJSONB(rec.SessionEnvelope),
 	})
 	if err != nil {
-		return false, fmt.Errorf("insert raw turn: %w", err)
+		// Classify so a content-level rejection that slips past the scrubber
+		// surfaces as storage.ErrInvalidContent (→ 4xx) rather than a generic
+		// downstream fault (→ 502).
+		return false, fmt.Errorf("insert raw turn: %w", asContentError(err))
 	}
 
 	if rec.HarnessSessionID != "" {

--- a/pkg/storage/postgres/raw_turns_test.go
+++ b/pkg/storage/postgres/raw_turns_test.go
@@ -83,6 +83,36 @@ var _ = Describe("RawTurnStore", func() {
 		Expect(req).To(HaveKeyWithValue("system", "You are a security monitor."))
 	})
 
+	It("scrubs an escaped NUL so the row lands instead of raising SQLSTATE 22P05", func() {
+		// An escaped NUL (the six bytes: backslash u 0 0 0 0) inside a jsonb
+		// string is exactly what Postgres rejects with 22P05 — the incident's
+		// synchronous-502 trigger. sanitizeJSONB must rewrite it to U+FFFD so
+		// the write succeeds and the turn is still captured.
+		escNUL := []byte{0x5c, 0x75, 0x30, 0x30, 0x30, 0x30}
+		payload := append([]byte(`{"model":"x","messages":[{"role":"user","content":"hi`), escNUL...)
+		payload = append(payload, []byte(`"}]}`)...)
+
+		rec := rawRecord("req-nul")
+		rec.RawRequest = json.RawMessage(payload)
+
+		inserted, err := driver.PutRawTurn(ctx, rec)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(inserted).To(BeTrue())
+
+		rows, err := driver.ListRawTurns(ctx, 0, 10)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rows).To(HaveLen(1))
+
+		var req struct {
+			Messages []struct {
+				Content string `json:"content"`
+			} `json:"messages"`
+		}
+		Expect(json.Unmarshal(rows[0].RawRequest, &req)).To(Succeed())
+		Expect(req.Messages).To(HaveLen(1))
+		Expect(req.Messages[0].Content).To(Equal("hi" + string(rune(0xFFFD))))
+	})
+
 	It("dedupes retried writes by (org, request_id) but appends distinct calls", func() {
 		inserted, err := driver.PutRawTurn(ctx, rawRecord("req-dup"))
 		Expect(err).NotTo(HaveOccurred())

--- a/pkg/storage/postgres/sanitize.go
+++ b/pkg/storage/postgres/sanitize.go
@@ -1,0 +1,153 @@
+package postgres
+
+import (
+	"bytes"
+	"encoding/json/jsontext"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/papercomputeco/tapes/pkg/storage"
+)
+
+// Postgres SQLSTATEs raised when a JSONB column rejects the payload's own
+// content rather than signalling an infrastructure fault.
+const (
+	// pgUnsupportedUnicodeEscape ("unsupported Unicode escape sequence") is
+	// raised when a jsonb string contains an escaped NUL (the six-character
+	// sequence backslash u 0 0 0 0), because NUL is not representable in a
+	// jsonb string.
+	pgUnsupportedUnicodeEscape = "22P05"
+
+	// pgInvalidByteSequence ("invalid byte sequence for encoding") is raised
+	// when the bytes are not valid UTF-8 in the server encoding.
+	pgInvalidByteSequence = "22021"
+)
+
+var (
+	// The only escapes a UTF-8 jsonb column rejects are an escaped NUL and a
+	// UTF-16 surrogate; every surrogate code point (U+D800 to U+DFFF) begins
+	// with a 'D' hex digit, so "backslash u D" (either case) is a cheap
+	// superset trigger. Crucially this leaves benign escapes a JSON encoder
+	// routinely emits (e.g. the ones for the less-than and ampersand
+	// characters, or accented letters) on the allocation-free fast path
+	// instead of forcing a decode/re-encode of a payload with nothing wrong.
+	escNULSeq  = []byte{0x5c, 0x75, 0x30, 0x30, 0x30, 0x30} // backslash u 0 0 0 0
+	escSurrUp  = []byte{0x5c, 0x75, 0x44}                   // backslash u D
+	escSurrLow = []byte{0x5c, 0x75, 0x64}                   // backslash u d
+
+	// replacementBytes is the UTF-8 encoding of U+FFFD REPLACEMENT CHARACTER.
+	replacementBytes = []byte(string(rune(0xFFFD)))
+
+	nulStr  = string(rune(0))
+	fffdStr = string(rune(0xFFFD))
+)
+
+// sanitizeJSONB neutralizes the content a Postgres JSONB column rejects
+// (SQLSTATE 22P05) — an escaped NUL, a raw NUL byte, and unpaired UTF-16
+// surrogate escapes — replacing each with U+FFFD. A payload with none of
+// these is returned unchanged and without allocation, so the raw layer's
+// field-survival contract is unaffected; only an offending payload (which
+// could not be stored faithfully anyway) is re-serialized via the JSON
+// token stream, which copies every token — known field or not — through.
+//
+// The trigger is deliberately narrow: benign escapes a JSON encoder emits
+// routinely (the less-than / ampersand / greater-than characters, accented
+// letters as u-escapes) do NOT force the decode/re-encode — only an escaped
+// NUL or a surrogate escape does. One thing this intentionally does NOT
+// catch is a payload carrying raw invalid UTF-8 bytes with no triggering
+// escape: that is rare, and it lands as a 22021 at the jsonb cast, which
+// asContentError turns into a clean 422 rather than a corrupt-but-stored row.
+//
+// The heavy lifting is delegated to encoding/json/jsontext (the same
+// syntactic layer merkle hashing already uses): its decoder, run with
+// AllowInvalidUTF8, mangles invalid UTF-8 and unpaired surrogates to U+FFFD
+// for us, so the only thing left to scrub by hand is NUL, which is valid
+// UTF-8 and therefore slips past that check. Malformed JSON that the decoder
+// cannot parse is returned unchanged for the jsonb cast (and asContentError)
+// to reject on its own terms.
+func sanitizeJSONB(in []byte) []byte {
+	if len(in) == 0 {
+		return in
+	}
+
+	hasNUL := bytes.IndexByte(in, 0x00) >= 0
+	hasEscape := bytes.Contains(in, escNULSeq) ||
+		bytes.Contains(in, escSurrUp) ||
+		bytes.Contains(in, escSurrLow)
+	if !hasNUL && !hasEscape {
+		return in // fast path: nothing a jsonb cast rejects can be present
+	}
+
+	b := in
+	if hasNUL {
+		// A raw NUL is only ever illegal-inside-a-string, so replacing it at
+		// the byte level both neutralizes it and keeps the token stream below
+		// parseable. bytes.ReplaceAll allocates a fresh slice; in is untouched.
+		b = bytes.ReplaceAll(b, []byte{0x00}, replacementBytes)
+	}
+	if !hasEscape {
+		return b // only raw NUL was present; no escapes to inspect
+	}
+
+	opts := []jsontext.Options{jsontext.AllowInvalidUTF8(true), jsontext.AllowDuplicateNames(true)}
+	dec := jsontext.NewDecoder(bytes.NewReader(b), opts...)
+	var buf bytes.Buffer
+	buf.Grow(len(b) + len(replacementBytes))
+	enc := jsontext.NewEncoder(&buf, opts...)
+
+	for {
+		tok, err := dec.ReadToken()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return b // unparseable: leave it for the jsonb cast to reject
+		}
+		if tok.Kind() == '"' {
+			tok = jsontext.String(scrubString(tok.String()))
+		}
+		if err := enc.WriteToken(tok); err != nil {
+			return b
+		}
+	}
+	return bytes.TrimRight(buf.Bytes(), "\n")
+}
+
+// scrubString replaces a decoded string's NUL runes with U+FFFD. Invalid
+// UTF-8 is already mangled to U+FFFD by the AllowInvalidUTF8 decoder, but
+// ToValidUTF8 is kept as a cheap belt-and-suspenders in case a caller ever
+// feeds this a string from elsewhere.
+func scrubString(s string) string {
+	if !strings.ContainsRune(s, 0) && utf8.ValidString(s) {
+		return s
+	}
+	s = strings.ReplaceAll(s, nulStr, fffdStr)
+	if !utf8.ValidString(s) {
+		s = strings.ToValidUTF8(s, fffdStr)
+	}
+	return s
+}
+
+// asContentError wraps err with storage.ErrInvalidContent when it is a
+// Postgres error whose SQLSTATE means "your content is unstorable"
+// (22P05 / 22021), so boundaries can distinguish a bad payload from a
+// storage outage via errors.Is. Any other error (including nil) is
+// returned unchanged.
+func asContentError(err error) error {
+	if err == nil {
+		return nil
+	}
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		switch pgErr.Code {
+		case pgUnsupportedUnicodeEscape, pgInvalidByteSequence:
+			return fmt.Errorf("%w: %s (SQLSTATE %s)", storage.ErrInvalidContent, pgErr.Message, pgErr.Code)
+		}
+	}
+	return err
+}

--- a/pkg/storage/postgres/sanitize_bench_test.go
+++ b/pkg/storage/postgres/sanitize_bench_test.go
@@ -1,0 +1,50 @@
+package postgres
+
+import (
+	"fmt"
+	"testing"
+)
+
+// buildPayload grows a JSON object whose "content" string repeats chunk until
+// the whole payload is at least target bytes. chunk is spliced into a string
+// value, so escape bytes in it land inside a JSON string.
+func buildPayload(chunk []byte, target int) []byte {
+	buf := []byte(`{"role":"assistant","content":"`)
+	filler := []byte("the quick brown fox jumps over the lazy dog ")
+	for len(buf) < target {
+		buf = append(buf, filler...)
+		buf = append(buf, chunk...)
+	}
+	return append(buf, []byte(`"}`)...)
+}
+
+var (
+	// clean: plain ASCII, no escapes, no NUL — fast path.
+	chunkClean = []byte("")
+	// benign u-escapes an encoder routinely emits: < (< ) and é (u00e9).
+	// After the narrowed trigger these stay on the fast path.
+	chunkBenign = []byte{0x5c, 0x75, 0x30, 0x30, 0x33, 0x63, 0x5c, 0x75, 0x30, 0x30, 0x65, 0x39}
+	// poison: an escaped NUL (backslash u 0 0 0 0): slow path, rewritten.
+	chunkPoison = []byte{0x5c, 0x75, 0x30, 0x30, 0x30, 0x30}
+	// lone high surrogate (backslash u D 8 0 0): slow path, rewritten.
+	chunkSurrogate = []byte{0x5c, 0x75, 0x44, 0x38, 0x30, 0x30}
+)
+
+func benchSanitize(b *testing.B, chunk []byte, size int) {
+	payload := buildPayload(chunk, size)
+	b.SetBytes(int64(len(payload)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		_ = sanitizeJSONB(payload)
+	}
+}
+
+func BenchmarkSanitizeJSONB(b *testing.B) {
+	for _, size := range []int{4 << 10, 480 << 10} { // 4KB typical, 480KB incident-sized
+		b.Run(fmt.Sprintf("clean/%dKB", size>>10), func(b *testing.B) { benchSanitize(b, chunkClean, size) })
+		b.Run(fmt.Sprintf("benign_esc/%dKB", size>>10), func(b *testing.B) { benchSanitize(b, chunkBenign, size) })
+		b.Run(fmt.Sprintf("poison/%dKB", size>>10), func(b *testing.B) { benchSanitize(b, chunkPoison, size) })
+		b.Run(fmt.Sprintf("surrogate/%dKB", size>>10), func(b *testing.B) { benchSanitize(b, chunkSurrogate, size) })
+	}
+}

--- a/pkg/storage/postgres/sanitize_internal_test.go
+++ b/pkg/storage/postgres/sanitize_internal_test.go
@@ -1,0 +1,145 @@
+package postgres
+
+import (
+	"encoding/json"
+	"errors"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/papercomputeco/tapes/pkg/storage"
+)
+
+// kValue parses {"k":"..."} and returns the decoded k string.
+func kValue(b []byte) string {
+	var v struct {
+		K string `json:"k"`
+	}
+	Expect(json.Unmarshal(b, &v)).To(Succeed())
+	return v.K
+}
+
+// Escape/byte sequences are built from explicit byte values so this file
+// carries no literal backslash-escapes that a source transform could
+// misread. 0x5c is a backslash, 0x75 is the letter u, 0x30 is the digit 0.
+var (
+	// six bytes: backslash u 0 0 0 0  (an escaped NUL)
+	escNUL = []byte{0x5c, 0x75, 0x30, 0x30, 0x30, 0x30}
+	// backslash u D 8 0 0  (a lone high surrogate)
+	escLoneHigh = []byte{0x5c, 0x75, 0x44, 0x38, 0x30, 0x30}
+	// backslash u D C 0 0  (a lone low surrogate)
+	escLoneLow = []byte{0x5c, 0x75, 0x44, 0x43, 0x30, 0x30}
+	// backslash u D 8 3 D  backslash u D E 0 0  (a valid high+low pair)
+	escValidPair = []byte{0x5c, 0x75, 0x44, 0x38, 0x33, 0x44, 0x5c, 0x75, 0x44, 0x45, 0x30, 0x30}
+	// bytes 5c 5c 75 30 30 30 30 (an escaped backslash, then the text u0000)
+	escBackslash = []byte{0x5c, 0x5c, 0x75, 0x30, 0x30, 0x30, 0x30}
+	// backslash u 0 0 e 9  (an ordinary BMP escape)
+	escBMP = []byte{0x5c, 0x75, 0x30, 0x30, 0x65, 0x39}
+	// the UTF-8 encoding of U+FFFD
+	uFFFD = []byte{0xEF, 0xBF, 0xBD}
+)
+
+// wrapStr embeds inner inside a minimal JSON object string value.
+func wrapStr(inner []byte) []byte {
+	out := append([]byte(`{"k":"`), inner...)
+	return append(out, []byte(`"}`)...)
+}
+
+var _ = Describe("sanitizeJSONB", func() {
+	It("replaces an escaped NUL with U+FFFD", func() {
+		Expect(sanitizeJSONB(wrapStr(escNUL))).To(Equal(wrapStr(uFFFD)))
+	})
+
+	It("replaces a raw NUL byte with U+FFFD", func() {
+		Expect(sanitizeJSONB(wrapStr([]byte{0x00}))).To(Equal(wrapStr(uFFFD)))
+	})
+
+	It("replaces a lone high surrogate escape", func() {
+		Expect(sanitizeJSONB(wrapStr(escLoneHigh))).To(Equal(wrapStr(uFFFD)))
+	})
+
+	It("replaces a lone low surrogate escape", func() {
+		Expect(sanitizeJSONB(wrapStr(escLoneLow))).To(Equal(wrapStr(uFFFD)))
+	})
+
+	It("preserves a valid surrogate pair (as its decoded rune)", func() {
+		// The escape may be rewritten to the raw UTF-8 rune, but the decoded
+		// value must be identical — U+1F600, the grinning face.
+		Expect(kValue(sanitizeJSONB(wrapStr(escValidPair)))).To(Equal(string(rune(0x1F600))))
+	})
+
+	It("does not treat an escaped backslash followed by u0000 as a NUL escape", func() {
+		// The decoded value is a literal backslash then the text u0000 — no NUL.
+		Expect(kValue(sanitizeJSONB(wrapStr(escBackslash)))).To(Equal(string(rune(0x5c)) + "u0000"))
+	})
+
+	It("preserves an ordinary BMP escape (as its decoded rune)", func() {
+		Expect(kValue(sanitizeJSONB(wrapStr(escBMP)))).To(Equal(string(rune(0x00e9)))) // é
+	})
+
+	It("preserves numbers, booleans, null, and array structure while scrubbing", func() {
+		in := append([]byte(`{"n":42,"f":3.14,"big":10000000000,"b":true,"z":null,"arr":[1,2,3],"k":"x`), escNUL...)
+		in = append(in, []byte(`"}`)...)
+
+		out := sanitizeJSONB(in)
+		var got map[string]any
+		Expect(json.Unmarshal(out, &got)).To(Succeed())
+		Expect(got["n"]).To(BeEquivalentTo(42))
+		Expect(got["f"]).To(BeEquivalentTo(3.14))
+		Expect(got["big"]).To(BeEquivalentTo(1e10))
+		Expect(got["b"]).To(Equal(true))
+		Expect(got["z"]).To(BeNil())
+		Expect(got["arr"]).To(HaveLen(3))
+		Expect(got["k"]).To(Equal("x" + string(rune(0xFFFD))))
+	})
+
+	It("returns a clean payload unchanged without allocating", func() {
+		in := []byte(`{"hello":"world","n":42}`)
+		out := sanitizeJSONB(in)
+		Expect(out).To(Equal(in))
+		// Same backing array: a clean payload is a true no-op.
+		Expect(&out[0]).To(BeIdenticalTo(&in[0]))
+	})
+
+	It("handles nil and empty input", func() {
+		Expect(sanitizeJSONB(nil)).To(BeNil())
+		Expect(sanitizeJSONB([]byte{})).To(Equal([]byte{}))
+	})
+
+	It("rewrites multiple offenders in one payload", func() {
+		in := append(append(append([]byte(`{"a":"`), escNUL...), []byte(`","b":"`)...), escLoneHigh...)
+		in = append(in, []byte(`"}`)...)
+		want := append(append(append([]byte(`{"a":"`), uFFFD...), []byte(`","b":"`)...), uFFFD...)
+		want = append(want, []byte(`"}`)...)
+		Expect(sanitizeJSONB(in)).To(Equal(want))
+	})
+})
+
+var _ = Describe("asContentError", func() {
+	It("wraps SQLSTATE 22P05 as ErrInvalidContent", func() {
+		err := asContentError(&pgconn.PgError{Code: "22P05", Message: "unsupported Unicode escape sequence"})
+		Expect(errors.Is(err, storage.ErrInvalidContent)).To(BeTrue())
+		Expect(err.Error()).To(ContainSubstring("22P05"))
+	})
+
+	It("wraps SQLSTATE 22021 as ErrInvalidContent", func() {
+		err := asContentError(&pgconn.PgError{Code: "22021", Message: "invalid byte sequence"})
+		Expect(errors.Is(err, storage.ErrInvalidContent)).To(BeTrue())
+	})
+
+	It("leaves an unrelated pg error unchanged", func() {
+		orig := &pgconn.PgError{Code: "23505", Message: "unique_violation"}
+		Expect(asContentError(orig)).To(BeIdenticalTo(orig))
+	})
+
+	It("leaves a non-pg error unchanged", func() {
+		orig := errors.New("boom")
+		Expect(asContentError(orig)).To(BeIdenticalTo(orig))
+		Expect(errors.Is(asContentError(orig), storage.ErrInvalidContent)).To(BeFalse())
+	})
+
+	It("returns nil for nil", func() {
+		Expect(asContentError(nil)).To(BeNil())
+	})
+})

--- a/pkg/storage/postgres/session_ingest.go
+++ b/pkg/storage/postgres/session_ingest.go
@@ -145,7 +145,10 @@ func (d *Driver) IngestTurn(ctx context.Context, req storage.IngestTurnRequest) 
 		}
 		rows, err := qtx.InsertNode(ctx, params)
 		if err != nil {
-			return storage.IngestTurnResult{}, fmt.Errorf("insert node %s: %w", node.Hash, err)
+			// Classify content-level rejections (e.g. a JSONB escape Postgres
+			// refuses) as storage.ErrInvalidContent so the derive/worker path
+			// can tell a poison payload from an infra fault.
+			return storage.IngestTurnResult{}, fmt.Errorf("insert node %s: %w", node.Hash, asContentError(err))
 		}
 		if rows == 0 {
 			// Duplicate (org_id, hash): the row already exists from a
@@ -579,10 +582,10 @@ func insertNodeParamsFromMerkle(orgID pgtype.UUID, n *merkle.Node) (gensqlc.Inse
 	return gensqlc.InsertNodeParams{
 		OrgID:                    orgID,
 		Hash:                     n.Hash,
-		Bucket:                   bucketJSON,
+		Bucket:                   sanitizeJSONB(bucketJSON),
 		Type:                     nullStringValue(n.Bucket.Type),
 		Role:                     nullStringValue(n.Bucket.Role),
-		Content:                  contentJSON,
+		Content:                  sanitizeJSONB(contentJSON),
 		Model:                    nullStringValue(n.Bucket.Model),
 		Provider:                 nullStringValue(n.Bucket.Provider),
 		AgentName:                nullStringValue(n.Bucket.AgentName),


### PR DESCRIPTION
## What

Payloads that contain an escaped NUL (`\u0000`), a raw NUL byte, or an unpaired UTF-16 surrogate are valid JSON but cannot be stored in a Postgres `JSONB` column — the insert fails with `SQLSTATE 22P05`. Since `raw_turns.raw_request`, `nodes.bucket`, and `nodes.content` are all `JSONB`, such a payload failed on every write path, and on the synchronous transcript ingest endpoint it surfaced as a 502.

This PR:

1. **Sanitizes** those sequences to `U+FFFD` before the insert (`sanitizeJSONB`), delegating escape/surrogate/UTF-8 handling to `encoding/json/jsontext` rather than a hand-rolled parser. The trigger is narrow: clean payloads and benign escapes are returned unchanged and unallocated; only an escaped NUL or a surrogate escape takes the decode/re-encode path. Applied to `raw_turns` and to node `bucket`/`content`.
2. **Classifies** `22P05`/`22021` as `storage.ErrInvalidContent`, so a malformed payload returns **422** (retrying the identical bytes can't help) instead of a 502 that reads as a gateway fault.
3. **Meters** the transcript ingest path on `tapes_ingest_writes_total` (`provider="transcript"`), which was previously unmetered — so its writes were invisible on the success counter.

Node hashes are computed on the canonical struct and dedup keys on the pre-sanitized bytes, so rewriting stored JSON changes neither.

## Why

A malformed payload was failing `JSONB` inserts and returning 502s rather than a 4xx, and the transcript write path wasn't reflected in the write-success metric — so the failures didn't show up on the counter.

## Verification

- `go build` / `go vet` / `gofmt` clean.
- Unit specs for each rewritten sequence, value preservation (numbers/booleans/null/arrays, valid surrogate pairs), and the escaped-backslash false positive.
- Handler specs: unstorable content → 422, genuine storage fault → 502, accepted path metered.
- DB-integration spec against Postgres 17: an escaped-NUL payload now stores (scrubbed) instead of raising 22P05.
- Sanitization is allocation-free on clean payloads; only an offending payload pays the decode/re-encode.

## Follow-up (not in this PR)

- Derive-worker quarantine, so a persistently-unstorable row isn't re-attempted on every poll.

related to PCC-870

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
