### PR TITLE
🔧 fix(derive): project modern Codex and Pi sessions

### DIFF
--- a/api/traces_handlers.go
+++ b/api/traces_handlers.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"fmt"
 	"regexp"
 	"sort"
 	"strconv"
@@ -430,6 +431,7 @@ var taskCreatedPattern = regexp.MustCompile(`#(\d+)`)
 // calls, not of the storage model.
 func foldTaskBlocks(uses []llm.ContentBlock, resultText map[string]string) []TreeTask {
 	byID := map[string]*TreeTask{}
+	bySubject := map[string]*TreeTask{}
 	var order []*TreeTask
 	{
 		for _, b := range uses {
@@ -466,6 +468,38 @@ func foldTaskBlocks(uses []llm.ContentBlock, resultText map[string]string) []Tre
 				}
 				if subject, ok := b.ToolInput["subject"].(string); ok && subject != "" {
 					task.Subject = subject
+				}
+			case "TaskPlan", "Parallel":
+				plan, ok := b.ToolInput["plan"].([]any)
+				if !ok {
+					continue
+				}
+				for _, raw := range plan {
+					item, ok := raw.(map[string]any)
+					if !ok {
+						continue
+					}
+					subject, _ := item["step"].(string)
+					if subject == "" {
+						continue
+					}
+					status, _ := item["status"].(string)
+					if status == "" {
+						status = "pending"
+					}
+					task := bySubject[subject]
+					if task == nil {
+						task = &TreeTask{
+							ID:      fmt.Sprintf("codex-plan-%d", len(order)+1),
+							Subject: subject,
+							Status:  status,
+						}
+						bySubject[subject] = task
+						order = append(order, task)
+						continue
+					}
+					task.Updates++
+					task.Status = status
 				}
 			}
 		}

--- a/api/traces_internal_test.go
+++ b/api/traces_internal_test.go
@@ -1,0 +1,37 @@
+package api
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/papercomputeco/tapes/pkg/llm"
+)
+
+var _ = Describe("session task folds", func() {
+	It("folds Codex update_plan snapshots alongside Claude task events", func() {
+		uses := []llm.ContentBlock{
+			{
+				Type:     "tool_use",
+				ToolName: "TaskPlan",
+				ToolInput: map[string]any{"plan": []any{
+					map[string]any{"step": "Inspect traces", "status": "in_progress"},
+					map[string]any{"step": "Verify UI", "status": "pending"},
+				}},
+			},
+			{
+				Type:     "tool_use",
+				ToolName: "Parallel",
+				ToolInput: map[string]any{"plan": []any{
+					map[string]any{"step": "Inspect traces", "status": "completed"},
+					map[string]any{"step": "Verify UI", "status": "in_progress"},
+				}},
+			},
+		}
+
+		tasks := foldTaskBlocks(uses, nil)
+		Expect(tasks).To(Equal([]TreeTask{
+			{ID: "codex-plan-1", Subject: "Inspect traces", Status: "completed", Updates: 1},
+			{ID: "codex-plan-2", Subject: "Verify UI", Status: "in_progress", Updates: 1},
+		}))
+	})
+})

--- a/pkg/derive/chain.go
+++ b/pkg/derive/chain.go
@@ -10,7 +10,10 @@
 package derive
 
 import (
+	"strings"
+
 	"github.com/papercomputeco/tapes/pkg/llm"
+	"github.com/papercomputeco/tapes/pkg/llm/provider/openai"
 	"github.com/papercomputeco/tapes/pkg/merkle"
 )
 
@@ -51,40 +54,53 @@ func TurnChain(call CallContext, req *llm.ChatRequest, resp *llm.ChatResponse) [
 	chain := make([]*merkle.Node, 0, len(req.Messages)+1)
 	var parent *merkle.Node
 
-	for _, msg := range req.Messages {
-		bucket := merkle.Bucket{
-			Type:      "message",
-			Role:      msg.Role,
-			Content:   msg.Content,
-			Model:     req.Model,
-			Provider:  call.Provider,
-			AgentName: call.AgentName,
-		}
-		node := merkle.NewNode(bucket, parent, merkle.NodeOptions{
-			Project: call.Project,
-			Request: params,
-		})
-		node.ThreadID = call.ThreadID
-		if injectedKind := ClassifyInjected(msg); injectedKind != "" {
-			// Side branch: keep the node, mark it, do NOT advance the
-			// spine. On the conversation spine this stops injected
-			// drift from forking the chain; on shadow calls it stops
-			// a shared context block (every permission check opens
-			// with the same <user_claude_md> blob) from fusing
-			// otherwise-independent calls into one fan.
-			node.Kind = injectedKind
+	for _, original := range req.Messages {
+		for _, msg := range splitCodexSkillMessage(original) {
+			bucket := merkle.Bucket{
+				Type:      "message",
+				Role:      msg.Role,
+				Content:   msg.Content,
+				Model:     req.Model,
+				Provider:  call.Provider,
+				AgentName: call.AgentName,
+			}
+			node := merkle.NewNode(bucket, parent, merkle.NodeOptions{
+				Project: call.Project,
+				Request: params,
+			})
+			node.ThreadID = call.ThreadID
+			if injectedKind := ClassifyInjected(msg); injectedKind != "" {
+				// Side branch: keep the node, mark it, do NOT advance the
+				// spine. On the conversation spine this stops injected
+				// drift from forking the chain; on shadow calls it stops
+				// a shared context block (every permission check opens
+				// with the same <user_claude_md> blob) from fusing
+				// otherwise-independent calls into one fan.
+				node.Kind = injectedKind
+				chain = append(chain, node)
+				continue
+			}
+			node.Kind = kind
 			chain = append(chain, node)
-			continue
+			parent = node
 		}
-		node.Kind = kind
-		chain = append(chain, node)
-		parent = node
+	}
+
+	// OpenAI Responses items the reducer preserved verbatim
+	// (custom_tool_call, custom_tool_call_output) normalize to
+	// canonical tool blocks HERE — the shared constructor — so
+	// capture-time ingest and offline re-derive produce identical
+	// hashes, and sessions captured before those item types were
+	// cataloged heal on re-derive.
+	responseContent := resp.Message.Content
+	if call.Provider == "openai" {
+		responseContent = openai.NormalizeResponsesContent(responseContent)
 	}
 
 	responseBucket := merkle.Bucket{
 		Type:      "message",
 		Role:      resp.Message.Role,
-		Content:   resp.Message.Content,
+		Content:   responseContent,
 		Model:     resp.Model,
 		Provider:  call.Provider,
 		AgentName: call.AgentName,
@@ -103,4 +119,31 @@ func TurnChain(call CallContext, req *llm.ChatRequest, resp *llm.ChatResponse) [
 	responseNode.ThreadID = call.ThreadID
 	chain = append(chain, responseNode)
 	return chain
+}
+
+// splitCodexSkillMessage separates a human `$skill` invocation from the skill
+// body that Codex appends to the same user message. The invocation belongs on
+// the conversation spine; the expansion is harness context and must remain an
+// injected side branch. Other message shapes pass through byte-for-byte.
+func splitCodexSkillMessage(msg llm.Message) []llm.Message {
+	if (msg.Role != "user" && msg.Role != "system") || len(msg.Content) != 1 {
+		return []llm.Message{msg}
+	}
+	b := msg.Content[0]
+	if b.Type != "text" && b.Type != "input_text" && b.Type != "" {
+		return []llm.Message{msg}
+	}
+	marker := strings.Index(b.Text, "<skill>")
+	if marker <= 0 {
+		return []llm.Message{msg}
+	}
+	prompt := strings.TrimSpace(b.Text[:marker])
+	if prompt == "" {
+		return []llm.Message{msg}
+	}
+	injected := strings.TrimSpace(b.Text[marker:])
+	return []llm.Message{
+		{Role: msg.Role, Content: []llm.ContentBlock{{Type: b.Type, Text: prompt}}},
+		{Role: msg.Role, Content: []llm.ContentBlock{{Type: b.Type, Text: injected}}},
+	}
 }

--- a/pkg/derive/classify.go
+++ b/pkg/derive/classify.go
@@ -39,7 +39,15 @@ const (
 	// side-branch nodes (see TurnChain) and marked with these kinds.
 	KindInjectedMCPInstructions = "injected:mcp-instructions"
 	KindInjectedSkillsList      = "injected:skills-list"
+	KindInjectedSkillContent    = "injected:skill-content"
 	KindInjectedModeBanner      = "injected:mode-banner"
+	// KindInjectedAgentContext is harness-supplied coding-agent context
+	// carried as a user message on the wire. Codex opens a session with
+	// AGENTS.md instructions and environment metadata before the human turn.
+	KindInjectedAgentContext = "injected:agent-context"
+	// KindInjectedEnvironmentContext is Codex's structured cwd, shell,
+	// date/timezone, and filesystem-permission envelope.
+	KindInjectedEnvironmentContext = "injected:environment-context"
 	// KindInjectedClaudeMD is the user-context blob the harness
 	// prepends to its security-monitor checks (<user_claude_md>…).
 	// Every check in a session shares it byte-for-byte, so left on the
@@ -151,7 +159,28 @@ func ClassifyCall(req *llm.ChatRequest, resp *llm.ChatResponse) string {
 		return KindMain
 	}
 
+	// GPT-5.6 Codex spine: the request carries NO client-side tool
+	// definitions (the ChatGPT Codex backend injects them server-side)
+	// but still declares tool routing. A streaming Responses call with
+	// tool_choice set is the conversation spine — tool-less shadow
+	// calls (title-gen, plan-name) send neither.
+	if streaming && responsesToolChoice(req) {
+		return KindMain
+	}
+
 	return KindUnknown
+}
+
+// responsesToolChoice reports whether a Responses API request declared
+// tool routing via tool_choice. The parser stores both markers in
+// Extra (see parseResponsesRequest); presence is the tell, the value
+// is irrelevant.
+func responsesToolChoice(req *llm.ChatRequest) bool {
+	if req.Extra == nil || req.Extra["endpoint"] != "responses" {
+		return false
+	}
+	_, ok := req.Extra["tool_choice"]
+	return ok
 }
 
 // ClassifyInjected reports the injected-context kind for one request
@@ -167,7 +196,7 @@ func ClassifyInjected(msg llm.Message) string {
 	var text strings.Builder
 	for _, b := range msg.Content {
 		switch b.Type {
-		case "text", "":
+		case blockText, "":
 			text.WriteString(b.Text)
 		default:
 			// tool_use / tool_result / image blocks are never injected
@@ -177,10 +206,22 @@ func ClassifyInjected(msg llm.Message) string {
 	}
 	t := strings.TrimSpace(text.String())
 	switch {
+	case strings.HasPrefix(t, "<environment_context>"):
+		return KindInjectedEnvironmentContext
+	case strings.HasPrefix(t, "# AGENTS.md instructions for "),
+		strings.HasPrefix(t, "<permissions instructions>"),
+		strings.HasPrefix(t, "<skills_instructions>"),
+		strings.HasPrefix(t, "<apps_instructions>"),
+		strings.HasPrefix(t, "<plugins_instructions>"),
+		strings.HasPrefix(t, "<collaboration_mode>"),
+		strings.HasPrefix(t, "<multi_agent_mode>"):
+		return KindInjectedAgentContext
 	case strings.HasPrefix(t, "# MCP Server Instructions"):
 		return KindInjectedMCPInstructions
 	case strings.HasPrefix(t, "The following skills are available"):
 		return KindInjectedSkillsList
+	case strings.HasPrefix(t, "<skill>"):
+		return KindInjectedSkillContent
 	case strings.HasPrefix(t, "Plan mode is active"),
 		strings.HasPrefix(t, "Exited Plan Mode"),
 		strings.HasPrefix(t, "## Exited Plan Mode"),

--- a/pkg/derive/classify_test.go
+++ b/pkg/derive/classify_test.go
@@ -156,8 +156,18 @@ var _ = Describe("ClassifyInjected", func() {
 	It("marks whole injected blocks", func() {
 		Expect(derive.ClassifyInjected(textMsg("user", "# MCP Server Instructions\n…"))).To(Equal(derive.KindInjectedMCPInstructions))
 		Expect(derive.ClassifyInjected(textMsg("user", "The following skills are available…"))).To(Equal(derive.KindInjectedSkillsList))
+		Expect(derive.ClassifyInjected(textMsg("user", "<skill><name>demo</name></skill>"))).To(Equal(derive.KindInjectedSkillContent))
 		Expect(derive.ClassifyInjected(textMsg("user", "Plan mode is active."))).To(Equal(derive.KindInjectedModeBanner))
 		Expect(derive.ClassifyInjected(textMsg("user", "Exited Plan Mode"))).To(Equal(derive.KindInjectedModeBanner))
+	})
+
+	It("marks Codex agent instructions and environment context", func() {
+		instructions := llm.Message{Role: "user", Content: []llm.ContentBlock{
+			{Type: "text", Text: "# AGENTS.md instructions for /workspace/project\n\n<INSTRUCTIONS>\nuse the grove\n</INSTRUCTIONS>"},
+			{Type: "text", Text: "<environment_context>\n  <cwd>/workspace/project</cwd>\n</environment_context>"},
+		}}
+		Expect(derive.ClassifyInjected(instructions)).To(Equal(derive.KindInjectedAgentContext))
+		Expect(derive.ClassifyInjected(textMsg("user", "<environment_context>\n<cwd>/tmp</cwd>\n</environment_context>"))).To(Equal(derive.KindInjectedEnvironmentContext))
 	})
 
 	It("leaves ordinary conversation and tool messages alone", func() {
@@ -180,6 +190,35 @@ var _ = Describe("BuildDerivedSet", func() {
 			Meta:       json.RawMessage(`{}`),
 		}
 	}
+
+	It("splits a Codex skill invocation from its injected expansion", func() {
+		turn := mkRaw(1, "skill", `{
+			"model":"gpt-5.6-sol","stream":true,"tool_choice":"auto",
+			"input":[{"role":"user","content":"$exercise-demo\n\n<skill><name>exercise-demo</name><path>/skills/exercise-demo/SKILL.md</path></skill>"}]
+		}`, `{"model":"gpt-5.6-sol","message":{"role":"assistant","content":[{"type":"text","text":"done"}]}}`)
+		turn.Provider = "openai"
+
+		set, err := derive.BuildDerivedSet([]storage.RawTurnRecord{turn}, "proj")
+		Expect(err).NotTo(HaveOccurred())
+		var prompt, injected string
+		var injectedHasParent bool
+		for _, derived := range set.Nodes {
+			node := derived.Node
+			switch node.Kind {
+			case derive.KindMain:
+				if node.Bucket.Role == "user" {
+					prompt = node.Bucket.ExtractText()
+				}
+			case derive.KindInjectedSkillContent:
+				injected = node.Bucket.ExtractText()
+				injectedHasParent = node.ParentHash != nil
+			}
+		}
+		Expect(prompt).To(Equal("$exercise-demo"))
+		Expect(injected).To(ContainSubstring("<name>exercise-demo</name>"))
+		// The expansion branches from the invocation but never advances the spine.
+		Expect(injectedHasParent).To(BeTrue())
+	})
 
 	It("derives, classifies, and attaches a verdict to its judged tool_use", func() {
 		mainTurn := mkRaw(1, "r1", `{
@@ -377,6 +416,100 @@ var _ = Describe("BuildDerivedSet", func() {
 		Expect(tool).NotTo(BeNil())
 		Expect(tool.SpanID).To(Equal("call_1"))
 		Expect(tool.Name).To(Equal("Bash"))
+		Expect(tool.Output).To(HaveLen(1))
+		Expect(tool.Output[0].ToolOutput).To(Equal("README.md"))
+	})
+
+	It("projects GPT-5.6 Codex custom tool calls as the conversation spine", func() {
+		// GPT-5.6 Codex sends no client-side `tools` array (the ChatGPT
+		// Codex backend injects definitions server-side) and expresses
+		// its tool spine as custom_tool_call / custom_tool_call_output
+		// items. The stored reduced response carries the custom item
+		// verbatim (the reducer preserves unknown types raw), so this
+		// exercises classification via tool_choice, request-echo
+		// mapping, AND derive-time response normalization together.
+		turn1 := storage.RawTurnRecord{
+			ID:               1,
+			Provider:         "openai",
+			HarnessID:        "codex",
+			HarnessSessionID: "sess-codex-56",
+			RequestID:        "resp_req_1",
+			ReceivedAt:       time.Unix(1783985110, 0),
+			RawRequest: json.RawMessage(`{
+				"model":"gpt-5.6-sol",
+				"instructions":"You are Codex.",
+				"stream":true,
+				"tool_choice":"auto",
+				"input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"list files"}]}]
+			}`),
+			Response: json.RawMessage(`{
+				"model":"gpt-5.6-sol",
+				"message":{"role":"assistant","content":[
+					{"type":"thinking","thinking_signature":"enc_blob"},
+					{"type":"custom_tool_call","content":{"type":"custom_tool_call","id":"ctc_1","status":"completed","call_id":"call_1","name":"exec","input":"const r = await tools.exec_command({cmd:\"ls\"})"}}
+				]},
+				"stop_reason":"tool_use",
+				"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}
+			}`),
+			Meta: json.RawMessage(`{}`),
+		}
+		turn2 := storage.RawTurnRecord{
+			ID:               2,
+			Provider:         "openai",
+			HarnessID:        "codex",
+			HarnessSessionID: "sess-codex-56",
+			RequestID:        "resp_req_2",
+			ReceivedAt:       time.Unix(1783985111, 0),
+			RawRequest: json.RawMessage(`{
+				"model":"gpt-5.6-sol",
+				"instructions":"You are Codex.",
+				"stream":true,
+				"tool_choice":"auto",
+				"input":[
+					{"type":"message","role":"user","content":[{"type":"input_text","text":"list files"}]},
+					{"type":"custom_tool_call","id":"ctc_1","status":"completed","call_id":"call_1","name":"exec","input":"const r = await tools.exec_command({cmd:\"ls\"})"},
+					{"type":"custom_tool_call_output","call_id":"call_1","output":[{"type":"input_text","text":"README.md"}]}
+				]
+			}`),
+			Response: json.RawMessage(`{
+				"model":"gpt-5.6-sol",
+				"message":{"role":"assistant","content":[{"type":"text","text":"README.md"}]},
+				"stop_reason":"stop",
+				"usage":{"prompt_tokens":20,"completion_tokens":2,"total_tokens":22}
+			}`),
+			Meta: json.RawMessage(`{}`),
+		}
+
+		set, err := derive.BuildDerivedSet([]storage.RawTurnRecord{turn1, turn2}, "p")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(set.Report.CallKinds).To(HaveKeyWithValue(derive.KindMain, 2))
+		Expect(set.Report.CallKinds).NotTo(HaveKey(derive.KindUnknown))
+
+		spans := derive.EmitSpans(set)
+		Expect(spans.Report.Traces).To(Equal(1))
+		Expect(spans.Report.SpanKinds).To(HaveKeyWithValue(derive.SpanKindLLM, 2))
+		Expect(spans.Report.SpanKinds).To(HaveKeyWithValue(derive.SpanKindTool, 1))
+		Expect(spans.Report.LinkKinds).To(HaveKeyWithValue(derive.LinkFeeds, 1))
+
+		trace := spans.Turns[0]
+		Expect(trace.UserPrompt).To(Equal("list files"))
+		Expect(trace.ResponsePreview).To(Equal("README.md"))
+
+		var tool *derive.Span
+		for _, span := range trace.Spans {
+			if span.Kind == derive.SpanKindTool {
+				tool = span
+				break
+			}
+		}
+		Expect(tool).NotTo(BeNil())
+		Expect(tool.SpanID).To(Equal("call_1"))
+		Expect(tool.Name).To(Equal("Bash"))
+		Expect(tool.Input).To(HaveLen(1))
+		Expect(tool.Input[0].Type).To(Equal("tool_use"))
+		Expect(tool.Input[0].ToolName).To(Equal("Bash"))
+		Expect(tool.Input[0].ToolInput).To(HaveKeyWithValue("command", "ls"))
+		Expect(tool.Input[0].ToolInput).NotTo(HaveKey("input"))
 		Expect(tool.Output).To(HaveLen(1))
 		Expect(tool.Output[0].ToolOutput).To(Equal("README.md"))
 	})

--- a/pkg/derive/deriver.go
+++ b/pkg/derive/deriver.go
@@ -243,7 +243,7 @@ func (dv *Deriver) AddTurn(rec *storage.RawTurnRecord) {
 		dv.set.Sessions = append(dv.set.Sessions, key)
 	}
 
-	turn := &attachTurn{kind: kind, index: len(dv.turns), threadID: threadIDFromMeta(rec.Meta)}
+	turn := &attachTurn{kind: kind, index: len(dv.turns), threadID: chain[len(chain)-1].ThreadID}
 	source := &SpanSource{
 		RawTurnID:  rec.ID,
 		RequestID:  rec.RequestID,

--- a/pkg/derive/reconcile.go
+++ b/pkg/derive/reconcile.go
@@ -1,5 +1,7 @@
 package derive
 
+import "maps"
+
 // Reconciliation fuses the two sources of truth: the wire capture is
 // the complete call inventory, the harness transcript is the
 // authoritative causal/fork skeleton. The join key is projected
@@ -37,8 +39,22 @@ func ReconcileTranscripts(set *DerivedSet, files []*TranscriptFile) *ReconcileSt
 
 	// Group transcript files per session.
 	bySession := map[SessionKey][]*TranscriptFile{}
+	spawnEdges := map[SessionKey]map[string]string{}
 	for _, f := range files {
 		bySession[f.Session] = append(bySession[f.Session], f)
+		if len(f.spawnEdges) > 0 {
+			if spawnEdges[f.Session] == nil {
+				spawnEdges[f.Session] = map[string]string{}
+			}
+			maps.Copy(spawnEdges[f.Session], f.spawnEdges)
+		}
+	}
+	// Codex stores the spawn call id in the parent rollout rather than the
+	// child session_meta. Resolve those cross-file edges before matching.
+	for _, f := range files {
+		if f.ToolUseID == "" && f.AgentID != "" {
+			f.ToolUseID = spawnEdges[f.Session][f.AgentID]
+		}
 	}
 
 	// Children index over the derived nodes (spine links only).

--- a/pkg/derive/reconcile_test.go
+++ b/pkg/derive/reconcile_test.go
@@ -96,4 +96,53 @@ var _ = Describe("ReconcileTranscripts", func() {
 		Expect(forkRoots).To(Equal(1))
 		Expect(plainRoots).To(Equal(1))
 	})
+
+	It("recovers Codex spawn edges from the parent rollout", func() {
+		wire := storage.RawTurnRecord{
+			ID: 1, Source: "wire", Provider: "openai", HarnessID: "codex",
+			HarnessSessionID: "root", RequestID: "r1",
+			RawRequest: json.RawMessage(`{
+				"model":"gpt-5.6-terra","stream":true,"tool_choice":"auto",
+				"input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"inspect headlines"}]}]
+			}`),
+			Response: json.RawMessage(`{"model":"gpt-5.6-terra","message":{"role":"assistant","content":[{"type":"text","text":"no browser available"}]}}`),
+			Meta:     json.RawMessage(`{"thread_id":"/root/research"}`),
+		}
+		set, err := derive.BuildDerivedSet([]storage.RawTurnRecord{wire}, "")
+		Expect(err).NotTo(HaveOccurred())
+
+		meta := func(agentID string) json.RawMessage {
+			value, _ := json.Marshal(map[string]any{"transcript": true, "agent_id": agentID})
+			return value
+		}
+		parentRec := storage.RawTurnRecord{
+			Source: "transcript", HarnessID: "codex", HarnessSessionID: "root", Meta: meta(""),
+			RawRequest: json.RawMessage(`[
+				{"type":"event_msg","payload":{"type":"sub_agent_activity","kind":"started","event_id":"call_spawn","agent_thread_id":"child-thread","agent_path":"/root/research"}}
+			]`),
+		}
+		childRec := storage.RawTurnRecord{
+			Source: "transcript", HarnessID: "codex", HarnessSessionID: "root", Meta: meta("/root/research"),
+			RawRequest: json.RawMessage(`[
+				{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"inspect headlines"}]}},
+				{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"no browser available"}]}}
+			]`),
+		}
+		parent, err := derive.ParseTranscriptFile(&parentRec)
+		Expect(err).NotTo(HaveOccurred())
+		child, err := derive.ParseTranscriptFile(&childRec)
+		Expect(err).NotTo(HaveOccurred())
+
+		stats := derive.ReconcileTranscripts(set, []*derive.TranscriptFile{parent, child})
+		Expect(child.ToolUseID).To(Equal("call_spawn"))
+		Expect(stats.SubagentForks).To(Equal(1))
+		Expect(stats.ForkedChains).To(Equal(1))
+		found := false
+		for _, node := range set.Nodes {
+			if node.Node.Kind == derive.KindMain && node.Node.ParentToolUseID == "call_spawn" {
+				found = true
+			}
+		}
+		Expect(found).To(BeTrue())
+	})
 })

--- a/pkg/derive/rederive.go
+++ b/pkg/derive/rederive.go
@@ -161,10 +161,14 @@ func rederiveChain(providers map[string]provider.Provider, rec *storage.RawTurnR
 	if resp.Message.Role == "" || len(resp.Message.Content) == 0 {
 		return nil, true, nil
 	}
+	threadID := threadIDFromMeta(rec.Meta)
+	if threadID == "" && req.Extra != nil {
+		threadID, _ = req.Extra["thread_id"].(string)
+	}
 	chain = TurnChain(CallContext{
 		Provider:  rec.Provider,
 		AgentName: rec.AgentName,
-		ThreadID:  threadIDFromMeta(rec.Meta),
+		ThreadID:  threadID,
 		Project:   project,
 	}, req, &resp)
 	if len(chain) == 0 {

--- a/pkg/derive/spans.go
+++ b/pkg/derive/spans.go
@@ -1,8 +1,11 @@
 package derive
 
 import (
+	"encoding/json"
 	"fmt"
+	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -38,10 +41,16 @@ const (
 const (
 	roleUser           = "user"
 	roleTool           = "tool"
+	roleSystem         = "system"
 	blockText          = "text"
 	blockToolUse       = "tool_use"
 	blockServerToolUse = "server_tool_use"
 	blockToolResult    = "tool_result"
+)
+
+const (
+	toolNameAgent = "Agent"
+	toolNameBash  = "Bash"
 )
 
 // Span link kinds — dataflow edges between spans. Containment is the
@@ -205,6 +214,7 @@ type spanEmitter struct {
 	toolTurn  map[string]*SpanTurn
 	agentSpan map[string]*Span // session|thread -> subagent agent span
 	agentTurn map[string]*SpanTurn
+	taskTools map[string]string // session|returned task name -> spawning tool id
 	seam      map[SessionKey]*seamSource
 }
 
@@ -237,6 +247,7 @@ func EmitSpans(set *DerivedSet) *SpanSet {
 		toolTurn:  map[string]*SpanTurn{},
 		agentSpan: map[string]*Span{},
 		agentTurn: map[string]*SpanTurn{},
+		taskTools: map[string]string{},
 		seam:      map[SessionKey]*seamSource{},
 	}
 	var threadCalls, shadowCalls []*SpanSource
@@ -297,6 +308,9 @@ func (em *spanEmitter) threadCall(src *SpanSource) {
 	turn := em.agentTurn[key]
 	if agent == nil {
 		taskID := threadAnchor(src)
+		if taskID == "" {
+			taskID = em.taskTools[src.Session.HarnessID+"|"+src.Session.HarnessSessionID+"|"+src.ThreadID]
+		}
 		task := em.toolSpans[taskID]
 		if task != nil {
 			turn = em.toolTurn[taskID]
@@ -397,7 +411,7 @@ func (em *spanEmitter) emitConversation(src *SpanSource, turn *SpanTurn, parent 
 			}
 			continue
 		}
-		if node.Bucket.Role == "system" {
+		if node.Bucket.Role == roleSystem {
 			// mid-spine system-role inserts (task reminders, CLAUDE.md
 			// re-injections, post-compaction replays) are harness
 			// context, not user input — same family as injected:*,
@@ -449,15 +463,19 @@ func (em *spanEmitter) emitConversation(src *SpanSource, turn *SpanTurn, parent 
 			})
 			continue
 		}
+		displayName, displayInput := displayTool(b.ToolName, b.ToolInput)
+		presented := b
+		presented.ToolName = displayName
+		presented.ToolInput = displayInput
 		ts := &Span{
 			SpanID:       b.ToolUseID,
 			ParentSpanID: parent.SpanID,
 			Kind:         SpanKindTool,
-			Name:         displayToolName(b.ToolName, b.ToolInput),
+			Name:         displayName,
 			Status:       "ok",
 			StartedAt:    src.CapturedAt,
 			ThreadID:     src.ThreadID,
-			Input:        []llm.ContentBlock{b},
+			Input:        []llm.ContentBlock{presented},
 		}
 		em.addSpan(turn, ts)
 		em.toolSpans[b.ToolUseID] = ts
@@ -470,22 +488,480 @@ func (em *spanEmitter) emitConversation(src *SpanSource, turn *SpanTurn, parent 
 	}
 }
 
-// displayToolName returns the user-facing tool name for a span. Some
-// Responses-first harnesses, notably Codex, expose a generic function wrapper
-// such as exec/exec_command while the input shape carries the actual action.
-// Keep the raw tool_use block in Span.Input, but use the semantic label for
-// the span row so Console groups it with Claude's Bash tool.
-func displayToolName(name string, input map[string]any) string {
+// displayTool returns the user-facing tool name and input for a span. Codex's
+// GPT-5.6 runtime wraps developer tools in a freeform `exec` program. The raw
+// program remains in the immutable node/raw-turn layers; this presentation
+// projection exposes only stable nested operations and useful arguments.
+func displayTool(name string, input map[string]any) (string, map[string]any) {
 	switch strings.ToLower(strings.TrimSpace(name)) {
-	case "exec", "exec_command", "shell", "shell_command":
-		if hasShellCommandInput(input) {
-			return "Bash"
+	case "exec":
+		if script, ok := input["input"].(string); ok {
+			return displayCodexExec(script)
 		}
+	case "exec_command", "shell", "shell_command":
+		if hasShellCommandInput(input) {
+			return toolNameBash, input
+		}
+	case "spawn_agent":
+		presented := map[string]any{"subagent_type": "Codex"}
+		if task, ok := input["task_name"].(string); ok && task != "" {
+			presented["description"] = task
+		}
+		if turns, ok := input["fork_turns"]; ok {
+			presented["fork_turns"] = turns
+		}
+		return toolNameAgent, presented
+	case "wait_agent":
+		return "Monitor", map[string]any{"description": "waiting for subagent"}
+	case "request_user_input":
+		return "AskUserQuestion", input
 	}
 	if name == "" {
-		return "tool"
+		return "tool", input
 	}
-	return name
+	return name, input
+}
+
+var skillPathPattern = regexp.MustCompile(`(?:^|/)skills/([^/]+)/SKILL\.md(?:$|[^A-Za-z0-9_.-])`)
+
+func displayCodexExec(script string) (string, map[string]any) {
+	calls := codexToolCallSites(script)
+	if len(calls) == 0 {
+		return "exec", map[string]any{}
+	}
+	canonical := make([]string, len(calls))
+	for i, call := range calls {
+		canonical[i] = canonicalCodexToolName(call.Name)
+	}
+	if len(canonical) > 1 {
+		presented := map[string]any{
+			"description": summarizeToolCalls(canonical),
+			"calls":       codexPresentedCalls(calls, codexParallelResultKeys(script, calls)),
+		}
+		if plan := codexPlanItems(script); len(plan) > 0 {
+			presented["plan"] = plan
+		}
+		return "Parallel", presented
+	}
+
+	name := canonical[0]
+	presented := codexPresentedInput(name, calls[0].Body)
+	switch name {
+	case toolNameBash:
+		if cmd, _ := presented["command"].(string); cmd != "" {
+			if match := skillPathPattern.FindStringSubmatch(cmd); match != nil {
+				presented["skill"] = match[1]
+				delete(presented, "command")
+				return "Skill", presented
+			}
+		}
+	case "TaskPlan":
+		presented["plan"] = codexPlanItems(script)
+		presented["description"] = "updated task plan"
+	}
+	return name, presented
+}
+
+func codexPresentedCalls(calls []codexToolCall, resultKeys map[int]string) []any {
+	out := make([]any, 0, len(calls))
+	for i, call := range calls {
+		name := canonicalCodexToolName(call.Name)
+		item := map[string]any{"name": name}
+		if key := resultKeys[i]; key != "" {
+			item["result_key"] = key
+		}
+		if input := codexPresentedInput(name, call.Body); len(input) > 0 {
+			item["arguments"] = input
+		}
+		out = append(out, item)
+	}
+	return out
+}
+
+func codexPresentedInput(name, body string) map[string]any {
+	out := map[string]any{}
+	keys := []string{"cmd", "workdir", "path", "query", "id", "task_name", "description"}
+	for _, key := range keys {
+		if value := codexStringProperty(body, key); value != "" {
+			out[key] = value
+		}
+	}
+	if cmd, ok := out["cmd"]; ok {
+		out["command"] = cmd
+		delete(out, "cmd")
+	}
+	if name == toolNameAgent {
+		out["subagent_type"] = "Codex"
+	}
+	return out
+}
+
+func canonicalCodexToolName(name string) string {
+	switch name {
+	case "exec_command":
+		return toolNameBash
+	case "apply_patch":
+		return "Edit"
+	case "update_plan":
+		return "TaskPlan"
+	case "request_user_input":
+		return "AskUserQuestion"
+	case "write_stdin", "wait":
+		return "Monitor"
+	case "view_image":
+		return "Read"
+	default:
+		return name
+	}
+}
+
+func summarizeToolCalls(names []string) string {
+	counts := map[string]int{}
+	var order []string
+	for _, name := range names {
+		if counts[name] == 0 {
+			order = append(order, name)
+		}
+		counts[name]++
+	}
+	parts := make([]string, 0, len(order))
+	for _, name := range order {
+		if counts[name] == 1 {
+			parts = append(parts, name)
+		} else {
+			parts = append(parts, fmt.Sprintf("%s x%d", name, counts[name]))
+		}
+	}
+	return strings.Join(parts, " + ")
+}
+
+type codexToolCall struct {
+	Name  string
+	Body  string
+	Start int
+}
+
+// codexToolCallSites is a small lexer for the only syntax needed here:
+// `tools.<identifier>(` call sites outside strings and comments. It avoids
+// treating tool names quoted inside commands or captured documentation as
+// actual calls without pulling a JavaScript runtime into the derive worker.
+func codexToolCallSites(src string) []codexToolCall {
+	var out []codexToolCall
+	for i := 0; i < len(src); {
+		switch src[i] {
+		case '\'', '"':
+			i = skipJSString(src, i)
+			continue
+		case '`':
+			expressions, next := jsTemplateExpressions(src, i)
+			for _, expression := range expressions {
+				calls := codexToolCallSites(src[expression.start:expression.end])
+				for j := range calls {
+					calls[j].Start += expression.start
+				}
+				out = append(out, calls...)
+			}
+			i = next
+			continue
+		case '/':
+			if i+1 < len(src) && src[i+1] == '/' {
+				i = skipJSLineComment(src, i+2)
+				continue
+			}
+			if i+1 < len(src) && src[i+1] == '*' {
+				i = skipJSBlockComment(src, i+2)
+				continue
+			}
+		}
+		if strings.HasPrefix(src[i:], "tools.") && (i == 0 || !isJSIdentifier(src[i-1])) {
+			start := i + len("tools.")
+			end := start
+			for end < len(src) && isJSIdentifier(src[end]) {
+				end++
+			}
+			j := end
+			for j < len(src) && strings.ContainsRune(" \t\n\r", rune(src[j])) {
+				j++
+			}
+			if end > start && j < len(src) && src[j] == '(' {
+				body, next := codexParenthesizedBody(src, j)
+				out = append(out, codexToolCall{Name: src[start:end], Body: body, Start: i})
+				i = next
+				continue
+			}
+		}
+		i++
+	}
+	return out
+}
+
+var codexPromiseAssignmentPattern = regexp.MustCompile(`(?s)(?:const|let|var)\s*\[\s*([A-Za-z_$][A-Za-z0-9_$]*(?:\s*,\s*[A-Za-z_$][A-Za-z0-9_$]*)*)\s*\]\s*=\s*await\s*Promise\.(?:all|allSettled)\s*\(`)
+
+// codexParallelResultKeys maps Promise destructuring names back to the tool
+// calls whose results they hold. The exec wrapper's final text(JSON.stringify)
+// uses these same names as object keys, allowing Console to display each
+// result under the corresponding decomposed child without guessing.
+func codexParallelResultKeys(script string, calls []codexToolCall) map[int]string {
+	out := map[int]string{}
+	for _, match := range codexPromiseAssignmentPattern.FindAllStringSubmatchIndex(script, -1) {
+		open := match[1] - 1
+		_, end := codexParenthesizedBody(script, open)
+		var indexes []int
+		for i, call := range calls {
+			if call.Start > open && call.Start < end {
+				indexes = append(indexes, i)
+			}
+		}
+		keys := strings.Split(script[match[2]:match[3]], ",")
+		if len(keys) != len(indexes) {
+			continue
+		}
+		for i, index := range indexes {
+			out[index] = strings.TrimSpace(keys[i])
+		}
+	}
+	return out
+}
+
+func codexParenthesizedBody(src string, open int) (string, int) {
+	start := open + 1
+	depth := 1
+	for i := start; i < len(src); {
+		switch src[i] {
+		case '\'', '"', '`':
+			i = skipJSString(src, i)
+			continue
+		case '/':
+			if i+1 < len(src) && src[i+1] == '/' {
+				i = skipJSLineComment(src, i+2)
+				continue
+			}
+			if i+1 < len(src) && src[i+1] == '*' {
+				i = skipJSBlockComment(src, i+2)
+				continue
+			}
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return src[start:i], i + 1
+			}
+		}
+		i++
+	}
+	return src[start:], len(src)
+}
+
+func codexStringProperty(src, key string) string {
+	for i := 0; i < len(src); {
+		if src[i] == '"' {
+			end := skipJSString(src, i)
+			quotedKey, err := strconv.Unquote(src[i:end])
+			if err == nil && quotedKey == key {
+				if value := codexStringValueAfterColon(src, end); value != "" {
+					return value
+				}
+			}
+			i = end
+			continue
+		}
+		if src[i] == '\'' || src[i] == '`' {
+			i = skipJSString(src, i)
+			continue
+		}
+		if strings.HasPrefix(src[i:], key) && (i == 0 || !isJSIdentifier(src[i-1])) {
+			if value := codexStringValueAfterColon(src, i+len(key)); value != "" {
+				return value
+			}
+		}
+		i++
+	}
+	return ""
+}
+
+func codexStringValueAfterColon(src string, start int) string {
+	j := start
+	for j < len(src) && strings.ContainsRune(" \t\n\r", rune(src[j])) {
+		j++
+	}
+	if j >= len(src) || src[j] != ':' {
+		return ""
+	}
+	j++
+	for j < len(src) && strings.ContainsRune(" \t\n\r", rune(src[j])) {
+		j++
+	}
+	if j >= len(src) || src[j] != '"' {
+		return ""
+	}
+	end := skipJSString(src, j)
+	value, err := strconv.Unquote(src[j:end])
+	if err != nil {
+		return ""
+	}
+	return value
+}
+
+func codexPlanItems(src string) []any {
+	call := codexCallBody(src, "update_plan")
+	if call == "" {
+		return nil
+	}
+	type item struct {
+		step   string
+		status string
+	}
+	var items []item
+	var current item
+	for i := 0; i < len(call); {
+		key := ""
+		value := ""
+		switch {
+		case call[i] == '"':
+			end := skipJSString(call, i)
+			decoded, err := strconv.Unquote(call[i:end])
+			if err == nil {
+				key = decoded
+				value = codexStringValueAfterColon(call, end)
+			}
+			i = end
+		case isJSIdentifier(call[i]) && (i == 0 || !isJSIdentifier(call[i-1])):
+			end := i + 1
+			for end < len(call) && isJSIdentifier(call[end]) {
+				end++
+			}
+			key = call[i:end]
+			value = codexStringValueAfterColon(call, end)
+			i = end
+		default:
+			i++
+			continue
+		}
+		if value == "" {
+			continue
+		}
+		switch key {
+		case "step":
+			if current.step != "" {
+				items = append(items, current)
+			}
+			current = item{step: value}
+		case "status":
+			current.status = value
+		}
+	}
+	if current.step != "" {
+		items = append(items, current)
+	}
+	out := make([]any, 0, len(items))
+	for _, item := range items {
+		if item.status == "" {
+			item.status = "pending"
+		}
+		out = append(out, map[string]any{"step": item.step, "status": item.status})
+	}
+	return out
+}
+
+func codexCallBody(src, name string) string {
+	for _, call := range codexToolCallSites(src) {
+		if call.Name == name {
+			return call.Body
+		}
+	}
+	return ""
+}
+
+func isJSIdentifier(b byte) bool {
+	return b == '_' || b == '$' || b >= 'a' && b <= 'z' || b >= 'A' && b <= 'Z' || b >= '0' && b <= '9'
+}
+
+func skipJSString(src string, start int) int {
+	quote := src[start]
+	for i := start + 1; i < len(src); i++ {
+		if src[i] == '\\' {
+			i++
+			continue
+		}
+		if src[i] == quote {
+			return i + 1
+		}
+	}
+	return len(src)
+}
+
+type jsSourceRange struct {
+	start int
+	end   int
+}
+
+// jsTemplateExpressions returns the expression bodies from one template
+// literal. Literal text remains opaque, while each ${...} body is fed back
+// through the tool-call lexer by codexToolCallSites.
+func jsTemplateExpressions(src string, start int) ([]jsSourceRange, int) {
+	var expressions []jsSourceRange
+	for i := start + 1; i < len(src); {
+		switch {
+		case src[i] == '\\':
+			i += 2
+		case src[i] == '`':
+			return expressions, i + 1
+		case src[i] == '$' && i+1 < len(src) && src[i+1] == '{':
+			end := skipJSBracedExpression(src, i+1)
+			expressions = append(expressions, jsSourceRange{start: i + 2, end: end - 1})
+			i = end
+		default:
+			i++
+		}
+	}
+	return expressions, len(src)
+}
+
+func skipJSBracedExpression(src string, open int) int {
+	depth := 1
+	for i := open + 1; i < len(src); {
+		switch src[i] {
+		case '\'', '"':
+			i = skipJSString(src, i)
+			continue
+		case '`':
+			_, i = jsTemplateExpressions(src, i)
+			continue
+		case '/':
+			if i+1 < len(src) && src[i+1] == '/' {
+				i = skipJSLineComment(src, i+2)
+				continue
+			}
+			if i+1 < len(src) && src[i+1] == '*' {
+				i = skipJSBlockComment(src, i+2)
+				continue
+			}
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return i + 1
+			}
+		}
+		i++
+	}
+	return len(src)
+}
+
+func skipJSLineComment(src string, start int) int {
+	if i := strings.IndexByte(src[start:], '\n'); i >= 0 {
+		return start + i + 1
+	}
+	return len(src)
+}
+
+func skipJSBlockComment(src string, start int) int {
+	if i := strings.Index(src[start:], "*/"); i >= 0 {
+		return start + i + 2
+	}
+	return len(src)
 }
 
 func hasShellCommandInput(input map[string]any) bool {
@@ -530,6 +1006,12 @@ func (em *spanEmitter) fillToolResult(b *llm.ContentBlock, at time.Time) *Span {
 		return nil // first result wins; replays don't re-feed
 	}
 	ts.Output = []llm.ContentBlock{*b}
+	if ts.Name == toolNameAgent {
+		if taskName := codexAgentTaskName(b.ToolOutput); taskName != "" {
+			key := em.toolTurn[id].Session.HarnessID + "|" + em.toolTurn[id].Session.HarnessSessionID + "|" + taskName
+			em.taskTools[key] = id
+		}
+	}
 	if b.IsError {
 		ts.Status = "error"
 	}
@@ -537,6 +1019,16 @@ func (em *spanEmitter) fillToolResult(b *llm.ContentBlock, at time.Time) *Span {
 		ts.DurationNS = d.Nanoseconds()
 	}
 	return ts
+}
+
+func codexAgentTaskName(output string) string {
+	var value struct {
+		TaskName string `json:"task_name"`
+	}
+	if json.Unmarshal([]byte(strings.TrimSpace(output)), &value) == nil {
+		return value.TaskName
+	}
+	return ""
 }
 
 func (em *spanEmitter) openTrace(src *SpanSource, prompt *DerivedNode) *SpanTurn {

--- a/pkg/derive/spans_internal_test.go
+++ b/pkg/derive/spans_internal_test.go
@@ -29,3 +29,85 @@ var _ = Describe("joinTextBlocks truncation", func() {
 		Expect(joinTextBlocks(blocks, false)).To(Equal("hello ✓"))
 	})
 })
+
+var _ = Describe("Codex tool presentation", func() {
+	It("labels one nested shell call and preserves its command", func() {
+		name, input := displayTool("exec", map[string]any{
+			"input": `const r = await tools.exec_command({cmd:"git status --short"}); text(r);`,
+		})
+		Expect(name).To(Equal("Bash"))
+		Expect(input).To(HaveKeyWithValue("command", "git status --short"))
+		Expect(input).NotTo(HaveKey("script"))
+	})
+
+	It("recognizes a skill load from its SKILL.md read", func() {
+		name, input := displayTool("exec", map[string]any{
+			"input": `const r = await tools.exec_command({"cmd":"sed -n '1,200p' /workspace/skills/exercise-codex/SKILL.md"}); text(r);`,
+		})
+		Expect(name).To(Equal("Skill"))
+		Expect(input).To(HaveKeyWithValue("skill", "exercise-codex"))
+	})
+
+	It("summarizes real parallel calls without reading names from strings or comments", func() {
+		name, input := displayTool("exec", map[string]any{
+			"input": `const note = "tools.update_plan({})"; // tools.apply_patch("ignored")
+const [a,b] = await Promise.all([tools.exec_command({cmd:"ls"}), tools.mcp__linear__list_issues({limit:3})]);`,
+		})
+		Expect(name).To(Equal("Parallel"))
+		Expect(input).To(HaveKeyWithValue("description", "Bash + mcp__linear__list_issues"))
+		Expect(input["calls"]).To(Equal([]any{
+			map[string]any{"name": "Bash", "result_key": "a", "arguments": map[string]any{"command": "ls"}},
+			map[string]any{"name": "mcp__linear__list_issues", "result_key": "b"},
+		}))
+	})
+
+	It("finds tool calls in template expressions without scanning template text", func() {
+		name, input := displayTool("exec", map[string]any{
+			"input": "const label = `tools.update_plan({}): ${await tools.exec_command({cmd:\"ls\"})}`; text(label);",
+		})
+		Expect(name).To(Equal("Bash"))
+		Expect(input).To(HaveKeyWithValue("command", "ls"))
+	})
+
+	It("only assigns Promise result keys to calls inside that Promise", func() {
+		name, input := displayTool("exec", map[string]any{
+			"input": `const before = await tools.update_plan({plan:[]});
+const [files, issues] = await Promise.all([tools.exec_command({cmd:"ls"}), tools.mcp__linear__list_issues({limit:3})]);
+text(JSON.stringify({before,files,issues}));`,
+		})
+		Expect(name).To(Equal("Parallel"))
+		Expect(input["calls"]).To(Equal([]any{
+			map[string]any{"name": "TaskPlan"},
+			map[string]any{"name": "Bash", "result_key": "files", "arguments": map[string]any{"command": "ls"}},
+			map[string]any{"name": "mcp__linear__list_issues", "result_key": "issues"},
+		}))
+	})
+
+	It("extracts a returned Codex task identity", func() {
+		Expect(codexAgentTaskName(`{"task_name":"/root/waddup_probe"}`)).To(Equal("/root/waddup_probe"))
+		Expect(codexAgentTaskName("Script completed")).To(BeEmpty())
+	})
+
+	It("presents Codex collaboration calls like the existing Agent surface", func() {
+		name, input := displayTool("spawn_agent", map[string]any{
+			"task_name":  "nyt_headlines",
+			"fork_turns": "all",
+			"message":    "opaque encrypted prompt",
+		})
+		Expect(name).To(Equal("Agent"))
+		Expect(input).To(HaveKeyWithValue("subagent_type", "Codex"))
+		Expect(input).To(HaveKeyWithValue("description", "nyt_headlines"))
+		Expect(input).NotTo(HaveKey("message"))
+	})
+
+	It("extracts Codex task-plan snapshots into structured presentation data", func() {
+		name, input := displayTool("exec", map[string]any{
+			"input": `const r = await tools.update_plan({plan:[{step:"Inspect traces",status:"in_progress"},{step:"Verify UI",status:"pending"}]}); text(r);`,
+		})
+		Expect(name).To(Equal("TaskPlan"))
+		Expect(input["plan"]).To(Equal([]any{
+			map[string]any{"step": "Inspect traces", "status": "in_progress"},
+			map[string]any{"step": "Verify UI", "status": "pending"},
+		}))
+	})
+})

--- a/pkg/derive/transcript.go
+++ b/pkg/derive/transcript.go
@@ -5,16 +5,22 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"encoding/json/jsontext"
-	"strings"
+	"errors"
+	"fmt"
 
 	"github.com/papercomputeco/tapes/pkg/llm"
 	"github.com/papercomputeco/tapes/pkg/merkle"
 	"github.com/papercomputeco/tapes/pkg/storage"
 )
 
-// blockTypeText is the content-block type for plain text blocks, shared
-// by the transcript parsers below.
-const blockTypeText = "text"
+// blockThinking is shared by transcript parsers. The remaining canonical
+// block discriminators live with the span emitter in spans.go.
+const blockThinking = "thinking"
+
+// ErrUnsupportedTranscriptHarness identifies transcript rows that this
+// version of the derive worker cannot reconcile yet. Callers may skip these
+// rows without suppressing parse failures for supported harnesses.
+var ErrUnsupportedTranscriptHarness = errors.New("unsupported transcript harness")
 
 // TranscriptFile is one parsed harness transcript: the main session
 // file or one subagent's. ToolUseID (from the harness's subagent
@@ -30,32 +36,9 @@ type TranscriptFile struct {
 	// signatures are the projected-content signatures of every block
 	// in the transcript — the join key against wire-derived nodes.
 	signatures map[string]struct{}
-}
-
-// transcriptRecord is the subset of a harness transcript line the
-// reconciler reads.
-type transcriptRecord struct {
-	UUID       string `json:"uuid"`
-	ParentUUID string `json:"parentUuid"`
-	Message    struct {
-		Role    string          `json:"role"`
-		Content json.RawMessage `json:"content"`
-	} `json:"message"`
-}
-
-// transcriptBlock is a harness-side content block. Field names differ
-// from the wire ContentBlock shape (name vs tool_name, id vs
-// tool_use_id, …); toContentBlock renames them.
-type transcriptBlock struct {
-	Type      string          `json:"type"`
-	Text      string          `json:"text"`
-	Thinking  string          `json:"thinking"`
-	Name      string          `json:"name"`
-	ID        string          `json:"id"`
-	Input     map[string]any  `json:"input"`
-	ToolUseID string          `json:"tool_use_id"`
-	Content   json.RawMessage `json:"content"`
-	IsError   bool            `json:"is_error"`
+	// spawnEdges are emitted by Codex's parent rollout. Keys include both
+	// child agent_path and child thread id; values are the spawn tool call id.
+	spawnEdges map[string]string
 }
 
 // transcriptMetaFields mirrors the meta block transcript ingest writes.
@@ -87,11 +70,6 @@ func ParseTranscriptFile(rec *storage.RawTurnRecord) (*TranscriptFile, error) {
 			return nil, err
 		}
 	}
-	var records []transcriptRecord
-	if err := json.Unmarshal(rec.RawRequest, &records); err != nil {
-		return nil, err
-	}
-
 	file := &TranscriptFile{
 		Session:     SessionKey{HarnessID: rec.HarnessID, HarnessSessionID: rec.HarnessSessionID},
 		AgentID:     m.AgentID,
@@ -99,84 +77,25 @@ func ParseTranscriptFile(rec *storage.RawTurnRecord) (*TranscriptFile, error) {
 		Description: m.Description,
 		ToolUseID:   m.ToolUseID,
 		signatures:  map[string]struct{}{},
+		spawnEdges:  map[string]string{},
 	}
-	for _, r := range records {
-		for _, block := range transcriptBlocks(r.Message.Content) {
-			if sig := blockSignature(block); sig != "" {
-				file.signatures[sig] = struct{}{}
-			}
+	switch rec.HarnessID {
+	case "codex":
+		if err := parseCodexTranscript(rec.RawRequest, file); err != nil {
+			return nil, err
 		}
+	case "claude", "claude-code":
+		if err := parseClaudeTranscript(rec.RawRequest, file); err != nil {
+			return nil, err
+		}
+	case "pi":
+		if err := parsePiTranscript(rec.RawRequest, file); err != nil {
+			return nil, err
+		}
+	default:
+		return nil, fmt.Errorf("%w %q", ErrUnsupportedTranscriptHarness, rec.HarnessID)
 	}
 	return file, nil
-}
-
-// transcriptBlocks converts a transcript message's content (string or
-// block array) into wire-shaped ContentBlocks — the §3.2 recipe:
-// rename name→tool_name, id→tool_use_id, tool_use_id→tool_result_id,
-// flatten tool_result content arrays into tool_output.
-func transcriptBlocks(content json.RawMessage) []llm.ContentBlock {
-	if len(content) == 0 {
-		return nil
-	}
-	var asText string
-	if err := json.Unmarshal(content, &asText); err == nil {
-		return []llm.ContentBlock{{Type: blockTypeText, Text: asText}}
-	}
-	var raw []transcriptBlock
-	if err := json.Unmarshal(content, &raw); err != nil {
-		return nil
-	}
-	out := make([]llm.ContentBlock, 0, len(raw))
-	for _, b := range raw {
-		cb := llm.ContentBlock{Type: b.Type}
-		switch b.Type {
-		case blockTypeText, "":
-			cb.Type = blockTypeText
-			cb.Text = b.Text
-		case "thinking":
-			cb.Thinking = b.Thinking
-		case "tool_use", "server_tool_use":
-			cb.ToolUseID = b.ID
-			cb.ToolName = b.Name
-			cb.ToolInput = b.Input
-		case "tool_result":
-			cb.ToolResultID = b.ToolUseID
-			cb.ToolOutput = flattenToolResult(b.Content)
-			cb.IsError = b.IsError
-		case "image":
-			// presence only; bytes don't participate in signatures
-		default:
-			cb.Text = b.Text
-		}
-		out = append(out, cb)
-	}
-	return out
-}
-
-// flattenToolResult collapses a transcript tool_result's content
-// (string or array of text parts) into the wire's tool_output string.
-func flattenToolResult(content json.RawMessage) string {
-	if len(content) == 0 {
-		return ""
-	}
-	var asText string
-	if err := json.Unmarshal(content, &asText); err == nil {
-		return asText
-	}
-	var parts []struct {
-		Type string `json:"type"`
-		Text string `json:"text"`
-	}
-	if err := json.Unmarshal(content, &parts); err != nil {
-		return ""
-	}
-	var sb []string
-	for _, p := range parts {
-		if p.Type == blockTypeText {
-			sb = append(sb, p.Text)
-		}
-	}
-	return strings.Join(sb, "\n")
 }
 
 // blockSignature canonicalizes ONE projected content block into a
@@ -191,7 +110,7 @@ func blockSignature(block llm.ContentBlock) string {
 		return ""
 	}
 	p := projected[0]
-	if p.Type == "thinking" {
+	if p.Type == blockThinking {
 		return ""
 	}
 	// Tool ids are harness-stable across both sources and already part

--- a/pkg/derive/transcript_claude.go
+++ b/pkg/derive/transcript_claude.go
@@ -1,0 +1,107 @@
+package derive
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/papercomputeco/tapes/pkg/llm"
+)
+
+type claudeTranscriptRecord struct {
+	UUID       string `json:"uuid"`
+	ParentUUID string `json:"parentUuid"`
+	Message    struct {
+		Role    string          `json:"role"`
+		Content json.RawMessage `json:"content"`
+	} `json:"message"`
+}
+
+type claudeTranscriptBlock struct {
+	Type      string          `json:"type"`
+	Text      string          `json:"text"`
+	Thinking  string          `json:"thinking"`
+	Name      string          `json:"name"`
+	ID        string          `json:"id"`
+	Input     map[string]any  `json:"input"`
+	ToolUseID string          `json:"tool_use_id"`
+	Content   json.RawMessage `json:"content"`
+	IsError   bool            `json:"is_error"`
+}
+
+func parseClaudeTranscript(raw json.RawMessage, file *TranscriptFile) error {
+	var records []claudeTranscriptRecord
+	if err := json.Unmarshal(raw, &records); err != nil {
+		return err
+	}
+	for _, record := range records {
+		for _, block := range claudeTranscriptBlocks(record.Message.Content) {
+			if sig := blockSignature(block); sig != "" {
+				file.signatures[sig] = struct{}{}
+			}
+		}
+	}
+	return nil
+}
+
+func claudeTranscriptBlocks(content json.RawMessage) []llm.ContentBlock {
+	if len(content) == 0 {
+		return nil
+	}
+	var asText string
+	if err := json.Unmarshal(content, &asText); err == nil {
+		return []llm.ContentBlock{{Type: blockText, Text: asText}}
+	}
+	var raw []claudeTranscriptBlock
+	if err := json.Unmarshal(content, &raw); err != nil {
+		return nil
+	}
+	out := make([]llm.ContentBlock, 0, len(raw))
+	for _, block := range raw {
+		canonical := llm.ContentBlock{Type: block.Type}
+		switch block.Type {
+		case blockText, "":
+			canonical.Type = blockText
+			canonical.Text = block.Text
+		case blockThinking:
+			canonical.Thinking = block.Thinking
+		case blockToolUse, blockServerToolUse:
+			canonical.ToolUseID = block.ID
+			canonical.ToolName = block.Name
+			canonical.ToolInput = block.Input
+		case blockToolResult:
+			canonical.ToolResultID = block.ToolUseID
+			canonical.ToolOutput = flattenClaudeToolResult(block.Content)
+			canonical.IsError = block.IsError
+		case "image":
+			// Presence only; bytes do not participate in signatures.
+		default:
+			canonical.Text = block.Text
+		}
+		out = append(out, canonical)
+	}
+	return out
+}
+
+func flattenClaudeToolResult(content json.RawMessage) string {
+	if len(content) == 0 {
+		return ""
+	}
+	var asText string
+	if err := json.Unmarshal(content, &asText); err == nil {
+		return asText
+	}
+	var parts []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal(content, &parts); err != nil {
+		return ""
+	}
+	var text []string
+	for _, part := range parts {
+		if part.Type == blockText {
+			text = append(text, part.Text)
+		}
+	}
+	return strings.Join(text, "\n")
+}

--- a/pkg/derive/transcript_codex.go
+++ b/pkg/derive/transcript_codex.go
@@ -1,0 +1,55 @@
+package derive
+
+import (
+	"encoding/json"
+
+	openaiProvider "github.com/papercomputeco/tapes/pkg/llm/provider/openai"
+)
+
+type codexTranscriptRecord struct {
+	Type    string          `json:"type"`
+	Payload json.RawMessage `json:"payload"`
+}
+
+type codexSubagentActivity struct {
+	Type          string `json:"type"`
+	Kind          string `json:"kind"`
+	EventID       string `json:"event_id"`
+	AgentThreadID string `json:"agent_thread_id"`
+	AgentPath     string `json:"agent_path"`
+}
+
+// parseCodexTranscript reads rollout JSONL records. response_item payloads are
+// actual Responses items, so the shared provider mapper gives byte-shape
+// parity with the wire parser. Parent-rollout activity events supply the
+// otherwise-missing spawn call id for child transcripts.
+func parseCodexTranscript(raw json.RawMessage, file *TranscriptFile) error {
+	var records []codexTranscriptRecord
+	if err := json.Unmarshal(raw, &records); err != nil {
+		return err
+	}
+	for _, record := range records {
+		switch record.Type {
+		case "response_item":
+			for _, block := range openaiProvider.ResponsesItemContentBlocks(record.Payload) {
+				if sig := blockSignature(block); sig != "" {
+					file.signatures[sig] = struct{}{}
+				}
+			}
+		case "event_msg":
+			var activity codexSubagentActivity
+			if json.Unmarshal(record.Payload, &activity) != nil ||
+				activity.Type != "sub_agent_activity" || activity.Kind != "started" ||
+				activity.EventID == "" {
+				continue
+			}
+			if activity.AgentThreadID != "" {
+				file.spawnEdges[activity.AgentThreadID] = activity.EventID
+			}
+			if activity.AgentPath != "" {
+				file.spawnEdges[activity.AgentPath] = activity.EventID
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/derive/transcript_pi.go
+++ b/pkg/derive/transcript_pi.go
@@ -1,0 +1,78 @@
+package derive
+
+import (
+	"encoding/json"
+
+	"github.com/papercomputeco/tapes/pkg/llm"
+)
+
+type piTranscriptRecord struct {
+	Type    string `json:"type"`
+	Message struct {
+		Role       string          `json:"role"`
+		Content    json.RawMessage `json:"content"`
+		ToolCallID string          `json:"toolCallId"`
+		ToolName   string          `json:"toolName"`
+		IsError    bool            `json:"isError"`
+	} `json:"message"`
+}
+
+type piTranscriptBlock struct {
+	Type      string         `json:"type"`
+	Text      string         `json:"text"`
+	Thinking  string         `json:"thinking"`
+	ID        string         `json:"id"`
+	Name      string         `json:"name"`
+	Arguments map[string]any `json:"arguments"`
+}
+
+// parsePiTranscript reads pi's append-only session tree. Pi stores canonical
+// user/assistant content in message records and tool results as their own
+// toolResult messages, independent of the provider used for the wire call.
+func parsePiTranscript(raw json.RawMessage, file *TranscriptFile) error {
+	var records []piTranscriptRecord
+	if err := json.Unmarshal(raw, &records); err != nil {
+		return err
+	}
+	for _, record := range records {
+		if record.Type != "message" {
+			continue
+		}
+		if record.Message.Role == "toolResult" {
+			block := llm.ContentBlock{
+				Type:         blockToolResult,
+				ToolResultID: record.Message.ToolCallID,
+				ToolOutput:   flattenClaudeToolResult(record.Message.Content),
+				IsError:      record.Message.IsError,
+			}
+			if sig := blockSignature(block); sig != "" {
+				file.signatures[sig] = struct{}{}
+			}
+			continue
+		}
+		var blocks []piTranscriptBlock
+		if json.Unmarshal(record.Message.Content, &blocks) != nil {
+			continue
+		}
+		for _, block := range blocks {
+			canonical := llm.ContentBlock{Type: block.Type}
+			switch block.Type {
+			case "text":
+				canonical.Text = block.Text
+			case blockThinking:
+				canonical.Thinking = block.Thinking
+			case "toolCall":
+				canonical.Type = blockToolUse
+				canonical.ToolUseID = block.ID
+				canonical.ToolName = block.Name
+				canonical.ToolInput = block.Arguments
+			default:
+				continue
+			}
+			if sig := blockSignature(canonical); sig != "" {
+				file.signatures[sig] = struct{}{}
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/derive/transcript_pi_test.go
+++ b/pkg/derive/transcript_pi_test.go
@@ -1,0 +1,34 @@
+package derive
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/papercomputeco/tapes/pkg/storage"
+)
+
+func TestParsePiTranscript(t *testing.T) {
+	g := NewWithT(t)
+	records := json.RawMessage(`[
+		{"type":"session","id":"pi-1","cwd":"/work","version":3},
+		{"type":"message","message":{"role":"user","content":[{"type":"text","text":"inspect it"}]}},
+		{"type":"message","message":{"role":"assistant","content":[{"type":"toolCall","id":"call_1","name":"bash","arguments":{"command":"pwd"}}]}},
+		{"type":"message","message":{"role":"toolResult","toolCallId":"call_1","toolName":"bash","content":[{"type":"text","text":"/work"}],"isError":false}}
+	]`)
+	rec := &storage.RawTurnRecord{
+		Source: "transcript", HarnessID: "pi", HarnessSessionID: "pi-1",
+		Meta: json.RawMessage(`{"transcript":true}`), RawRequest: records,
+	}
+	file, err := ParseTranscriptFile(rec)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(file.signatures).To(HaveLen(3))
+
+	unknown := *rec
+	unknown.HarnessID = "future-harness"
+	_, err = ParseTranscriptFile(&unknown)
+	g.Expect(err).To(MatchError(`unsupported transcript harness "future-harness"`))
+	g.Expect(errors.Is(err, ErrUnsupportedTranscriptHarness)).To(BeTrue())
+}

--- a/pkg/llm/provider/openai/responses.go
+++ b/pkg/llm/provider/openai/responses.go
@@ -26,22 +26,35 @@ type responsesRequest struct {
 	TopP            *float64          `json:"top_p,omitempty"`
 	Stream          *bool             `json:"stream,omitempty"`
 	Tools           []json.RawMessage `json:"tools,omitempty"`
+	ToolChoice      json.RawMessage   `json:"tool_choice,omitempty"`
 	Reasoning       map[string]any    `json:"reasoning,omitempty"`
 	PreviousID      string            `json:"previous_response_id,omitempty"`
 }
+
+// Responses item types for the custom-tool spine (GPT-5.6 Codex's
+// freeform exec runtime). Shared by the request parser and the
+// derive-time content normalizer.
+const (
+	itemCustomToolCall       = "custom_tool_call"
+	itemCustomToolCallOutput = "custom_tool_call_output"
+)
 
 // responsesItem is the union of the Responses input/output item shapes tapes
 // understands. Codex omits `"type":"message"` on plain role/content items,
 // so a missing type with a role present is treated as a message.
 type responsesItem struct {
-	Type    string          `json:"type"`
-	Role    string          `json:"role"`
-	Content json.RawMessage `json:"content"`
+	Type      string          `json:"type"`
+	Role      string          `json:"role"`
+	Content   json.RawMessage `json:"content"`
+	Author    string          `json:"author"`
+	Recipient string          `json:"recipient"`
 
-	// function_call / function_call_output
+	// function_call / function_call_output; custom_tool_call shares
+	// call_id/name and carries its freeform input on `input`.
 	CallID    string          `json:"call_id"`
 	Name      string          `json:"name"`
 	Arguments string          `json:"arguments"`
+	Input     string          `json:"input"`
 	Output    json.RawMessage `json:"output"`
 
 	// reasoning
@@ -123,15 +136,54 @@ func parseResponsesRequest(payload []byte) (*llm.ChatRequest, error) {
 	}
 
 	extra := map[string]any{"endpoint": "responses"}
+	if threadID := responsesThreadIDFromInput(req.Input); threadID != "" {
+		extra["thread_id"] = threadID
+	}
 	if len(req.Reasoning) > 0 {
 		extra["reasoning"] = req.Reasoning
 	}
 	if req.PreviousID != "" {
 		extra["previous_response_id"] = req.PreviousID
 	}
+	// GPT-5.6 Codex omits client-side tool definitions (the backend
+	// injects them server-side) but still declares tool routing via
+	// tool_choice — preserve it so classification can recognize the
+	// conversation spine without a `tools` array.
+	if jsonFieldPresent(req.ToolChoice) {
+		extra["tool_choice"] = string(req.ToolChoice)
+	}
 	result.Extra = extra
 
 	return result, nil
+}
+
+// responsesThreadIDFromInput recovers Codex collaboration child identity from
+// the request envelope. Codex does not currently send the capture-side
+// thread-id header used by Claude, but child calls carry an agent_message
+// addressed to /root/<task> whose visible prefix says NEW_TASK. Parent-thread
+// FINAL_ANSWER handbacks are deliberately excluded.
+func responsesThreadIDFromInput(input json.RawMessage) string {
+	var items []json.RawMessage
+	if json.Unmarshal(input, &items) != nil {
+		return ""
+	}
+	return responsesThreadID(items)
+}
+
+func responsesThreadID(items []json.RawMessage) string {
+	for _, raw := range items {
+		var item responsesItem
+		if json.Unmarshal(raw, &item) != nil || item.Type != "agent_message" {
+			continue
+		}
+		if item.Recipient == "" || item.Recipient == "/root" {
+			continue
+		}
+		if strings.Contains(rawToText(item.Content), "Message Type: NEW_TASK") {
+			return item.Recipient
+		}
+	}
+	return ""
 }
 
 // responsesItemToMessage maps one Responses item to a canonical message.
@@ -166,6 +218,18 @@ func responsesItemToMessage(raw json.RawMessage) (llm.Message, bool) {
 			}},
 		}, true
 
+	case item.Type == itemCustomToolCall:
+		return llm.Message{
+			Role:    "assistant",
+			Content: []llm.ContentBlock{customToolCallBlock(item)},
+		}, true
+
+	case item.Type == itemCustomToolCallOutput:
+		return llm.Message{
+			Role:    "tool",
+			Content: []llm.ContentBlock{customToolCallOutputBlock(item)},
+		}, true
+
 	case item.Type == "reasoning":
 		return llm.Message{
 			Role:    "assistant",
@@ -178,6 +242,17 @@ func responsesItemToMessage(raw json.RawMessage) (llm.Message, bool) {
 			Content: []llm.ContentBlock{{Type: item.Type, Content: raw}},
 		}, true
 	}
+}
+
+// ResponsesItemContentBlocks exposes the canonical content projection for one
+// Responses item. Harness transcript adapters use the same mapper as wire
+// requests so reconciliation signatures cannot drift between capture sources.
+func ResponsesItemContentBlocks(raw json.RawMessage) []llm.ContentBlock {
+	msg, ok := responsesItemToMessage(raw)
+	if !ok {
+		return nil
+	}
+	return msg.Content
 }
 
 // responsesContentBlocks maps a message item's content — bare string or
@@ -231,6 +306,92 @@ func functionCallBlock(item responsesItem, raw json.RawMessage) llm.ContentBlock
 		}
 	}
 	return cb
+}
+
+// customToolCallBlock maps a custom_tool_call item to a tool_use block.
+// Custom tools (GPT-5.6 Codex's exec runtime) carry a freeform string
+// instead of JSON arguments; it lands under the "input" key so the block
+// stays a structured tool call rather than an opaque blob. Only the
+// call identity fields participate, so a response item (which also
+// carries id/status) and its request-echo map to identical blocks.
+func customToolCallBlock(item responsesItem) llm.ContentBlock {
+	cb := llm.ContentBlock{
+		Type:      "tool_use",
+		ToolUseID: item.CallID,
+		ToolName:  item.Name,
+	}
+	if item.Input != "" {
+		cb.ToolInput = map[string]any{"input": item.Input}
+	}
+	return cb
+}
+
+// customToolCallOutputBlock maps a custom_tool_call_output item to a
+// tool_result block. The wire output is either a bare string or an
+// array of content parts ({type:"input_text",text:...}); parts are
+// joined so the result reads as the text the model saw.
+func customToolCallOutputBlock(item responsesItem) llm.ContentBlock {
+	return llm.ContentBlock{
+		Type:         "tool_result",
+		ToolResultID: item.CallID,
+		ToolOutput:   customToolOutputText(item.Output),
+	}
+}
+
+// customToolOutputText renders a custom_tool_call_output payload as
+// text: bare strings unquote, content-part arrays join their text, and
+// anything else stays compact JSON so nothing is lost.
+func customToolOutputText(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s
+	}
+	var parts []responsesContentPart
+	if err := json.Unmarshal(raw, &parts); err == nil {
+		var b strings.Builder
+		for _, part := range parts {
+			b.WriteString(part.Text)
+		}
+		return b.String()
+	}
+	return string(raw)
+}
+
+// NormalizeResponsesContent rewrites Responses output items that the
+// capture reducer preserved verbatim — custom_tool_call and
+// custom_tool_call_output — into the canonical tool blocks the derived
+// layer understands. The reducer keeps unknown item types raw by
+// design, so this runs at derive time (chain construction), which also
+// heals sessions whose responses were reduced before these item types
+// were cataloged: a re-derive reprojects them from the preserved raw
+// item. Blocks of any other type pass through untouched.
+func NormalizeResponsesContent(blocks []llm.ContentBlock) []llm.ContentBlock {
+	normalized := blocks
+	copied := false
+	for i, b := range blocks {
+		if (b.Type != itemCustomToolCall && b.Type != itemCustomToolCallOutput) || len(b.Content) == 0 {
+			continue
+		}
+		var item responsesItem
+		if err := json.Unmarshal(b.Content, &item); err != nil || item.CallID == "" {
+			continue
+		}
+		if !copied {
+			normalized = make([]llm.ContentBlock, len(blocks))
+			copy(normalized, blocks)
+			copied = true
+		}
+		switch b.Type {
+		case itemCustomToolCall:
+			normalized[i] = customToolCallBlock(item)
+		case itemCustomToolCallOutput:
+			normalized[i] = customToolCallOutputBlock(item)
+		}
+	}
+	return normalized
 }
 
 // reasoningBlock maps a reasoning item to a thinking block. The summary text

--- a/pkg/llm/provider/openai/responses_test.go
+++ b/pkg/llm/provider/openai/responses_test.go
@@ -1,9 +1,12 @@
 package openai_test
 
 import (
+	"encoding/json"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/papercomputeco/tapes/pkg/llm"
 	"github.com/papercomputeco/tapes/pkg/llm/provider/openai"
 )
 
@@ -91,6 +94,69 @@ var _ = Describe("Responses API request parsing", func() {
 		Expect(req.Messages[0].Content[0].Content).NotTo(BeEmpty())
 	})
 
+	It("infers a Codex child thread from a NEW_TASK agent message", func() {
+		req, err := provider.ParseRequest([]byte(`{
+			"model":"gpt-5.6-sol",
+			"input":[{"type":"agent_message","author":"/root","recipient":"/root/waddup_probe","content":[{"type":"input_text","text":"Message Type: NEW_TASK\nTask name: /root/waddup_probe\nSender: /root\nPayload:\n"}]}]
+		}`))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(req.Extra).To(HaveKeyWithValue("thread_id", "/root/waddup_probe"))
+	})
+
+	It("does not mistake a child FINAL_ANSWER handback for a child call", func() {
+		req, err := provider.ParseRequest([]byte(`{
+			"model":"gpt-5.6-sol",
+			"input":[{"type":"agent_message","author":"/root/waddup_probe","recipient":"/root","content":[{"type":"input_text","text":"Message Type: FINAL_ANSWER\nTask name: /root\nSender: /root/waddup_probe\nPayload:\nwaddup"}]}]
+		}`))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(req.Extra).NotTo(HaveKey("thread_id"))
+	})
+
+	It("maps custom tool calls to canonical tool blocks", func() {
+		// GPT-5.6 Codex wire shape: no `tools` array (the ChatGPT
+		// Codex backend injects definitions server-side), tool_choice
+		// declared, and the tool spine expressed as custom_tool_call /
+		// custom_tool_call_output items with freeform string input.
+		req, err := provider.ParseRequest([]byte(`{
+			"model": "gpt-5.6-sol",
+			"instructions": "You are Codex.",
+			"stream": true,
+			"tool_choice": "auto",
+			"input": [
+				{"type": "message", "role": "user", "content": [{"type": "input_text", "text": "list files"}]},
+				{"type": "custom_tool_call", "id": "ctc_1", "status": "completed", "call_id": "call_1", "name": "exec", "input": "const r = await tools.exec_command({cmd:\"ls\"})"},
+				{"type": "custom_tool_call_output", "call_id": "call_1", "output": [{"type": "input_text", "text": "Script completed\n"}, {"type": "input_text", "text": "README.md"}]}
+			]
+		}`))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(req.Tools).To(BeEmpty())
+		Expect(req.Extra).To(HaveKeyWithValue("tool_choice", `"auto"`))
+
+		Expect(req.Messages).To(HaveLen(3))
+
+		call := req.Messages[1]
+		Expect(call.Role).To(Equal("assistant"))
+		Expect(call.Content[0].Type).To(Equal("tool_use"))
+		Expect(call.Content[0].ToolUseID).To(Equal("call_1"))
+		Expect(call.Content[0].ToolName).To(Equal("exec"))
+		Expect(call.Content[0].ToolInput).To(HaveKeyWithValue("input", `const r = await tools.exec_command({cmd:"ls"})`))
+
+		result := req.Messages[2]
+		Expect(result.Role).To(Equal("tool"))
+		Expect(result.Content[0].Type).To(Equal("tool_result"))
+		Expect(result.Content[0].ToolResultID).To(Equal("call_1"))
+		Expect(result.Content[0].ToolOutput).To(Equal("Script completed\nREADME.md"))
+	})
+
+	It("renders a bare-string custom tool output verbatim", func() {
+		req, err := provider.ParseRequest([]byte(`{
+			"model": "gpt-5.6-sol",
+			"input": [{"type": "custom_tool_call_output", "call_id": "call_2", "output": "plain text"}]
+		}`))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(req.Messages[0].Content[0].ToolOutput).To(Equal("plain text"))
+	})
+
 	It("treats an explicit null input as Chat Completions, not Responses", func() {
 		// json.RawMessage keeps the literal `null` bytes; without the
 		// null check this would fabricate an empty user message.
@@ -108,5 +174,38 @@ var _ = Describe("Responses API request parsing", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(req.Messages).To(HaveLen(1))
 		Expect(req.Extra).NotTo(HaveKey("endpoint"))
+	})
+})
+
+var _ = Describe("NormalizeResponsesContent", func() {
+	It("rewrites verbatim custom tool items into canonical tool blocks", func() {
+		blocks := []llm.ContentBlock{
+			{Type: "thinking", ThinkingSignature: "blob"},
+			{Type: "custom_tool_call", Content: json.RawMessage(`{"type":"custom_tool_call","id":"ctc_1","status":"completed","call_id":"call_1","name":"exec","input":"echo hi"}`)},
+			{Type: "text", Text: "done"},
+		}
+
+		normalized := openai.NormalizeResponsesContent(blocks)
+
+		Expect(normalized).To(HaveLen(3))
+		Expect(normalized[0]).To(Equal(blocks[0]))
+		Expect(normalized[2]).To(Equal(blocks[2]))
+		Expect(normalized[1].Type).To(Equal("tool_use"))
+		Expect(normalized[1].ToolUseID).To(Equal("call_1"))
+		Expect(normalized[1].ToolName).To(Equal("exec"))
+		Expect(normalized[1].ToolInput).To(HaveKeyWithValue("input", "echo hi"))
+
+		// The input slice is never mutated — chains hash from it.
+		Expect(blocks[1].Type).To(Equal("custom_tool_call"))
+	})
+
+	It("passes through content without custom tool items untouched", func() {
+		blocks := []llm.ContentBlock{{Type: "text", Text: "hi"}}
+		Expect(openai.NormalizeResponsesContent(blocks)).To(Equal(blocks))
+	})
+
+	It("leaves undecodable custom tool items verbatim", func() {
+		blocks := []llm.ContentBlock{{Type: "custom_tool_call", Content: json.RawMessage(`"not an object"`)}}
+		Expect(openai.NormalizeResponsesContent(blocks)).To(Equal(blocks))
 	})
 })

--- a/pkg/storage/postgres/derive.go
+++ b/pkg/storage/postgres/derive.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"sort"
 	"time"
 
@@ -124,6 +125,11 @@ func (d *Driver) RederiveFromRaw(ctx context.Context, project string) (map[strin
 			rec := rawTurnRecordFromRow(row)
 			file, err := derive.ParseTranscriptFile(&rec)
 			if err != nil {
+				if errors.Is(err, derive.ErrUnsupportedTranscriptHarness) {
+					slog.WarnContext(ctx, "skip unsupported transcript harness",
+						"raw_turn_id", id, "harness_id", rec.HarnessID)
+					continue
+				}
 				return nil, fmt.Errorf("parse transcript row %d: %w", id, err)
 			}
 			files = append(files, file)
@@ -216,6 +222,11 @@ func (d *Driver) RederiveSession(ctx context.Context, project, orgID, harnessID,
 		rec := rawTurnRecordFromRow(row)
 		file, err := derive.ParseTranscriptFile(&rec)
 		if err != nil {
+			if errors.Is(err, derive.ErrUnsupportedTranscriptHarness) {
+				slog.WarnContext(ctx, "skip unsupported transcript harness",
+					"raw_turn_id", id, "harness_id", rec.HarnessID)
+				continue
+			}
 			return nil, fmt.Errorf("parse transcript row %d: %w", id, err)
 		}
 		files = append(files, file)

--- a/pkg/storage/postgres/export_test.go
+++ b/pkg/storage/postgres/export_test.go
@@ -18,5 +18,6 @@ func InterfaceInt64ForTest(v any) int64 {
 // ordering validator so the unit suite can exercise it without an
 // integration database.
 func ValidateChainOrderingForTest(nodes []*merkle.Node) error {
-	return validateChainOrdering(nodes)
+	_, err := validateChainOrdering(nodes)
+	return err
 }

--- a/pkg/storage/postgres/postgres_internal_test.go
+++ b/pkg/storage/postgres/postgres_internal_test.go
@@ -54,6 +54,31 @@ var _ = Describe("validateChainOrdering", func() {
 		Expect(postgres.ValidateChainOrderingForTest(nodes)).To(Succeed())
 	})
 
+	It("accepts leading injected context beside the conversation root", func() {
+		nodes := []*merkle.Node{
+			{Hash: "injected", Kind: "injected:agent-context"},
+			{Hash: "h0"},
+			{Hash: "h1", ParentHash: stringPtr("h0")},
+		}
+		Expect(postgres.ValidateChainOrderingForTest(nodes)).To(Succeed())
+	})
+
+	It("accepts an injected side branch without advancing the spine", func() {
+		nodes := []*merkle.Node{
+			{Hash: "h0"},
+			{Hash: "injected", Kind: "injected:mode-banner", ParentHash: stringPtr("h0")},
+			{Hash: "h1", ParentHash: stringPtr("h0")},
+		}
+		Expect(postgres.ValidateChainOrderingForTest(nodes)).To(Succeed())
+	})
+
+	It("rejects a projection containing only injected nodes", func() {
+		nodes := []*merkle.Node{{Hash: "injected", Kind: "injected:agent-context"}}
+		err := postgres.ValidateChainOrderingForTest(nodes)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("no conversation spine"))
+	})
+
 	It("rejects a chain whose root carries a ParentHash", func() {
 		nodes := []*merkle.Node{
 			{Hash: "h0", ParentHash: stringPtr("not-a-root")},
@@ -84,11 +109,11 @@ var _ = Describe("validateChainOrdering", func() {
 		Expect(err.Error()).To(ContainSubstring("nodes[1]"))
 	})
 
-	It("rejects a scrambled chain whose ParentHash does not chain", func() {
+	It("rejects a real side branch from the conversation spine", func() {
 		nodes := []*merkle.Node{
 			{Hash: "h0"},
 			{Hash: "h1", ParentHash: stringPtr("h0")},
-			{Hash: "h2", ParentHash: stringPtr("h0")}, // should be h1
+			{Hash: "h2", ParentHash: stringPtr("h0")}, // not classified as injected
 		}
 		err := postgres.ValidateChainOrderingForTest(nodes)
 		Expect(err).To(HaveOccurred())

--- a/pkg/storage/postgres/session_ingest.go
+++ b/pkg/storage/postgres/session_ingest.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"math/big"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -65,10 +66,11 @@ func (d *Driver) IngestTurn(ctx context.Context, req storage.IngestTurnRequest) 
 	if len(req.Nodes) == 0 {
 		return storage.IngestTurnResult{}, errors.New("ingest turn: no nodes supplied")
 	}
-	if err := validateChainOrdering(req.Nodes); err != nil {
-		// Synthetic id derivation (req.Nodes[0].Hash) trusts the caller's
-		// root-to-leaf ordering — a scrambled chain would derive the
-		// wrong "root" and silently land turns on the wrong session.
+	root, err := validateChainOrdering(req.Nodes)
+	if err != nil {
+		// Synthetic id derivation trusts the caller's ordered projection.
+		// A scrambled spine would derive the wrong root and silently land
+		// turns on the wrong session.
 		// Reject at the boundary; do not attempt to repair.
 		return storage.IngestTurnResult{}, fmt.Errorf("ingest turn: %w", err)
 	}
@@ -83,7 +85,7 @@ func (d *Driver) IngestTurn(ctx context.Context, req storage.IngestTurnRequest) 
 	now := time.Now().UTC()
 	nowTS := pgtype.Timestamptz{Time: now, Valid: true}
 
-	envelope, harnessSessionID, err := resolveHarnessSessionID(req.Session, req.Nodes[0])
+	envelope, harnessSessionID, err := resolveHarnessSessionID(req.Session, root)
 	if err != nil {
 		return storage.IngestTurnResult{}, fmt.Errorf("resolve harness_session_id: %w", err)
 	}
@@ -335,35 +337,47 @@ UPDATE nodes
 	}, nil
 }
 
-// validateChainOrdering enforces the root-to-leaf invariant documented
-// on storage.IngestTurnRequest: each node's ParentHash must point at
-// the previous node's Hash. Nodes[0] is the conversation root, so its
-// ParentHash must be nil or empty.
+// validateChainOrdering enforces the ordered-projection invariant documented
+// on storage.IngestTurnRequest. Non-injected nodes form a root-to-leaf spine.
+// Injected nodes are side branches from the current spine parent and do not
+// advance it, so leading injected context and the conversation root may both
+// have no ParentHash.
 //
-// The synthetic harness_session_id derivation depends on Nodes[0]
-// actually being the root, and the (org_id, hash) PK on nodes means a
-// scrambled chain produces real duplicate-hash conflicts on the wrong
-// session; we reject at the boundary rather than attempt a repair.
-func validateChainOrdering(nodes []*merkle.Node) error {
+// The returned node is the conversation root used for synthetic session IDs.
+// The (org_id, hash) PK on nodes means a scrambled spine produces real
+// duplicate-hash conflicts on the wrong session, so reject rather than repair.
+func validateChainOrdering(nodes []*merkle.Node) (*merkle.Node, error) {
+	var root *merkle.Node
+	var spineParent *merkle.Node
 	for i, node := range nodes {
 		if node == nil {
-			return fmt.Errorf("nodes[%d] is nil", i)
+			return nil, fmt.Errorf("nodes[%d] is nil", i)
 		}
-		if i == 0 {
-			if node.ParentHash != nil && *node.ParentHash != "" {
-				return fmt.Errorf("nodes[0] must be the conversation root: ParentHash=%q", *node.ParentHash)
-			}
+
+		expectedParent := ""
+		if spineParent != nil {
+			expectedParent = spineParent.Hash
+		}
+		actualParent := ""
+		if node.ParentHash != nil {
+			actualParent = *node.ParentHash
+		}
+		if actualParent != expectedParent {
+			return nil, fmt.Errorf("nodes[%d].ParentHash=%q does not chain to spine parent %q", i, actualParent, expectedParent)
+		}
+
+		if strings.HasPrefix(node.Kind, "injected:") {
 			continue
 		}
-		prev := nodes[i-1]
-		if node.ParentHash == nil || *node.ParentHash == "" {
-			return fmt.Errorf("nodes[%d] has no ParentHash but expected %q", i, prev.Hash)
+		if root == nil {
+			root = node
 		}
-		if *node.ParentHash != prev.Hash {
-			return fmt.Errorf("nodes[%d].ParentHash=%q does not chain to nodes[%d].Hash=%q", i, *node.ParentHash, i-1, prev.Hash)
-		}
+		spineParent = node
 	}
-	return nil
+	if root == nil {
+		return nil, errors.New("nodes contain no conversation spine")
+	}
+	return root, nil
 }
 
 // resolveHarnessSessionID returns the envelope to persist (always

--- a/pkg/storage/postgres/session_reads.go
+++ b/pkg/storage/postgres/session_reads.go
@@ -180,6 +180,7 @@ SELECT DISTINCT ON (session_id) session_id::text, bucket
 FROM nodes
 WHERE session_id = ANY($1::uuid[])
   AND role = 'user'
+  AND COALESCE(node_kind, '') NOT LIKE 'injected:%'
 ORDER BY session_id, created_at ASC
 `, ids)
 	if err != nil {
@@ -249,7 +250,9 @@ func (d *Driver) GetSessionRecord(ctx context.Context, orgID, id string) (*stora
 		return nil, fmt.Errorf("get session record: %w", err)
 	}
 	s := sessionRecordFromRow(row)
-	return &s, nil
+	recs := []storage.SessionRecord{s}
+	d.attachPreviews(ctx, recs)
+	return &recs[0], nil
 }
 
 // DeleteSession removes a session by its org-scoped id and returns whether a

--- a/pkg/storage/postgres/session_reads_test.go
+++ b/pkg/storage/postgres/session_reads_test.go
@@ -6,6 +6,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/papercomputeco/tapes/pkg/merkle"
 	"github.com/papercomputeco/tapes/pkg/sessions"
 	"github.com/papercomputeco/tapes/pkg/storage"
 	"github.com/papercomputeco/tapes/pkg/storage/postgres"
@@ -98,6 +99,42 @@ var _ = Describe("Driver.GetSessionRecordByHarness", func() {
 		Expect(listed).To(HaveLen(1))
 		Expect(listed[0].ID).To(Equal(rec.ID))
 		Expect(listed[0].Preview).To(Equal(rec.Preview))
+	})
+
+	It("returns the preview when looking up a session by UUID", func() {
+		orgID := newTestOrgID()
+		sessionID := seedSession(orgID, "codex", "detail-preview", "detail page title")
+
+		rec, err := pgDriver.GetSessionRecord(ctx, orgID, sessionID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rec).NotTo(BeNil())
+		Expect(rec.Preview).To(Equal("detail page title"))
+	})
+
+	It("uses the first human message for a Codex session preview", func() {
+		orgID := newTestOrgID()
+		humanTurn := sessionFixture("fix the linear mcp server")
+		context := sessionFixture("# AGENTS.md instructions for /workspace/project")[0]
+		context.Kind = "injected:agent-context"
+		human := merkle.NewNode(humanTurn[0].Bucket, nil)
+		response := merkle.NewNode(humanTurn[1].Bucket, human, merkle.NodeOptions{StopReason: "stop"})
+		nodes := []*merkle.Node{context, human, response}
+
+		_, err := ingester.IngestTurn(ctx, storage.IngestTurnRequest{
+			Session: &sessions.IngestEnvelope{
+				OrgID:            orgID,
+				AuthSubject:      "subject-codex",
+				HarnessID:        "codex",
+				HarnessSessionID: "codex-preview",
+			},
+			Nodes: nodes,
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		rec, err := pgDriver.GetSessionRecordByHarness(ctx, orgID, "codex", "codex-preview")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rec).NotTo(BeNil())
+		Expect(rec.Preview).To(Equal("fix the linear mcp server"))
 	})
 
 	It("returns nil without error when no row matches the natural key", func() {

--- a/pkg/storage/session_ingester.go
+++ b/pkg/storage/session_ingester.go
@@ -53,10 +53,10 @@ type IngestTurnRequest struct {
 	// to a Merkle-derived synthetic harness_session_id.
 	Session *sessions.IngestEnvelope
 
-	// Nodes is the chain of nodes for this turn, ordered root-to-leaf.
-	// The first element is the conversation root; the last is the
-	// assistant response. ParentHash linkage between successive
-	// elements must already be set by NewNode at the call site.
+	// Nodes is the ordered projection for this turn. Non-injected nodes
+	// form the root-to-leaf conversation spine; injected nodes may appear
+	// between them as side branches from the current spine parent. The
+	// last element is the assistant response.
 	Nodes []*merkle.Node
 
 	// InputTokens / OutputTokens / CostUSD are the per-turn deltas


### PR DESCRIPTION
## Summary

- recognize streaming Responses calls whose tools are injected server-side
- normalize custom tool calls before hashing so capture and re-derive agree
- isolate Claude, Codex, and Pi transcript parsing behind harness-specific adapters
- recover Codex subagent spawn edges from parent rollouts and project nested runtime activity semantically

## Validation

- `make format`
- `make test`
- `make e2e-test`
- `make test-kafka-e2e`
- verified GPT-5.6 and Pi derivation in the local clearing

Fixes PCC-881
