### PR TITLE
🔧 fix(api): snap and cache /v1/stats window aggregates

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -16,12 +16,13 @@ import (
 
 // Server is the API server for managing and querying the Tapes system
 type Server struct {
-	config    Config
-	driver    storage.Driver
-	logger    *slog.Logger
-	app       *fiber.App
-	metrics   *Metrics
-	mcpServer *mcp.Server
+	config     Config
+	driver     storage.Driver
+	logger     *slog.Logger
+	app        *fiber.App
+	metrics    *Metrics
+	mcpServer  *mcp.Server
+	statsCache *statsCache
 }
 
 // NewServer creates a new API server.
@@ -34,11 +35,12 @@ func NewServer(config Config, driver storage.Driver, log *slog.Logger) (*Server,
 	})
 
 	s := &Server{
-		config:  config,
-		driver:  driver,
-		logger:  log,
-		app:     app,
-		metrics: NewMetrics(),
+		config:     config,
+		driver:     driver,
+		logger:     log,
+		app:        app,
+		metrics:    NewMetrics(),
+		statsCache: newStatsCache(),
 	}
 
 	// RED metrics is registered first so it sits as the outermost wrapper.

--- a/api/stats_cache.go
+++ b/api/stats_cache.go
@@ -1,0 +1,111 @@
+package api
+
+import (
+	"strings"
+	"sync"
+	"time"
+)
+
+// statsCacheTTL bounds how stale a cached /v1/stats aggregate may be
+// served. 60s matches the console's client-side staleTime, so the end-user
+// freshness contract is unchanged: the dashboard already treats stats as
+// up-to-a-minute stale.
+const statsCacheTTL = 60 * time.Second
+
+// statsCacheMaxEntries caps the cache map. Keys are (org, minute-snapped
+// window), so steady-state growth is a handful of entries per active org
+// per minute; the cap is a backstop against a caller sweeping arbitrary
+// windows, not a working-set tuning knob.
+const statsCacheMaxEntries = 1024
+
+type statsCacheEntry struct {
+	response  StatsResponse
+	expiresAt time.Time
+}
+
+// statsCache memoizes the span-layer /v1/stats aggregate per
+// (org, minute-snapped window). The aggregate scans every span turn in the
+// window on each request, and dashboard clients re-request the same logical
+// window with millisecond-unique `since` values — without snapping and
+// memoizing, the identical number is recomputed for every page view.
+type statsCache struct {
+	mu      sync.Mutex
+	entries map[string]statsCacheEntry
+	// now is injectable so TTL expiry is testable without sleeping.
+	now func() time.Time
+}
+
+func newStatsCache() *statsCache {
+	return &statsCache{
+		entries: make(map[string]statsCacheEntry),
+		now:     time.Now,
+	}
+}
+
+func (c *statsCache) get(key string) (StatsResponse, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	e, ok := c.entries[key]
+	if !ok || c.now().After(e.expiresAt) {
+		return StatsResponse{}, false
+	}
+	return e.response, true
+}
+
+func (c *statsCache) set(key string, resp StatsResponse) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.entries) >= statsCacheMaxEntries {
+		now := c.now()
+		for k, e := range c.entries {
+			if now.After(e.expiresAt) {
+				delete(c.entries, k)
+			}
+		}
+		// Everything still live means a pathological key sweep inside one
+		// TTL; dropping the map wholesale is cheaper than tracking LRU
+		// order for a cache whose entries cost one aggregate query each.
+		if len(c.entries) >= statsCacheMaxEntries {
+			clear(c.entries)
+		}
+	}
+	c.entries[key] = statsCacheEntry{response: resp, expiresAt: c.now().Add(statsCacheTTL)}
+}
+
+// snapStatsWindow widens the requested window to whole-minute boundaries:
+// since floors, until ceils. Dashboard clients anchor `since` on their own
+// clock at request time, so two requests for the same logical window ("last
+// 30d") differ by milliseconds and would never share a cache entry. The
+// snapped window always CONTAINS the requested one (never drops data the
+// caller asked for); it over-includes at most 60s per edge, which is noise
+// for a whole-window aggregate.
+func snapStatsWindow(since, until *time.Time) (*time.Time, *time.Time) {
+	if since != nil {
+		t := since.UTC().Truncate(time.Minute)
+		since = &t
+	}
+	if until != nil {
+		t := until.UTC().Truncate(time.Minute)
+		if t.Before(until.UTC()) {
+			t = t.Add(time.Minute)
+		}
+		until = &t
+	}
+	return since, until
+}
+
+// statsCacheKey identifies one (org, window) aggregate. Callers pass the
+// already-snapped window so equal logical windows collide.
+func statsCacheKey(orgID string, since, until *time.Time) string {
+	var b strings.Builder
+	b.WriteString(orgID)
+	b.WriteByte('|')
+	if since != nil {
+		b.WriteString(since.UTC().Format(time.RFC3339))
+	}
+	b.WriteByte('|')
+	if until != nil {
+		b.WriteString(until.UTC().Format(time.RFC3339))
+	}
+	return b.String()
+}

--- a/api/stats_cache_test.go
+++ b/api/stats_cache_test.go
@@ -1,0 +1,97 @@
+package api
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("statsCache", func() {
+	var (
+		cache *statsCache
+		now   time.Time
+	)
+
+	BeforeEach(func() {
+		cache = newStatsCache()
+		now = time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
+		cache.now = func() time.Time { return now }
+	})
+
+	It("returns a stored entry within the TTL", func() {
+		cache.set("k", StatsResponse{SessionCount: 3})
+
+		now = now.Add(statsCacheTTL - time.Second)
+		got, ok := cache.get("k")
+		Expect(ok).To(BeTrue())
+		Expect(got.SessionCount).To(Equal(3))
+	})
+
+	It("expires entries after the TTL", func() {
+		cache.set("k", StatsResponse{SessionCount: 3})
+
+		now = now.Add(statsCacheTTL + time.Second)
+		_, ok := cache.get("k")
+		Expect(ok).To(BeFalse())
+	})
+
+	It("misses on unknown keys", func() {
+		_, ok := cache.get("nope")
+		Expect(ok).To(BeFalse())
+	})
+
+	It("stays bounded under a pathological key sweep", func() {
+		for i := 0; i < statsCacheMaxEntries*2; i++ {
+			cache.set(time.Duration(i).String(), StatsResponse{})
+		}
+		Expect(len(cache.entries)).To(BeNumerically("<=", statsCacheMaxEntries))
+	})
+})
+
+var _ = Describe("snapStatsWindow", func() {
+	ts := func(t time.Time) *time.Time { return &t }
+
+	It("passes nil bounds through", func() {
+		since, until := snapStatsWindow(nil, nil)
+		Expect(since).To(BeNil())
+		Expect(until).To(BeNil())
+	})
+
+	It("floors since to the minute", func() {
+		since, _ := snapStatsWindow(ts(time.Date(2026, 4, 1, 12, 30, 45, 123e6, time.UTC)), nil)
+		Expect(since.UTC()).To(Equal(time.Date(2026, 4, 1, 12, 30, 0, 0, time.UTC)))
+	})
+
+	It("ceils a fractional until to the next minute so the requested window stays contained", func() {
+		// The console's custom ranges end at T23:59:59.999Z; flooring
+		// would silently drop the final minute of requested data.
+		_, until := snapStatsWindow(nil, ts(time.Date(2026, 4, 1, 23, 59, 59, 999e6, time.UTC)))
+		Expect(until.UTC()).To(Equal(time.Date(2026, 4, 2, 0, 0, 0, 0, time.UTC)))
+	})
+
+	It("leaves minute-aligned bounds unchanged", func() {
+		since, until := snapStatsWindow(
+			ts(time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)),
+			ts(time.Date(2026, 4, 2, 0, 0, 0, 0, time.UTC)),
+		)
+		Expect(since.UTC()).To(Equal(time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)))
+		Expect(until.UTC()).To(Equal(time.Date(2026, 4, 2, 0, 0, 0, 0, time.UTC)))
+	})
+})
+
+var _ = Describe("statsCacheKey", func() {
+	It("distinguishes open and bounded windows", func() {
+		since := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+		until := time.Date(2026, 4, 2, 0, 0, 0, 0, time.UTC)
+		open := statsCacheKey("org", nil, nil)
+		sinceOnly := statsCacheKey("org", &since, nil)
+		bounded := statsCacheKey("org", &since, &until)
+		Expect(open).NotTo(Equal(sinceOnly))
+		Expect(sinceOnly).NotTo(Equal(bounded))
+	})
+
+	It("scopes by org", func() {
+		Expect(statsCacheKey("a", nil, nil)).NotTo(Equal(statsCacheKey("b", nil, nil)))
+	})
+})

--- a/api/v1_handlers.go
+++ b/api/v1_handlers.go
@@ -41,7 +41,7 @@ type StatsResponse struct {
 //
 //	@Summary		Get aggregate session stats
 //	@ID			getStats
-//	@Description	Returns counts plus cost / token / duration / tool-call / completed-count totals for the window. The numbers are span-grain trace rollup sums (delta-only usage, agent time = sum of trace durations) so they agree with the session and trace views; turn_count counts traces. Filter the window with since/until.
+//	@Description	Returns counts plus cost / token / duration / tool-call / completed-count totals for the window. The numbers are span-grain trace rollup sums (delta-only usage, agent time = sum of trace durations) so they agree with the session and trace views; turn_count counts traces. Filter the window with since/until. The window is snapped outward to whole-minute boundaries (since floors, until ceils) and the aggregate is served from a per-org cache for up to 60 seconds, so repeated requests for the same logical window do not recompute.
 //	@Tags			sessions
 //	@Produce		json
 //	@Param			since		query		string	false	"Only include records at or after this RFC3339 timestamp"	format(date-time)
@@ -56,6 +56,16 @@ func (s *Server) handleStats(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusBadRequest).JSON(llm.ErrorResponse{Error: err.Error()})
 	}
 
+	// Snap the window to whole minutes so requests for the same logical
+	// window ("last 30d", anchored on the caller's clock) share one cache
+	// entry instead of recomputing the aggregate per millisecond-unique
+	// `since`. See snapStatsWindow for the containment guarantee.
+	since, until = snapStatsWindow(since, until)
+	cacheKey := statsCacheKey(orgIDFromCtx(c), since, until)
+	if cached, ok := s.statsCache.get(cacheKey); ok {
+		return c.JSON(cached)
+	}
+
 	// Span-layer trace-grain rollups are the only accounting: the deriver
 	// is the single writer of session/trace totals.
 	reader, ok := s.driver.(storage.SpanStatsReader)
@@ -68,7 +78,7 @@ func (s *Server) handleStats(c *fiber.Ctx) error {
 		s.logger.Error("aggregate span stats", "error", err)
 		return c.Status(fiber.StatusInternalServerError).JSON(llm.ErrorResponse{Error: "failed to compute stats"})
 	}
-	return c.JSON(StatsResponse{
+	resp := StatsResponse{
 		SessionCount:    stats.SessionCount,
 		TurnCount:       stats.TurnCount,
 		CompletedCount:  stats.CompletedCount,
@@ -77,7 +87,9 @@ func (s *Server) handleStats(c *fiber.Ctx) error {
 		OutputTokens:    stats.OutputTokens,
 		TotalDurationMs: stats.TotalDurationNS / int64(time.Millisecond),
 		ToolCalls:       stats.ToolCalls,
-	})
+	}
+	s.statsCache.set(cacheKey, resp)
+	return c.JSON(resp)
 }
 
 // parseStatsWindow reads the optional since/until time window from query

--- a/api/v1_handlers_test.go
+++ b/api/v1_handlers_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"time"
@@ -87,6 +88,63 @@ var _ = Describe("v1 session handlers", func() {
 			Expect(drv.lastUntil).NotTo(BeNil())
 			Expect(drv.lastSince.UTC()).To(Equal(time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)))
 			Expect(drv.lastUntil.UTC()).To(Equal(time.Date(2026, 4, 2, 0, 0, 0, 0, time.UTC)))
+		})
+
+		It("serves a repeated window from cache without re-aggregating", func() {
+			drv := &statsStubDriver{
+				Driver: inmemory.NewDriver(),
+				stats:  storage.SpanStats{SessionCount: 7, TotalCostUSD: 12.5},
+			}
+			server := newStatsServer(drv)
+
+			first := decodeStats(server, "/v1/stats?since=2026-04-01T00:00:00Z")
+			second := decodeStats(server, "/v1/stats?since=2026-04-01T00:00:00Z")
+
+			Expect(drv.calls).To(Equal(1))
+			Expect(second).To(Equal(first))
+		})
+
+		It("collapses millisecond-unique since values into one snapped window", func() {
+			// Dashboard clients anchor since on their own clock, so two
+			// requests for the same logical window differ by milliseconds.
+			drv := &statsStubDriver{Driver: inmemory.NewDriver()}
+			server := newStatsServer(drv)
+
+			_ = decodeStats(server, "/v1/stats?since=2026-04-01T00:00:00.123Z")
+			_ = decodeStats(server, "/v1/stats?since=2026-04-01T00:00:59.987Z")
+
+			Expect(drv.calls).To(Equal(1))
+			Expect(drv.lastSince).NotTo(BeNil())
+			Expect(drv.lastSince.UTC()).To(Equal(time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)))
+		})
+
+		It("caches distinct windows separately", func() {
+			drv := &statsStubDriver{Driver: inmemory.NewDriver()}
+			server := newStatsServer(drv)
+
+			_ = decodeStats(server, "/v1/stats?since=2026-04-01T00:00:00Z")
+			_ = decodeStats(server, "/v1/stats?since=2026-04-01T00:01:00Z")
+
+			Expect(drv.calls).To(Equal(2))
+		})
+
+		It("does not cache aggregate failures", func() {
+			drv := &statsStubDriver{
+				Driver:   inmemory.NewDriver(),
+				statsErr: errors.New("boom"),
+			}
+			server := newStatsServer(drv)
+
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "/v1/stats?since=2026-04-01T00:00:00Z", nil)
+			Expect(err).NotTo(HaveOccurred())
+			resp, err := server.app.Test(req)
+			Expect(err).NotTo(HaveOccurred())
+			resp.Body.Close()
+			Expect(resp.StatusCode).To(Equal(fiber.StatusInternalServerError))
+
+			drv.statsErr = nil
+			_ = decodeStats(server, "/v1/stats?since=2026-04-01T00:00:00Z")
+			Expect(drv.calls).To(Equal(2))
 		})
 
 		It("returns zeros across every field for an empty aggregate", func() {

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -747,7 +747,7 @@ const docTemplate = `{
         },
         "/v1/stats": {
             "get": {
-                "description": "Returns counts plus cost / token / duration / tool-call / completed-count totals for the window. The numbers are span-grain trace rollup sums (delta-only usage, agent time = sum of trace durations) so they agree with the session and trace views; turn_count counts traces. Filter the window with since/until.",
+                "description": "Returns counts plus cost / token / duration / tool-call / completed-count totals for the window. The numbers are span-grain trace rollup sums (delta-only usage, agent time = sum of trace durations) so they agree with the session and trace views; turn_count counts traces. Filter the window with since/until. The window is snapped outward to whole-minute boundaries (since floors, until ceils) and the aggregate is served from a per-org cache for up to 60 seconds, so repeated requests for the same logical window do not recompute.",
                 "produces": [
                     "application/json"
                 ],

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -744,7 +744,7 @@
         },
         "/v1/stats": {
             "get": {
-                "description": "Returns counts plus cost / token / duration / tool-call / completed-count totals for the window. The numbers are span-grain trace rollup sums (delta-only usage, agent time = sum of trace durations) so they agree with the session and trace views; turn_count counts traces. Filter the window with since/until.",
+                "description": "Returns counts plus cost / token / duration / tool-call / completed-count totals for the window. The numbers are span-grain trace rollup sums (delta-only usage, agent time = sum of trace durations) so they agree with the session and trace views; turn_count counts traces. Filter the window with since/until. The window is snapped outward to whole-minute boundaries (since floors, until ceils) and the aggregate is served from a per-org cache for up to 60 seconds, so repeated requests for the same logical window do not recompute.",
                 "produces": [
                     "application/json"
                 ],

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1043,6 +1043,9 @@ paths:
         totals for the window. The numbers are span-grain trace rollup sums (delta-only
         usage, agent time = sum of trace durations) so they agree with the session
         and trace views; turn_count counts traces. Filter the window with since/until.
+        The window is snapped outward to whole-minute boundaries (since floors, until
+        ceils) and the aggregate is served from a per-org cache for up to 60 seconds,
+        so repeated requests for the same logical window do not recompute.
       operationId: getStats
       parameters:
       - description: Only include records at or after this RFC3339 timestamp


### PR DESCRIPTION
## What users notice

The console's stat strip (Sessions dashboard and Insights) stops paying a full database aggregation on every page view. Any repeat view of the same stats window within a minute — same user navigating between pages, a teammate loading the same dashboard — is served instantly from a server-side cache instead of recomputing the identical numbers.

## Why the cache never hit before

Dashboard clients anchor `since` on their own clock at request time, so two requests for the same logical window ("last 30d") differ by milliseconds. Every request was a window the server had never seen, so no cache at any layer could help, and each one re-ran the whole-window span aggregate (`AggregateSpanStats`: window scan + correlated `EXISTS` per turn row + tool-span count).

## How

- **Snap the window outward to whole-minute boundaries** (since floors, until ceils) before querying. The snapped window always contains the requested one; over-inclusion is ≤60s per edge, which is noise for a whole-window aggregate. Snapping makes identical logical windows collide on one key.
- **Memoize per (org, snapped window) for 60s** — the same staleTime the console already applies client-side, so end-user freshness is unchanged. Errors are never cached. The map is size-capped (1024) with expired-first eviction against pathological key sweeps.
- Swagger description updated and docs regenerated.

No client changes needed; every consumer benefits.

## Testing

- `go test ./api/` — new handler specs: repeated window served from cache (1 driver call), millisecond-unique `since` values collapse to one snapped window, distinct windows cached separately, failures not cached; unit specs for TTL expiry, snap floor/ceil/containment, and key scoping.
- Pre-existing `pkg/spanembed` failure reproduces on clean `origin/main` (environmental, unrelated).

Refs PCC-936 (the deeper fix — rollup tables — stays open; this removes the repeat-recompute cost).