### PR TITLE
🔧 fix(derive): project GPT-5.6 Codex custom tool calls

### DIFF
--- a/pkg/derive/chain.go
+++ b/pkg/derive/chain.go
@@ -11,6 +11,7 @@ package derive
 
 import (
 	"github.com/papercomputeco/tapes/pkg/llm"
+	"github.com/papercomputeco/tapes/pkg/llm/provider/openai"
 	"github.com/papercomputeco/tapes/pkg/merkle"
 )
 
@@ -81,10 +82,21 @@ func TurnChain(call CallContext, req *llm.ChatRequest, resp *llm.ChatResponse) [
 		parent = node
 	}
 
+	// OpenAI Responses items the reducer preserved verbatim
+	// (custom_tool_call, custom_tool_call_output) normalize to
+	// canonical tool blocks HERE — the shared constructor — so
+	// capture-time ingest and offline re-derive produce identical
+	// hashes, and sessions captured before those item types were
+	// cataloged heal on re-derive.
+	responseContent := resp.Message.Content
+	if call.Provider == "openai" {
+		responseContent = openai.NormalizeResponsesContent(responseContent)
+	}
+
 	responseBucket := merkle.Bucket{
 		Type:      "message",
 		Role:      resp.Message.Role,
-		Content:   resp.Message.Content,
+		Content:   responseContent,
 		Model:     resp.Model,
 		Provider:  call.Provider,
 		AgentName: call.AgentName,

--- a/pkg/derive/classify.go
+++ b/pkg/derive/classify.go
@@ -1,6 +1,7 @@
 package derive
 
 import (
+	"encoding/json"
 	"strings"
 
 	"github.com/papercomputeco/tapes/pkg/llm"
@@ -151,7 +152,42 @@ func ClassifyCall(req *llm.ChatRequest, resp *llm.ChatResponse) string {
 		return KindMain
 	}
 
+	// GPT-5.6 Codex spine: the request carries NO client-side tool
+	// definitions (the ChatGPT Codex backend injects them server-side)
+	// but still declares tool routing. A streaming Responses call with
+	// an enabled tool_choice is the conversation spine — tool-less shadow
+	// calls (title-gen, plan-name) send neither.
+	if streaming && responsesToolRoutingEnabled(req) {
+		return KindMain
+	}
+
 	return KindUnknown
+}
+
+// responsesToolRoutingEnabled reports whether a Responses API request
+// declared active tool routing via tool_choice. The parser preserves the
+// choice as raw JSON in Extra (see parseResponsesRequest).
+func responsesToolRoutingEnabled(req *llm.ChatRequest) bool {
+	if req.Extra == nil || req.Extra["endpoint"] != "responses" {
+		return false
+	}
+	raw, ok := req.Extra["tool_choice"].(string)
+	if !ok {
+		return false
+	}
+
+	var choice any
+	if err := json.Unmarshal([]byte(raw), &choice); err != nil {
+		return false
+	}
+	switch choice := choice.(type) {
+	case string:
+		return choice != "" && choice != "none"
+	case map[string]any:
+		return len(choice) > 0
+	default:
+		return false
+	}
 }
 
 // ClassifyInjected reports the injected-context kind for one request

--- a/pkg/derive/classify_test.go
+++ b/pkg/derive/classify_test.go
@@ -142,6 +142,18 @@ Be concise, structured, and focused on helping the next LLM seamlessly continue 
 		Expect(derive.ClassifyCall(req, assistantText("on it"))).To(Equal(derive.KindMain))
 	})
 
+	It("does not treat disabled Responses tool routing as the conversation spine", func() {
+		req := &llm.ChatRequest{
+			Stream: boolp(true),
+			Extra: map[string]any{
+				"endpoint":    "responses",
+				"tool_choice": `"none"`,
+			},
+			Messages: []llm.Message{textMsg("user", "some background call")},
+		}
+		Expect(derive.ClassifyCall(req, assistantText("done"))).To(Equal(derive.KindUnknown))
+	})
+
 	It("surfaces unmatched shapes as unknown rather than guessing", func() {
 		req := &llm.ChatRequest{
 			Stream:    boolp(true),
@@ -377,6 +389,98 @@ var _ = Describe("BuildDerivedSet", func() {
 		Expect(tool).NotTo(BeNil())
 		Expect(tool.SpanID).To(Equal("call_1"))
 		Expect(tool.Name).To(Equal("Bash"))
+		Expect(tool.Output).To(HaveLen(1))
+		Expect(tool.Output[0].ToolOutput).To(Equal("README.md"))
+	})
+
+	It("projects GPT-5.6 Codex custom tool calls as the conversation spine", func() {
+		// GPT-5.6 Codex sends no client-side `tools` array (the ChatGPT
+		// Codex backend injects definitions server-side) and expresses
+		// its tool spine as custom_tool_call / custom_tool_call_output
+		// items. The stored reduced response carries the custom item
+		// verbatim (the reducer preserves unknown types raw), so this
+		// exercises classification via tool_choice, request-echo
+		// mapping, AND derive-time response normalization together.
+		turn1 := storage.RawTurnRecord{
+			ID:               1,
+			Provider:         "openai",
+			HarnessID:        "codex",
+			HarnessSessionID: "sess-codex-56",
+			RequestID:        "resp_req_1",
+			ReceivedAt:       time.Unix(1783985110, 0),
+			RawRequest: json.RawMessage(`{
+				"model":"gpt-5.6-sol",
+				"instructions":"You are Codex.",
+				"stream":true,
+				"tool_choice":"auto",
+				"input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"list files"}]}]
+			}`),
+			Response: json.RawMessage(`{
+				"model":"gpt-5.6-sol",
+				"message":{"role":"assistant","content":[
+					{"type":"thinking","thinking_signature":"enc_blob"},
+					{"type":"custom_tool_call","content":{"type":"custom_tool_call","id":"ctc_1","status":"completed","call_id":"call_1","name":"exec","input":"const r = await tools.exec_command({cmd:\"ls\"})"}}
+				]},
+				"stop_reason":"tool_use",
+				"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}
+			}`),
+			Meta: json.RawMessage(`{}`),
+		}
+		turn2 := storage.RawTurnRecord{
+			ID:               2,
+			Provider:         "openai",
+			HarnessID:        "codex",
+			HarnessSessionID: "sess-codex-56",
+			RequestID:        "resp_req_2",
+			ReceivedAt:       time.Unix(1783985111, 0),
+			RawRequest: json.RawMessage(`{
+				"model":"gpt-5.6-sol",
+				"instructions":"You are Codex.",
+				"stream":true,
+				"tool_choice":"auto",
+				"input":[
+					{"type":"message","role":"user","content":[{"type":"input_text","text":"list files"}]},
+					{"type":"custom_tool_call","id":"ctc_1","status":"completed","call_id":"call_1","name":"exec","input":"const r = await tools.exec_command({cmd:\"ls\"})"},
+					{"type":"custom_tool_call_output","call_id":"call_1","output":[{"type":"input_text","text":"README.md"}]}
+				]
+			}`),
+			Response: json.RawMessage(`{
+				"model":"gpt-5.6-sol",
+				"message":{"role":"assistant","content":[{"type":"text","text":"README.md"}]},
+				"stop_reason":"stop",
+				"usage":{"prompt_tokens":20,"completion_tokens":2,"total_tokens":22}
+			}`),
+			Meta: json.RawMessage(`{}`),
+		}
+
+		set, err := derive.BuildDerivedSet([]storage.RawTurnRecord{turn1, turn2}, "p")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(set.Report.CallKinds).To(HaveKeyWithValue(derive.KindMain, 2))
+		Expect(set.Report.CallKinds).NotTo(HaveKey(derive.KindUnknown))
+
+		spans := derive.EmitSpans(set)
+		Expect(spans.Report.Traces).To(Equal(1))
+		Expect(spans.Report.SpanKinds).To(HaveKeyWithValue(derive.SpanKindLLM, 2))
+		Expect(spans.Report.SpanKinds).To(HaveKeyWithValue(derive.SpanKindTool, 1))
+		Expect(spans.Report.LinkKinds).To(HaveKeyWithValue(derive.LinkFeeds, 1))
+
+		trace := spans.Turns[0]
+		Expect(trace.UserPrompt).To(Equal("list files"))
+		Expect(trace.ResponsePreview).To(Equal("README.md"))
+
+		var tool *derive.Span
+		for _, span := range trace.Spans {
+			if span.Kind == derive.SpanKindTool {
+				tool = span
+				break
+			}
+		}
+		Expect(tool).NotTo(BeNil())
+		Expect(tool.SpanID).To(Equal("call_1"))
+		Expect(tool.Name).To(Equal("exec"))
+		Expect(tool.Input).To(HaveLen(1))
+		Expect(tool.Input[0].Type).To(Equal("tool_use"))
+		Expect(tool.Input[0].ToolInput).To(HaveKeyWithValue("input", `const r = await tools.exec_command({cmd:"ls"})`))
 		Expect(tool.Output).To(HaveLen(1))
 		Expect(tool.Output[0].ToolOutput).To(Equal("README.md"))
 	})

--- a/pkg/llm/provider/openai/responses.go
+++ b/pkg/llm/provider/openai/responses.go
@@ -26,9 +26,18 @@ type responsesRequest struct {
 	TopP            *float64          `json:"top_p,omitempty"`
 	Stream          *bool             `json:"stream,omitempty"`
 	Tools           []json.RawMessage `json:"tools,omitempty"`
+	ToolChoice      json.RawMessage   `json:"tool_choice,omitempty"`
 	Reasoning       map[string]any    `json:"reasoning,omitempty"`
 	PreviousID      string            `json:"previous_response_id,omitempty"`
 }
+
+// Responses item types for the custom-tool spine (GPT-5.6 Codex's
+// freeform exec runtime). Shared by the request parser and the
+// derive-time content normalizer.
+const (
+	itemCustomToolCall       = "custom_tool_call"
+	itemCustomToolCallOutput = "custom_tool_call_output"
+)
 
 // responsesItem is the union of the Responses input/output item shapes tapes
 // understands. Codex omits `"type":"message"` on plain role/content items,
@@ -38,10 +47,12 @@ type responsesItem struct {
 	Role    string          `json:"role"`
 	Content json.RawMessage `json:"content"`
 
-	// function_call / function_call_output
+	// function_call / function_call_output; custom_tool_call shares
+	// call_id/name and carries its freeform input on `input`.
 	CallID    string          `json:"call_id"`
 	Name      string          `json:"name"`
 	Arguments string          `json:"arguments"`
+	Input     string          `json:"input"`
 	Output    json.RawMessage `json:"output"`
 
 	// reasoning
@@ -129,6 +140,13 @@ func parseResponsesRequest(payload []byte) (*llm.ChatRequest, error) {
 	if req.PreviousID != "" {
 		extra["previous_response_id"] = req.PreviousID
 	}
+	// GPT-5.6 Codex omits client-side tool definitions (the backend
+	// injects them server-side) but still declares tool routing via
+	// tool_choice — preserve it so classification can recognize the
+	// conversation spine without a `tools` array.
+	if jsonFieldPresent(req.ToolChoice) {
+		extra["tool_choice"] = string(req.ToolChoice)
+	}
 	result.Extra = extra
 
 	return result, nil
@@ -164,6 +182,18 @@ func responsesItemToMessage(raw json.RawMessage) (llm.Message, bool) {
 				ToolResultID: item.CallID,
 				ToolOutput:   rawToText(item.Output),
 			}},
+		}, true
+
+	case item.Type == itemCustomToolCall:
+		return llm.Message{
+			Role:    "assistant",
+			Content: []llm.ContentBlock{customToolCallBlock(item)},
+		}, true
+
+	case item.Type == itemCustomToolCallOutput:
+		return llm.Message{
+			Role:    "tool",
+			Content: []llm.ContentBlock{customToolCallOutputBlock(item)},
 		}, true
 
 	case item.Type == "reasoning":
@@ -231,6 +261,92 @@ func functionCallBlock(item responsesItem, raw json.RawMessage) llm.ContentBlock
 		}
 	}
 	return cb
+}
+
+// customToolCallBlock maps a custom_tool_call item to a tool_use block.
+// Custom tools (GPT-5.6 Codex's exec runtime) carry a freeform string
+// instead of JSON arguments; it lands under the "input" key so the block
+// stays a structured tool call rather than an opaque blob. Only the
+// call identity fields participate, so a response item (which also
+// carries id/status) and its request-echo map to identical blocks.
+func customToolCallBlock(item responsesItem) llm.ContentBlock {
+	cb := llm.ContentBlock{
+		Type:      "tool_use",
+		ToolUseID: item.CallID,
+		ToolName:  item.Name,
+	}
+	if item.Input != "" {
+		cb.ToolInput = map[string]any{"input": item.Input}
+	}
+	return cb
+}
+
+// customToolCallOutputBlock maps a custom_tool_call_output item to a
+// tool_result block. The wire output is either a bare string or an
+// array of content parts ({type:"input_text",text:...}); parts are
+// joined so the result reads as the text the model saw.
+func customToolCallOutputBlock(item responsesItem) llm.ContentBlock {
+	return llm.ContentBlock{
+		Type:         "tool_result",
+		ToolResultID: item.CallID,
+		ToolOutput:   customToolOutputText(item.Output),
+	}
+}
+
+// customToolOutputText renders a custom_tool_call_output payload as
+// text: bare strings unquote, content-part arrays join their text, and
+// anything else stays compact JSON so nothing is lost.
+func customToolOutputText(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s
+	}
+	var parts []responsesContentPart
+	if err := json.Unmarshal(raw, &parts); err == nil {
+		var b strings.Builder
+		for _, part := range parts {
+			b.WriteString(part.Text)
+		}
+		return b.String()
+	}
+	return string(raw)
+}
+
+// NormalizeResponsesContent rewrites Responses output items that the
+// capture reducer preserved verbatim — custom_tool_call and
+// custom_tool_call_output — into the canonical tool blocks the derived
+// layer understands. The reducer keeps unknown item types raw by
+// design, so this runs at derive time (chain construction), which also
+// heals sessions whose responses were reduced before these item types
+// were cataloged: a re-derive reprojects them from the preserved raw
+// item. Blocks of any other type pass through untouched.
+func NormalizeResponsesContent(blocks []llm.ContentBlock) []llm.ContentBlock {
+	normalized := blocks
+	copied := false
+	for i, b := range blocks {
+		if (b.Type != itemCustomToolCall && b.Type != itemCustomToolCallOutput) || len(b.Content) == 0 {
+			continue
+		}
+		var item responsesItem
+		if err := json.Unmarshal(b.Content, &item); err != nil || item.CallID == "" {
+			continue
+		}
+		if !copied {
+			normalized = make([]llm.ContentBlock, len(blocks))
+			copy(normalized, blocks)
+			copied = true
+		}
+		switch b.Type {
+		case itemCustomToolCall:
+			normalized[i] = customToolCallBlock(item)
+		case itemCustomToolCallOutput:
+			normalized[i] = customToolCallOutputBlock(item)
+		}
+	}
+	return normalized
 }
 
 // reasoningBlock maps a reasoning item to a thinking block. The summary text

--- a/pkg/llm/provider/openai/responses_test.go
+++ b/pkg/llm/provider/openai/responses_test.go
@@ -1,9 +1,12 @@
 package openai_test
 
 import (
+	"encoding/json"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/papercomputeco/tapes/pkg/llm"
 	"github.com/papercomputeco/tapes/pkg/llm/provider/openai"
 )
 
@@ -91,6 +94,51 @@ var _ = Describe("Responses API request parsing", func() {
 		Expect(req.Messages[0].Content[0].Content).NotTo(BeEmpty())
 	})
 
+	It("maps custom tool calls to canonical tool blocks", func() {
+		// GPT-5.6 Codex wire shape: no `tools` array (the ChatGPT
+		// Codex backend injects definitions server-side), tool_choice
+		// declared, and the tool spine expressed as custom_tool_call /
+		// custom_tool_call_output items with freeform string input.
+		req, err := provider.ParseRequest([]byte(`{
+			"model": "gpt-5.6-sol",
+			"instructions": "You are Codex.",
+			"stream": true,
+			"tool_choice": "auto",
+			"input": [
+				{"type": "message", "role": "user", "content": [{"type": "input_text", "text": "list files"}]},
+				{"type": "custom_tool_call", "id": "ctc_1", "status": "completed", "call_id": "call_1", "name": "exec", "input": "const r = await tools.exec_command({cmd:\"ls\"})"},
+				{"type": "custom_tool_call_output", "call_id": "call_1", "output": [{"type": "input_text", "text": "Script completed\n"}, {"type": "input_text", "text": "README.md"}]}
+			]
+		}`))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(req.Tools).To(BeEmpty())
+		Expect(req.Extra).To(HaveKeyWithValue("tool_choice", `"auto"`))
+
+		Expect(req.Messages).To(HaveLen(3))
+
+		call := req.Messages[1]
+		Expect(call.Role).To(Equal("assistant"))
+		Expect(call.Content[0].Type).To(Equal("tool_use"))
+		Expect(call.Content[0].ToolUseID).To(Equal("call_1"))
+		Expect(call.Content[0].ToolName).To(Equal("exec"))
+		Expect(call.Content[0].ToolInput).To(HaveKeyWithValue("input", `const r = await tools.exec_command({cmd:"ls"})`))
+
+		result := req.Messages[2]
+		Expect(result.Role).To(Equal("tool"))
+		Expect(result.Content[0].Type).To(Equal("tool_result"))
+		Expect(result.Content[0].ToolResultID).To(Equal("call_1"))
+		Expect(result.Content[0].ToolOutput).To(Equal("Script completed\nREADME.md"))
+	})
+
+	It("renders a bare-string custom tool output verbatim", func() {
+		req, err := provider.ParseRequest([]byte(`{
+			"model": "gpt-5.6-sol",
+			"input": [{"type": "custom_tool_call_output", "call_id": "call_2", "output": "plain text"}]
+		}`))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(req.Messages[0].Content[0].ToolOutput).To(Equal("plain text"))
+	})
+
 	It("treats an explicit null input as Chat Completions, not Responses", func() {
 		// json.RawMessage keeps the literal `null` bytes; without the
 		// null check this would fabricate an empty user message.
@@ -108,5 +156,38 @@ var _ = Describe("Responses API request parsing", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(req.Messages).To(HaveLen(1))
 		Expect(req.Extra).NotTo(HaveKey("endpoint"))
+	})
+})
+
+var _ = Describe("NormalizeResponsesContent", func() {
+	It("rewrites verbatim custom tool items into canonical tool blocks", func() {
+		blocks := []llm.ContentBlock{
+			{Type: "thinking", ThinkingSignature: "blob"},
+			{Type: "custom_tool_call", Content: json.RawMessage(`{"type":"custom_tool_call","id":"ctc_1","status":"completed","call_id":"call_1","name":"exec","input":"echo hi"}`)},
+			{Type: "text", Text: "done"},
+		}
+
+		normalized := openai.NormalizeResponsesContent(blocks)
+
+		Expect(normalized).To(HaveLen(3))
+		Expect(normalized[0]).To(Equal(blocks[0]))
+		Expect(normalized[2]).To(Equal(blocks[2]))
+		Expect(normalized[1].Type).To(Equal("tool_use"))
+		Expect(normalized[1].ToolUseID).To(Equal("call_1"))
+		Expect(normalized[1].ToolName).To(Equal("exec"))
+		Expect(normalized[1].ToolInput).To(HaveKeyWithValue("input", "echo hi"))
+
+		// The input slice is never mutated — chains hash from it.
+		Expect(blocks[1].Type).To(Equal("custom_tool_call"))
+	})
+
+	It("passes through content without custom tool items untouched", func() {
+		blocks := []llm.ContentBlock{{Type: "text", Text: "hi"}}
+		Expect(openai.NormalizeResponsesContent(blocks)).To(Equal(blocks))
+	})
+
+	It("leaves undecodable custom tool items verbatim", func() {
+		blocks := []llm.ContentBlock{{Type: "custom_tool_call", Content: json.RawMessage(`"not an object"`)}}
+		Expect(openai.NormalizeResponsesContent(blocks)).To(Equal(blocks))
 	})
 })


### PR DESCRIPTION
## Summary

- recognize streaming GPT-5.6 Codex Responses calls as the main conversation spine when tools are injected server-side and `tool_choice` is present
- map `custom_tool_call` and `custom_tool_call_output` items to canonical tool-use and tool-result blocks
- normalize preserved Responses items during chain construction so capture and re-derive produce the same projection

## Context

This reincorporates the focused GPT-5.6 derivation core from #254 on top of the raw-turns-only derivation refactor in #256. It intentionally leaves the PoC's broader transcript-adapter and subagent work out of scope.

## Validation

- `nix develop --impure --command make check`
- `nix develop --impure --command make e2e-test`
- grove clearing with `tapes:dev` built from this commit: a real `gpt-5.6-sol` Codex session with an `exec` call derived as two main LLM spans plus one tool span, with prompt/response previews, nonzero main usage, and a `feeds` link
- session-scoped re-derive reproduced the complete session/trace/span/link projection with the same canonical SHA-256 digest

Fixes PCC-881
