### PR TITLE
✨ feat(sessions): resolve a session display title server-side, backed by an editable name

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -83,7 +83,8 @@ components:
             DisplayName -> rollup.title (generated) -> preview -> Name -> id
             slice. Resolving once on the server keeps every client (Console,
             paper CLI) from re-deriving — and diverging on — the precedence
-            (PCC-970). Never empty: it falls back to a short id slice.
+            (PCC-970). Never empty: it falls back to a short harness id slice, then
+            the session id (the primary key, always set for a stored row).
           type: string
         ended_at:
           type: string

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -69,6 +69,22 @@ components:
           type: string
         cwd:
           type: string
+        display_name:
+          description: |-
+            DisplayName is the user's Console rename (sessions.display_name),
+            empty unless a user set one. Written only by PATCH /v1/sessions/:id,
+            never by ingest, so it survives a live session. It is the top of the
+            DisplayTitle resolution; exposed raw so the edit affordance can seed
+            its input from the user's own title (not the resolved fallback).
+          type: string
+        display_title:
+          description: |-
+            DisplayTitle is the server-resolved label clients should render:
+            DisplayName -> rollup.title (generated) -> preview -> Name -> id
+            slice. Resolving once on the server keeps every client (Console,
+            paper CLI) from re-deriving — and diverging on — the precedence
+            (PCC-970). Never empty: it falls back to a short id slice.
+          type: string
         ended_at:
           type: string
         harness_id:
@@ -95,11 +111,11 @@ components:
           type: boolean
         name:
           description: |-
-            Name is the session's display label: the value on the identity row —
-            a user rename or the harness-supplied session name — when set,
-            otherwise the folded title (rollup.title) as a fallback. Empty only
-            when the session has neither. It therefore equals rollup.title
-            exactly when no identity-row name exists.
+            Name is the harness identity-row label — the harness-supplied session
+            name (a plan slug), or the folded title (rollup.title) as a fallback
+            when no name was captured. This is capture/deriver provenance, NOT a
+            user title: ingest re-sends it every turn. Clients should render
+            DisplayTitle, not Name (PCC-970).
           type: string
         parent_session_id:
           type: string
@@ -453,7 +469,7 @@ components:
       type: object
     sessionUpdateRequest:
       properties:
-        name:
+        display_name:
           type: string
       type: object
     swaggerMCPError:
@@ -866,7 +882,7 @@ paths:
       tags:
       - sessions
     patch:
-      description: Updates the user-editable session name. An absent field is a 400;
+      description: Updates the user-editable display_name. An absent field is a 400;
         null or empty (after trim) clears back to the auto-derived title. Length is
         bounded to 200 characters.
       operationId: patchV1SessionsId
@@ -897,8 +913,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-          description: Missing/malformed id, missing name field, or name exceeds 200
-            characters
+          description: Missing/malformed id, missing display_name field, or display_name
+            exceeds 200 characters
         "404":
           content:
             application/json:

--- a/api/sessions_display_title_test.go
+++ b/api/sessions_display_title_test.go
@@ -1,0 +1,54 @@
+package api
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/papercomputeco/tapes/pkg/storage"
+)
+
+// resolveSessionDisplayTitle owns the one-place precedence every client
+// renders (PCC-970): DisplayName -> DerivedTitle -> Preview -> Name -> a short
+// harness id slice -> the session id. It must never return empty.
+var _ = Describe("resolveSessionDisplayTitle", func() {
+	base := storage.SessionRecord{
+		ID:               "019f8be5-721b-72c5-a097-3bc50287f89f",
+		HarnessSessionID: "clearing-example-abcdef123",
+	}
+
+	It("prefers the user's display_name over every derived/captured field", func() {
+		s := base
+		s.DisplayName = "My title"
+		s.DerivedTitle = "derived"
+		s.Preview = "hello"
+		s.Name = "slug"
+		Expect(resolveSessionDisplayTitle(s)).To(Equal("My title"))
+	})
+
+	It("falls back display_name -> derived_title -> preview -> name", func() {
+		s := base
+		s.DerivedTitle = "derived"
+		s.Preview = "hello"
+		s.Name = "slug"
+		Expect(resolveSessionDisplayTitle(s)).To(Equal("derived"))
+		s.DerivedTitle = ""
+		Expect(resolveSessionDisplayTitle(s)).To(Equal("hello"))
+		s.Preview = ""
+		Expect(resolveSessionDisplayTitle(s)).To(Equal("slug"))
+	})
+
+	It("skips a JSON tool-result blob preview and uses the harness id slice", func() {
+		s := base
+		s.Preview = `{"channel_link":"https://example.com"}`
+		Expect(resolveSessionDisplayTitle(s)).To(Equal("clearing-exa"))
+	})
+
+	It("falls back to the harness id slice when nothing human is set", func() {
+		Expect(resolveSessionDisplayTitle(base)).To(Equal("clearing-exa"))
+	})
+
+	It("never returns empty: uses the session id when harness_session_id is empty (contract)", func() {
+		s := storage.SessionRecord{ID: "019f8be5-721b-72c5-a097-3bc50287f89f"}
+		Expect(resolveSessionDisplayTitle(s)).To(Equal("019f8be5-721b-72c5-a097-3bc50287f89f"))
+	})
+})

--- a/api/sessions_export_handlers_test.go
+++ b/api/sessions_export_handlers_test.go
@@ -56,9 +56,9 @@ func (d *exportStubDriver) GetSessionRecordByHarness(_ context.Context, _, _, _ 
 	return nil, nil
 }
 
-// UpdateSessionName satisfies the widened sessionsReader interface; the
-// export handlers never call it.
-func (d *exportStubDriver) UpdateSessionName(_ context.Context, _, _ string, _ *string) (int64, error) {
+// UpdateSessionDisplayName satisfies the widened sessionsReader interface;
+// the export handlers never call it.
+func (d *exportStubDriver) UpdateSessionDisplayName(_ context.Context, _, _ string, _ *string) (int64, error) {
 	return 0, nil
 }
 

--- a/api/sessions_handlers.go
+++ b/api/sessions_handlers.go
@@ -91,7 +91,8 @@ type SessionItem struct {
 	// DisplayName -> rollup.title (generated) -> preview -> Name -> id
 	// slice. Resolving once on the server keeps every client (Console,
 	// paper CLI) from re-deriving — and diverging on — the precedence
-	// (PCC-970). Never empty: it falls back to a short id slice.
+	// (PCC-970). Never empty: it falls back to a short harness id slice, then
+	// the session id (the primary key, always set for a stored row).
 	DisplayTitle string `json:"display_title"`
 	// Live is a runtime presence signal, not a projection fact: true when
 	// the session was seen within the liveness window AND the deriver has
@@ -184,7 +185,7 @@ type SessionDetailResponse struct {
 //	-> DerivedTitle (generated title-gen output)
 //	-> Preview (first user prompt)    — skipped if it's a JSON tool-result blob
 //	-> Name (harness slug / coalesced) — last human-ish label
-//	-> a short harness_session_id slice — never empty
+//	-> a short harness_session_id slice, then the session id — never empty
 //
 // Preview is already scaffolding-stripped by the deriver; the JSON guard
 // mirrors the Console's prior client-side rule for attribution-gap sessions
@@ -202,7 +203,14 @@ func resolveSessionDisplayTitle(s storage.SessionRecord) string {
 	if t := strings.TrimSpace(s.Name); t != "" {
 		return t
 	}
-	return shortHarnessSessionID(s.HarnessSessionID)
+	// Ultimate fallback: the harness id slice, or — if a row somehow carries
+	// no harness_session_id — the session's own primary key, which is always
+	// set for a stored row. Guarantees the never-empty contract (DisplayTitle
+	// has no omitempty) even for a degenerate record.
+	if slug := shortHarnessSessionID(s.HarnessSessionID); slug != "" {
+		return slug
+	}
+	return s.ID
 }
 
 // looksLikeJSONPreview is a cheap guard for previews that are really

--- a/api/sessions_handlers.go
+++ b/api/sessions_handlers.go
@@ -28,12 +28,14 @@ type sessionsReader interface {
 	ListSessionRecords(ctx context.Context, orgID string, opts storage.SessionListOpts) ([]storage.SessionRecord, error)
 	GetSessionRecord(ctx context.Context, orgID, id string) (*storage.SessionRecord, error)
 	GetSessionRecordByHarness(ctx context.Context, orgID string, harnessID string, harnessSessionID string) (*storage.SessionRecord, error)
-	// UpdateSessionName sets (or, when name is nil or trims empty, clears)
-	// the user-editable session title. The org_id predicate lives in the
+	// UpdateSessionDisplayName sets (or, when name is nil or trims empty,
+	// clears) the user-editable session title. It writes the dedicated
+	// display_name column, not name, so a rename survives ingest re-sending
+	// the harness slug (PCC-970). The org_id predicate lives in the
 	// implementation's storage query (CC-2): a cross-org id must affect
 	// zero rows. Returns the number of rows affected so the handler can
 	// distinguish "updated" from "not in this org / unknown id" (404).
-	UpdateSessionName(ctx context.Context, orgID, id string, name *string) (int64, error)
+	UpdateSessionDisplayName(ctx context.Context, orgID, id string, name *string) (int64, error)
 }
 
 // sessionsWriter is the capability interface for mutating sessions (DELETE
@@ -73,12 +75,24 @@ type SessionItem struct {
 	// captured at ingest; empty for rows captured before the edge began
 	// stamping it.
 	AuthSubject string `json:"auth_subject,omitempty"`
-	// Name is the session's display label: the value on the identity row —
-	// a user rename or the harness-supplied session name — when set,
-	// otherwise the folded title (rollup.title) as a fallback. Empty only
-	// when the session has neither. It therefore equals rollup.title
-	// exactly when no identity-row name exists.
+	// Name is the harness identity-row label — the harness-supplied session
+	// name (a plan slug), or the folded title (rollup.title) as a fallback
+	// when no name was captured. This is capture/deriver provenance, NOT a
+	// user title: ingest re-sends it every turn. Clients should render
+	// DisplayTitle, not Name (PCC-970).
 	Name string `json:"name,omitempty"`
+	// DisplayName is the user's Console rename (sessions.display_name),
+	// empty unless a user set one. Written only by PATCH /v1/sessions/:id,
+	// never by ingest, so it survives a live session. It is the top of the
+	// DisplayTitle resolution; exposed raw so the edit affordance can seed
+	// its input from the user's own title (not the resolved fallback).
+	DisplayName string `json:"display_name,omitempty"`
+	// DisplayTitle is the server-resolved label clients should render:
+	// DisplayName -> rollup.title (generated) -> preview -> Name -> id
+	// slice. Resolving once on the server keeps every client (Console,
+	// paper CLI) from re-deriving — and diverging on — the precedence
+	// (PCC-970). Never empty: it falls back to a short id slice.
+	DisplayTitle string `json:"display_title"`
 	// Live is a runtime presence signal, not a projection fact: true when
 	// the session was seen within the liveness window AND the deriver has
 	// not marked it terminal. Computed at response time from last_seen_at,
@@ -162,6 +176,52 @@ type SessionDetailResponse struct {
 	Session SessionItem `json:"session"`
 }
 
+// resolveSessionDisplayTitle picks the label clients render, resolving the
+// provenance tiers in ONE place so every client (Console, paper CLI) agrees
+// instead of re-deriving — and diverging on — the precedence (PCC-970):
+//
+//	DisplayName (user Console rename) — explicit, always wins
+//	-> DerivedTitle (generated title-gen output)
+//	-> Preview (first user prompt)    — skipped if it's a JSON tool-result blob
+//	-> Name (harness slug / coalesced) — last human-ish label
+//	-> a short harness_session_id slice — never empty
+//
+// Preview is already scaffolding-stripped by the deriver; the JSON guard
+// mirrors the Console's prior client-side rule for attribution-gap sessions
+// whose first captured node is a tool_result rather than prose.
+func resolveSessionDisplayTitle(s storage.SessionRecord) string {
+	if t := strings.TrimSpace(s.DisplayName); t != "" {
+		return t
+	}
+	if t := strings.TrimSpace(s.DerivedTitle); t != "" {
+		return t
+	}
+	if t := strings.TrimSpace(s.Preview); t != "" && !looksLikeJSONPreview(t) {
+		return t
+	}
+	if t := strings.TrimSpace(s.Name); t != "" {
+		return t
+	}
+	return shortHarnessSessionID(s.HarnessSessionID)
+}
+
+// looksLikeJSONPreview is a cheap guard for previews that are really
+// tool-result payloads rather than user prose (a leading { or [).
+func looksLikeJSONPreview(s string) bool {
+	t := strings.TrimLeft(s, " \t\r\n")
+	return strings.HasPrefix(t, "{") || strings.HasPrefix(t, "[")
+}
+
+// shortHarnessSessionID is the last-resort label: a 12-char slice of the
+// harness session id, matching the Console's historical id fallback.
+func shortHarnessSessionID(id string) string {
+	const n = 12
+	if len(id) <= n {
+		return id
+	}
+	return id[:n]
+}
+
 func sessionItemFromStorage(s storage.SessionRecord, now time.Time) SessionItem {
 	item := SessionItem{
 		ID:               s.ID,
@@ -176,6 +236,8 @@ func sessionItemFromStorage(s storage.SessionRecord, now time.Time) SessionItem 
 		HarnessMetadata:  s.HarnessMetadata,
 		AuthSubject:      s.AuthSubject,
 		Name:             s.Name,
+		DisplayName:      s.DisplayName,
+		DisplayTitle:     resolveSessionDisplayTitle(s),
 		Live:             now.Sub(s.LastSeenAt) < sessionLiveWindow && !terminalStatus(s.DerivedStatus),
 		Rollup: SessionRollup{
 			Status:     s.DerivedStatus,
@@ -959,12 +1021,14 @@ func (s *Server) handleDeleteSession(c *fiber.Ctx) error {
 	return c.SendStatus(fiber.StatusNoContent)
 }
 
-// sessionUpdateRequest is the PATCH /v1/sessions/:id body. Name is a pointer
-// so an absent field (nil) is distinguishable from an explicit null or an
-// empty string, both of which mean "clear back to the auto-derived title"
-// (CC-3); an absent field is a 400 (nothing to update).
+// sessionUpdateRequest is the PATCH /v1/sessions/:id body. DisplayName is a
+// pointer so an absent field (nil) is distinguishable from an explicit null
+// or an empty string, both of which mean "clear back to the auto-derived
+// title" (CC-3); an absent field is a 400 (nothing to update). The field is
+// display_name (not name) so the request matches the display_name it sets on
+// the response — and never the harness identity `name` (PCC-970).
 type sessionUpdateRequest struct {
-	Name *string `json:"name"`
+	DisplayName *string `json:"display_name"`
 }
 
 // Referenced only by the swagger @Param annotation on handleUpdateSession (the
@@ -975,21 +1039,21 @@ var _ = sessionUpdateRequest{}
 
 // handleUpdateSession handles PATCH /v1/sessions/:id.
 //
-// It updates the user-editable session title only (CC-1, CC-4): the server
-// trims and bounds the name (CC-3), calls UpdateSessionName with the
+// It updates the user-editable display title only (CC-1, CC-4): the server
+// trims and bounds the value (CC-3), calls UpdateSessionDisplayName with the
 // org-scoped predicate carried in storage (CC-2), and on success re-reads
 // GetSessionRecord to return the updated session summary so the client can
 // write its cache through (CC-6/CC-7 on the frontend side).
 //
 //	@Summary		Update a session's title
-//	@Description	Updates the user-editable session name. An absent field is a 400; null or empty (after trim) clears back to the auto-derived title. Length is bounded to 200 characters.
+//	@Description	Updates the user-editable display_name. An absent field is a 400; null or empty (after trim) clears back to the auto-derived title. Length is bounded to 200 characters.
 //	@Tags			sessions
 //	@Accept			json
 //	@Produce		json
 //	@Param			id		path		string					true	"Session id (UUID)"
 //	@Param			request	body		sessionUpdateRequest	true	"Update request"
 //	@Success		200		{object}	SessionDetailResponse
-//	@Failure		400		{object}	llm.ErrorResponse	"Missing/malformed id, missing name field, or name exceeds 200 characters"
+//	@Failure		400		{object}	llm.ErrorResponse	"Missing/malformed id, missing display_name field, or display_name exceeds 200 characters"
 //	@Failure		404		{object}	llm.ErrorResponse	"Session not found or not in caller's org"
 //	@Failure		500		{object}	llm.ErrorResponse	"Failed to update session"
 //	@Failure		501		{object}	llm.ErrorResponse	"Sessions not supported by this backend"
@@ -1008,22 +1072,22 @@ func (s *Server) handleUpdateSession(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusBadRequest).JSON(llm.ErrorResponse{Error: "id must be a valid UUID"})
 	}
 
-	// Decode into raw messages first so an absent "name" key (nothing to
-	// update, 400) is distinguishable from an explicit null or empty string
+	// Decode into raw messages first so an absent "display_name" key (nothing
+	// to update, 400) is distinguishable from an explicit null or empty string
 	// (both valid "clear the title" requests). A *string alone can't make
 	// that distinction — both cases unmarshal to nil.
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(c.Body(), &raw); err != nil {
 		return c.Status(fiber.StatusBadRequest).JSON(llm.ErrorResponse{Error: "invalid request body"})
 	}
-	nameRaw, present := raw["name"]
+	nameRaw, present := raw["display_name"]
 	if !present {
-		return c.Status(fiber.StatusBadRequest).JSON(llm.ErrorResponse{Error: "name is required"})
+		return c.Status(fiber.StatusBadRequest).JSON(llm.ErrorResponse{Error: "display_name is required"})
 	}
 
 	var name *string
 	if err := json.Unmarshal(nameRaw, &name); err != nil {
-		return c.Status(fiber.StatusBadRequest).JSON(llm.ErrorResponse{Error: "name must be a string or null"})
+		return c.Status(fiber.StatusBadRequest).JSON(llm.ErrorResponse{Error: "display_name must be a string or null"})
 	}
 
 	// Normalize server-side (CC-3): trim; empty-after-trim (including an
@@ -1034,16 +1098,16 @@ func (s *Server) handleUpdateSession(c *fiber.Ctx) error {
 		trimmed := strings.TrimSpace(*name)
 		if trimmed != "" {
 			if utf8.RuneCountInString(trimmed) > maxSessionNameLength {
-				return c.Status(fiber.StatusBadRequest).JSON(llm.ErrorResponse{Error: "name must be at most 200 characters"})
+				return c.Status(fiber.StatusBadRequest).JSON(llm.ErrorResponse{Error: "display_name must be at most 200 characters"})
 			}
 			normalized = &trimmed
 		}
 	}
 
 	orgID := orgIDFromCtx(c)
-	rowsAffected, err := reader.UpdateSessionName(c.Context(), orgID, id, normalized)
+	rowsAffected, err := reader.UpdateSessionDisplayName(c.Context(), orgID, id, normalized)
 	if err != nil {
-		s.logger.Error("update session name", "id", id, "error", err)
+		s.logger.Error("update session display name", "id", id, "error", err)
 		return c.Status(fiber.StatusInternalServerError).JSON(llm.ErrorResponse{Error: "failed to update session"})
 	}
 	if rowsAffected == 0 {

--- a/api/sessions_handlers_test.go
+++ b/api/sessions_handlers_test.go
@@ -124,7 +124,7 @@ func (d *sessionsStubDriver) GetSessionRecordByHarness(_ context.Context, orgID,
 // rowsAffected/err, mirroring the real driver's contract: the handler must
 // treat rowsAffected==0 as "not in this org / unknown id" (CC-2) rather than
 // inspecting the name it sent.
-func (d *sessionsStubDriver) UpdateSessionName(_ context.Context, orgID, id string, name *string) (int64, error) {
+func (d *sessionsStubDriver) UpdateSessionDisplayName(_ context.Context, orgID, id string, name *string) (int64, error) {
 	d.updateCalls++
 	d.lastUpdateOrgID = orgID
 	d.lastUpdateID = id

--- a/api/sessions_update_handler_test.go
+++ b/api/sessions_update_handler_test.go
@@ -3,7 +3,7 @@ package api
 // Specs for PATCH /v1/sessions/:id (handleUpdateSession) land here in the
 // tester phase, driven against sessionsStubDriver (see
 // sessions_handlers_test.go) — no Postgres required. Covers: whitespace
-// trimming, the rune-counted length>200->400 bound, missing name field->400,
+// trimming, the rune-counted length>200->400 bound, missing display_name field->400,
 // 200 + updated summary via GetSessionRecord, and cross-org/unknown id->404
 // via rowsAffected==0 (CC-2, CC-3, CC-4). The empty/null clear-to-NULL and the
 // 501-when-unsupported paths are exercised at the storage layer, not here.
@@ -99,7 +99,7 @@ var _ = Describe("PATCH /v1/sessions/:id (handleUpdateSession)", func() {
 		server := newSessionsServer(drv)
 
 		// When the client PATCHes a valid name
-		_, _, status := patchSession(server, "/v1/sessions/"+sessionID, org, `{"name":"My corrected title"}`)
+		_, _, status := patchSession(server, "/v1/sessions/"+sessionID, org, `{"display_name":"My corrected title"}`)
 
 		// Then the request succeeds and the driver saw the trimmed name
 		// plus the org id threaded from context
@@ -122,7 +122,7 @@ var _ = Describe("PATCH /v1/sessions/:id (handleUpdateSession)", func() {
 
 		// When the client PATCHes a name padded with leading/trailing
 		// whitespace
-		_, _, status := patchSession(server, "/v1/sessions/"+sessionID, org, `{"name":"   spaced title   "}`)
+		_, _, status := patchSession(server, "/v1/sessions/"+sessionID, org, `{"display_name":"   spaced title   "}`)
 
 		// Then the server trims before calling the driver (CC-3)
 		Expect(status).To(Equal(fiber.StatusOK))
@@ -143,7 +143,7 @@ var _ = Describe("PATCH /v1/sessions/:id (handleUpdateSession)", func() {
 		// When the client PATCHes a name over 200 characters after
 		// trimming
 		overLong := "  " + strings.Repeat("a", 201) + "  "
-		_, errBody, status := patchSession(server, "/v1/sessions/"+sessionID, org, `{"name":"`+overLong+`"}`)
+		_, errBody, status := patchSession(server, "/v1/sessions/"+sessionID, org, `{"display_name":"`+overLong+`"}`)
 
 		// Then the server rejects it before ever calling the driver
 		// (CC-3, EST-9/10)
@@ -164,7 +164,7 @@ var _ = Describe("PATCH /v1/sessions/:id (handleUpdateSession)", func() {
 		// When the client PATCHes a title of exactly maxSessionNameLength
 		// multi-byte runes (200 emoji = 800 UTF-8 bytes)
 		title := strings.Repeat("🚀", maxSessionNameLength)
-		_, _, status := patchSession(server, "/v1/sessions/"+sessionID, org, `{"name":"`+title+`"}`)
+		_, _, status := patchSession(server, "/v1/sessions/"+sessionID, org, `{"display_name":"`+title+`"}`)
 
 		// Then the length bound counts runes, not bytes (CC-3): a title at
 		// the character ceiling is accepted even though its byte length is
@@ -199,7 +199,7 @@ var _ = Describe("PATCH /v1/sessions/:id (handleUpdateSession)", func() {
 		// Given a driver that reports success and, on the post-write
 		// re-read, returns the record reflecting the new name
 		updated := record
-		updated.Name = "My corrected title"
+		updated.DisplayName = "My corrected title"
 		drv := &sessionsStubDriver{
 			Driver:             inmemory.NewDriver(),
 			updateRowsAffected: 1,
@@ -208,7 +208,7 @@ var _ = Describe("PATCH /v1/sessions/:id (handleUpdateSession)", func() {
 		server := newSessionsServer(drv)
 
 		// When the client PATCHes the name
-		body, _, status := patchSession(server, "/v1/sessions/"+sessionID, org, `{"name":"My corrected title"}`)
+		body, _, status := patchSession(server, "/v1/sessions/"+sessionID, org, `{"display_name":"My corrected title"}`)
 
 		// Then the handler re-reads via GetSessionRecord and returns the
 		// updated session summary shape (EST-2)
@@ -217,7 +217,9 @@ var _ = Describe("PATCH /v1/sessions/:id (handleUpdateSession)", func() {
 		Expect(drv.lastGetOrgID).To(Equal(org))
 		Expect(drv.lastGetID).To(Equal(sessionID))
 		Expect(body.Session.ID).To(Equal(sessionID))
-		Expect(body.Session.Name).To(Equal("My corrected title"))
+		Expect(body.Session.DisplayName).To(Equal("My corrected title"))
+		Expect(body.Session.DisplayTitle).To(Equal("My corrected title"),
+			"a user rename resolves as the display title")
 	})
 
 	It("test_update_session_name_cross_org_404", func() {
@@ -231,7 +233,7 @@ var _ = Describe("PATCH /v1/sessions/:id (handleUpdateSession)", func() {
 		server := newSessionsServer(drv)
 
 		// When the client PATCHes a valid name
-		_, errBody, status := patchSession(server, "/v1/sessions/"+sessionID, org, `{"name":"My corrected title"}`)
+		_, errBody, status := patchSession(server, "/v1/sessions/"+sessionID, org, `{"display_name":"My corrected title"}`)
 
 		// Then the handler reports not-found rather than a false success
 		// (CC-2, EST-7), and never falls through to the re-read

--- a/api/skill_querier_test.go
+++ b/api/skill_querier_test.go
@@ -43,7 +43,7 @@ func (r *querierStubReader) GetSessionRecordByHarness(context.Context, string, s
 	return nil, nil
 }
 
-func (r *querierStubReader) UpdateSessionName(context.Context, string, string, *string) (int64, error) {
+func (r *querierStubReader) UpdateSessionDisplayName(context.Context, string, string, *string) (int64, error) {
 	panic("not implemented")
 }
 

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1050,7 +1050,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "display_title": {
-                    "description": "DisplayTitle is the server-resolved label clients should render:\nDisplayName -\u003e rollup.title (generated) -\u003e preview -\u003e Name -\u003e id\nslice. Resolving once on the server keeps every client (Console,\npaper CLI) from re-deriving — and diverging on — the precedence\n(PCC-970). Never empty: it falls back to a short id slice.",
+                    "description": "DisplayTitle is the server-resolved label clients should render:\nDisplayName -\u003e rollup.title (generated) -\u003e preview -\u003e Name -\u003e id\nslice. Resolving once on the server keeps every client (Console,\npaper CLI) from re-deriving — and diverging on — the precedence\n(PCC-970). Never empty: it falls back to a short harness id slice, then\nthe session id (the primary key, always set for a stored row).",
                     "type": "string"
                 },
                 "ended_at": {

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -504,7 +504,7 @@ const docTemplate = `{
                 }
             },
             "patch": {
-                "description": "Updates the user-editable session name. An absent field is a 400; null or empty (after trim) clears back to the auto-derived title. Length is bounded to 200 characters.",
+                "description": "Updates the user-editable display_name. An absent field is a 400; null or empty (after trim) clears back to the auto-derived title. Length is bounded to 200 characters.",
                 "consumes": [
                     "application/json"
                 ],
@@ -541,7 +541,7 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Missing/malformed id, missing name field, or name exceeds 200 characters",
+                        "description": "Missing/malformed id, missing display_name field, or display_name exceeds 200 characters",
                         "schema": {
                             "$ref": "#/definitions/github_com_papercomputeco_tapes_pkg_llm.ErrorResponse"
                         }
@@ -1045,6 +1045,14 @@ const docTemplate = `{
                 "cwd": {
                     "type": "string"
                 },
+                "display_name": {
+                    "description": "DisplayName is the user's Console rename (sessions.display_name),\nempty unless a user set one. Written only by PATCH /v1/sessions/:id,\nnever by ingest, so it survives a live session. It is the top of the\nDisplayTitle resolution; exposed raw so the edit affordance can seed\nits input from the user's own title (not the resolved fallback).",
+                    "type": "string"
+                },
+                "display_title": {
+                    "description": "DisplayTitle is the server-resolved label clients should render:\nDisplayName -\u003e rollup.title (generated) -\u003e preview -\u003e Name -\u003e id\nslice. Resolving once on the server keeps every client (Console,\npaper CLI) from re-deriving — and diverging on — the precedence\n(PCC-970). Never empty: it falls back to a short id slice.",
+                    "type": "string"
+                },
                 "ended_at": {
                     "type": "string"
                 },
@@ -1073,7 +1081,7 @@ const docTemplate = `{
                     "type": "boolean"
                 },
                 "name": {
-                    "description": "Name is the session's display label: the value on the identity row —\na user rename or the harness-supplied session name — when set,\notherwise the folded title (rollup.title) as a fallback. Empty only\nwhen the session has neither. It therefore equals rollup.title\nexactly when no identity-row name exists.",
+                    "description": "Name is the harness identity-row label — the harness-supplied session\nname (a plan slug), or the folded title (rollup.title) as a fallback\nwhen no name was captured. This is capture/deriver provenance, NOT a\nuser title: ingest re-sends it every turn. Clients should render\nDisplayTitle, not Name (PCC-970).",
                     "type": "string"
                 },
                 "parent_session_id": {
@@ -1503,7 +1511,7 @@ const docTemplate = `{
         "api.sessionUpdateRequest": {
             "type": "object",
             "properties": {
-                "name": {
+                "display_name": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1047,7 +1047,7 @@
                     "type": "string"
                 },
                 "display_title": {
-                    "description": "DisplayTitle is the server-resolved label clients should render:\nDisplayName -\u003e rollup.title (generated) -\u003e preview -\u003e Name -\u003e id\nslice. Resolving once on the server keeps every client (Console,\npaper CLI) from re-deriving — and diverging on — the precedence\n(PCC-970). Never empty: it falls back to a short id slice.",
+                    "description": "DisplayTitle is the server-resolved label clients should render:\nDisplayName -\u003e rollup.title (generated) -\u003e preview -\u003e Name -\u003e id\nslice. Resolving once on the server keeps every client (Console,\npaper CLI) from re-deriving — and diverging on — the precedence\n(PCC-970). Never empty: it falls back to a short harness id slice, then\nthe session id (the primary key, always set for a stored row).",
                     "type": "string"
                 },
                 "ended_at": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -501,7 +501,7 @@
                 }
             },
             "patch": {
-                "description": "Updates the user-editable session name. An absent field is a 400; null or empty (after trim) clears back to the auto-derived title. Length is bounded to 200 characters.",
+                "description": "Updates the user-editable display_name. An absent field is a 400; null or empty (after trim) clears back to the auto-derived title. Length is bounded to 200 characters.",
                 "consumes": [
                     "application/json"
                 ],
@@ -538,7 +538,7 @@
                         }
                     },
                     "400": {
-                        "description": "Missing/malformed id, missing name field, or name exceeds 200 characters",
+                        "description": "Missing/malformed id, missing display_name field, or display_name exceeds 200 characters",
                         "schema": {
                             "$ref": "#/definitions/github_com_papercomputeco_tapes_pkg_llm.ErrorResponse"
                         }
@@ -1042,6 +1042,14 @@
                 "cwd": {
                     "type": "string"
                 },
+                "display_name": {
+                    "description": "DisplayName is the user's Console rename (sessions.display_name),\nempty unless a user set one. Written only by PATCH /v1/sessions/:id,\nnever by ingest, so it survives a live session. It is the top of the\nDisplayTitle resolution; exposed raw so the edit affordance can seed\nits input from the user's own title (not the resolved fallback).",
+                    "type": "string"
+                },
+                "display_title": {
+                    "description": "DisplayTitle is the server-resolved label clients should render:\nDisplayName -\u003e rollup.title (generated) -\u003e preview -\u003e Name -\u003e id\nslice. Resolving once on the server keeps every client (Console,\npaper CLI) from re-deriving — and diverging on — the precedence\n(PCC-970). Never empty: it falls back to a short id slice.",
+                    "type": "string"
+                },
                 "ended_at": {
                     "type": "string"
                 },
@@ -1070,7 +1078,7 @@
                     "type": "boolean"
                 },
                 "name": {
-                    "description": "Name is the session's display label: the value on the identity row —\na user rename or the harness-supplied session name — when set,\notherwise the folded title (rollup.title) as a fallback. Empty only\nwhen the session has neither. It therefore equals rollup.title\nexactly when no identity-row name exists.",
+                    "description": "Name is the harness identity-row label — the harness-supplied session\nname (a plan slug), or the folded title (rollup.title) as a fallback\nwhen no name was captured. This is capture/deriver provenance, NOT a\nuser title: ingest re-sends it every turn. Clients should render\nDisplayTitle, not Name (PCC-970).",
                     "type": "string"
                 },
                 "parent_session_id": {
@@ -1500,7 +1508,7 @@
         "api.sessionUpdateRequest": {
             "type": "object",
             "properties": {
-                "name": {
+                "display_name": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -77,7 +77,8 @@ definitions:
           DisplayName -> rollup.title (generated) -> preview -> Name -> id
           slice. Resolving once on the server keeps every client (Console,
           paper CLI) from re-deriving — and diverging on — the precedence
-          (PCC-970). Never empty: it falls back to a short id slice.
+          (PCC-970). Never empty: it falls back to a short harness id slice, then
+          the session id (the primary key, always set for a stored row).
         type: string
       ended_at:
         type: string

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -63,6 +63,22 @@ definitions:
         type: string
       cwd:
         type: string
+      display_name:
+        description: |-
+          DisplayName is the user's Console rename (sessions.display_name),
+          empty unless a user set one. Written only by PATCH /v1/sessions/:id,
+          never by ingest, so it survives a live session. It is the top of the
+          DisplayTitle resolution; exposed raw so the edit affordance can seed
+          its input from the user's own title (not the resolved fallback).
+        type: string
+      display_title:
+        description: |-
+          DisplayTitle is the server-resolved label clients should render:
+          DisplayName -> rollup.title (generated) -> preview -> Name -> id
+          slice. Resolving once on the server keeps every client (Console,
+          paper CLI) from re-deriving — and diverging on — the precedence
+          (PCC-970). Never empty: it falls back to a short id slice.
+        type: string
       ended_at:
         type: string
       harness_id:
@@ -89,11 +105,11 @@ definitions:
         type: boolean
       name:
         description: |-
-          Name is the session's display label: the value on the identity row —
-          a user rename or the harness-supplied session name — when set,
-          otherwise the folded title (rollup.title) as a fallback. Empty only
-          when the session has neither. It therefore equals rollup.title
-          exactly when no identity-row name exists.
+          Name is the harness identity-row label — the harness-supplied session
+          name (a plan slug), or the folded title (rollup.title) as a fallback
+          when no name was captured. This is capture/deriver provenance, NOT a
+          user title: ingest re-sends it every turn. Clients should render
+          DisplayTitle, not Name (PCC-970).
         type: string
       parent_session_id:
         type: string
@@ -429,7 +445,7 @@ definitions:
     type: object
   api.sessionUpdateRequest:
     properties:
-      name:
+      display_name:
         type: string
     type: object
   api.swaggerMCPError:
@@ -813,7 +829,7 @@ paths:
     patch:
       consumes:
       - application/json
-      description: Updates the user-editable session name. An absent field is a 400;
+      description: Updates the user-editable display_name. An absent field is a 400;
         null or empty (after trim) clears back to the auto-derived title. Length is
         bounded to 200 characters.
       parameters:
@@ -836,8 +852,8 @@ paths:
           schema:
             $ref: '#/definitions/api.SessionDetailResponse'
         "400":
-          description: Missing/malformed id, missing name field, or name exceeds 200
-            characters
+          description: Missing/malformed id, missing display_name field, or display_name
+            exceeds 200 characters
           schema:
             $ref: '#/definitions/github_com_papercomputeco_tapes_pkg_llm.ErrorResponse'
         "404":

--- a/migrations/1781450000_session_display_name.down.sql
+++ b/migrations/1781450000_session_display_name.down.sql
@@ -1,0 +1,5 @@
+-- Inverse of the display_name migration. The user-editable title is a
+-- capture-independent fact (never recomputed from raw_turns), so dropping
+-- the column discards any user renames; the read layer falls back to
+-- derived_title/preview/name as before.
+ALTER TABLE sessions DROP COLUMN IF EXISTS display_name;

--- a/migrations/1781450000_session_display_name.up.sql
+++ b/migrations/1781450000_session_display_name.up.sql
@@ -1,0 +1,14 @@
+-- The user-editable display title lives in its own column, separate from
+-- `name`. `name` carries the harness-supplied session name — a plan slug
+-- like `clearing-example-2e`, or a harness `/rename` — which the ingest
+-- envelope re-sends on EVERY turn (UpsertSession: name = COALESCE(narg,
+-- name)). A console rename written into `name` is therefore clobbered by
+-- the next turn's upsert on any live session, and the slug also masks the
+-- deriver's title (PCC-970).
+--
+-- display_name is written ONLY by PATCH /v1/sessions/:id and never by
+-- ingest, so a user's title survives an active session. Empty/NULL means
+-- "no user title"; the read layer resolves the display title by falling
+-- back display_name -> derived_title -> preview -> name.
+ALTER TABLE sessions
+    ADD COLUMN IF NOT EXISTS display_name TEXT;

--- a/pkg/storage/postgres/gensqlc/models.go
+++ b/pkg/storage/postgres/gensqlc/models.go
@@ -69,6 +69,7 @@ type Session struct {
 	DurationNs        pgtype.Int8
 	Tasks             []byte
 	KindCounts        []byte
+	DisplayName       pgtype.Text
 }
 
 type Skill struct {

--- a/pkg/storage/postgres/gensqlc/sessions.sql.go
+++ b/pkg/storage/postgres/gensqlc/sessions.sql.go
@@ -35,7 +35,7 @@ func (q *Queries) DeleteSession(ctx context.Context, arg DeleteSessionParams) (i
 }
 
 const getSessionByNaturalKey = `-- name: GetSessionByNaturalKey :one
-SELECT id, org_id, auth_subject, harness_id, harness_session_id, name, cwd, harness_version, parent_session_id, started_at, last_seen_at, ended_at, harness_metadata, total_input_tokens, total_output_tokens, total_cost_usd, turn_count, derived_status, has_git_activity, tool_result_count, tool_error_count, derived_title, derived_model, model_usage, total_tokens, duration_ns, tasks, kind_counts FROM sessions
+SELECT id, org_id, auth_subject, harness_id, harness_session_id, name, cwd, harness_version, parent_session_id, started_at, last_seen_at, ended_at, harness_metadata, total_input_tokens, total_output_tokens, total_cost_usd, turn_count, derived_status, has_git_activity, tool_result_count, tool_error_count, derived_title, derived_model, model_usage, total_tokens, duration_ns, tasks, kind_counts, display_name FROM sessions
 WHERE org_id = $1
   AND harness_id = $2
   AND harness_session_id = $3
@@ -83,12 +83,13 @@ func (q *Queries) GetSessionByNaturalKey(ctx context.Context, arg GetSessionByNa
 		&i.DurationNs,
 		&i.Tasks,
 		&i.KindCounts,
+		&i.DisplayName,
 	)
 	return i, err
 }
 
 const getSessionRecord = `-- name: GetSessionRecord :one
-SELECT id, org_id, auth_subject, harness_id, harness_session_id, name, cwd, harness_version, parent_session_id, started_at, last_seen_at, ended_at, harness_metadata, total_input_tokens, total_output_tokens, total_cost_usd, turn_count, derived_status, has_git_activity, tool_result_count, tool_error_count, derived_title, derived_model, model_usage, total_tokens, duration_ns, tasks, kind_counts FROM sessions
+SELECT id, org_id, auth_subject, harness_id, harness_session_id, name, cwd, harness_version, parent_session_id, started_at, last_seen_at, ended_at, harness_metadata, total_input_tokens, total_output_tokens, total_cost_usd, turn_count, derived_status, has_git_activity, tool_result_count, tool_error_count, derived_title, derived_model, model_usage, total_tokens, duration_ns, tasks, kind_counts, display_name FROM sessions
 WHERE org_id = $1 AND id = $2
 `
 
@@ -129,6 +130,7 @@ func (q *Queries) GetSessionRecord(ctx context.Context, arg GetSessionRecordPara
 		&i.DurationNs,
 		&i.Tasks,
 		&i.KindCounts,
+		&i.DisplayName,
 	)
 	return i, err
 }
@@ -206,6 +208,36 @@ func (q *Queries) UpdateSessionDerivedTitle(ctx context.Context, arg UpdateSessi
 	return err
 }
 
+const updateSessionDisplayName = `-- name: UpdateSessionDisplayName :execrows
+UPDATE sessions SET display_name = $1
+WHERE id = $2 AND org_id = $3
+`
+
+type UpdateSessionDisplayNameParams struct {
+	DisplayName pgtype.Text
+	ID          pgtype.UUID
+	OrgID       pgtype.UUID
+}
+
+// User-driven rename of a session's display title (Console edit affordance).
+// Writes the dedicated `display_name` column — NOT `name`. `name` carries
+// the harness-supplied session slug, which ingest re-sends on every turn
+// (UpsertSession COALESCEs it back in), so a rename written there is
+// clobbered on the next turn of a live session and also masks the derived
+// title (PCC-970). display_name is touched only here, never by ingest, so
+// a user's title is durable. Org-scoped in the WHERE clause (never just by
+// id) so a cross-org id can never be updated; :execrows returns the
+// affected-row count, which the caller uses to distinguish a successful
+// update from an unknown/foreign id (0 rows). A NULL clears back to the
+// derived/auto title (the read layer resolves the fallback).
+func (q *Queries) UpdateSessionDisplayName(ctx context.Context, arg UpdateSessionDisplayNameParams) (int64, error) {
+	result, err := q.db.Exec(ctx, updateSessionDisplayName, arg.DisplayName, arg.ID, arg.OrgID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const updateSessionKindCounts = `-- name: UpdateSessionKindCounts :exec
 UPDATE sessions SET kind_counts = $1 WHERE id = $2
 `
@@ -239,33 +271,6 @@ type UpdateSessionModelUsageParams struct {
 func (q *Queries) UpdateSessionModelUsage(ctx context.Context, arg UpdateSessionModelUsageParams) error {
 	_, err := q.db.Exec(ctx, updateSessionModelUsage, arg.ModelUsage, arg.ID)
 	return err
-}
-
-const updateSessionName = `-- name: UpdateSessionName :execrows
-UPDATE sessions SET name = $1
-WHERE id = $2 AND org_id = $3
-`
-
-type UpdateSessionNameParams struct {
-	Name  pgtype.Text
-	ID    pgtype.UUID
-	OrgID pgtype.UUID
-}
-
-// User-driven rename of a session's display title (Console edit affordance).
-// Unlike UpdateSessionDerivedTitle (title-gen output, Postgres-internal),
-// this sets the user-facing `name` column and is exposed on the
-// sessionsReader capability interface. Org-scoped in the WHERE clause
-// (never just by id) so a cross-org id can never be updated; :execrows
-// returns the affected-row count, which the caller uses to distinguish a
-// successful update from an unknown/foreign id (0 rows). A NULL name
-// clears back to the derived/auto title.
-func (q *Queries) UpdateSessionName(ctx context.Context, arg UpdateSessionNameParams) (int64, error) {
-	result, err := q.db.Exec(ctx, updateSessionName, arg.Name, arg.ID, arg.OrgID)
-	if err != nil {
-		return 0, err
-	}
-	return result.RowsAffected(), nil
 }
 
 const updateSessionStatus = `-- name: UpdateSessionStatus :exec
@@ -357,7 +362,7 @@ SET last_seen_at     = $10,
     cwd              = COALESCE($7, sessions.cwd),
     harness_version  = COALESCE($8, sessions.harness_version),
     parent_session_id = COALESCE($9, sessions.parent_session_id)
-RETURNING id, org_id, auth_subject, harness_id, harness_session_id, name, cwd, harness_version, parent_session_id, started_at, last_seen_at, ended_at, harness_metadata, total_input_tokens, total_output_tokens, total_cost_usd, turn_count, derived_status, has_git_activity, tool_result_count, tool_error_count, derived_title, derived_model, model_usage, total_tokens, duration_ns, tasks, kind_counts
+RETURNING id, org_id, auth_subject, harness_id, harness_session_id, name, cwd, harness_version, parent_session_id, started_at, last_seen_at, ended_at, harness_metadata, total_input_tokens, total_output_tokens, total_cost_usd, turn_count, derived_status, has_git_activity, tool_result_count, tool_error_count, derived_title, derived_model, model_usage, total_tokens, duration_ns, tasks, kind_counts, display_name
 `
 
 type UpsertSessionParams struct {
@@ -434,6 +439,7 @@ func (q *Queries) UpsertSession(ctx context.Context, arg UpsertSessionParams) (S
 		&i.DurationNs,
 		&i.Tasks,
 		&i.KindCounts,
+		&i.DisplayName,
 	)
 	return i, err
 }

--- a/pkg/storage/postgres/queries/sessions.sql
+++ b/pkg/storage/postgres/queries/sessions.sql
@@ -148,14 +148,17 @@ UPDATE sessions SET tasks = sqlc.arg(tasks) WHERE id = sqlc.arg(id);
 -- Re-derive overwrites it idempotently.
 UPDATE sessions SET kind_counts = sqlc.arg(kind_counts) WHERE id = sqlc.arg(id);
 
--- name: UpdateSessionName :execrows
+-- name: UpdateSessionDisplayName :execrows
 -- User-driven rename of a session's display title (Console edit affordance).
--- Unlike UpdateSessionDerivedTitle (title-gen output, Postgres-internal),
--- this sets the user-facing `name` column and is exposed on the
--- sessionsReader capability interface. Org-scoped in the WHERE clause
--- (never just by id) so a cross-org id can never be updated; :execrows
--- returns the affected-row count, which the caller uses to distinguish a
--- successful update from an unknown/foreign id (0 rows). A NULL name
--- clears back to the derived/auto title.
-UPDATE sessions SET name = sqlc.narg(name)
+-- Writes the dedicated `display_name` column — NOT `name`. `name` carries
+-- the harness-supplied session slug, which ingest re-sends on every turn
+-- (UpsertSession COALESCEs it back in), so a rename written there is
+-- clobbered on the next turn of a live session and also masks the derived
+-- title (PCC-970). display_name is touched only here, never by ingest, so
+-- a user's title is durable. Org-scoped in the WHERE clause (never just by
+-- id) so a cross-org id can never be updated; :execrows returns the
+-- affected-row count, which the caller uses to distinguish a successful
+-- update from an unknown/foreign id (0 rows). A NULL clears back to the
+-- derived/auto title (the read layer resolves the fallback).
+UPDATE sessions SET display_name = sqlc.narg(display_name)
 WHERE id = sqlc.arg(id) AND org_id = sqlc.arg(org_id);

--- a/pkg/storage/postgres/session_reads.go
+++ b/pkg/storage/postgres/session_reads.go
@@ -71,7 +71,7 @@ func (d *Driver) ListSessionRecords(
 		`harness_version, parent_session_id, started_at, last_seen_at, ended_at, harness_metadata, ` +
 		`total_input_tokens, total_output_tokens, total_cost_usd, turn_count, derived_status, ` +
 		`has_git_activity, tool_result_count, tool_error_count, derived_title, derived_model, model_usage, ` +
-		`tasks, kind_counts`
+		`tasks, kind_counts, display_name`
 
 	// Values bind as pgx named args (@name). The dynamic ORDER BY forces a
 	// hand-built query, but every caller value is still a named, bound parameter
@@ -142,7 +142,7 @@ func (d *Driver) ListSessionRecords(
 			&g.HarnessVersion, &g.ParentSessionID, &g.StartedAt, &g.LastSeenAt, &g.EndedAt, &g.HarnessMetadata,
 			&g.TotalInputTokens, &g.TotalOutputTokens, &g.TotalCostUsd, &g.TurnCount, &g.DerivedStatus,
 			&g.HasGitActivity, &g.ToolResultCount, &g.ToolErrorCount, &g.DerivedTitle, &g.DerivedModel, &g.ModelUsage,
-			&g.Tasks, &g.KindCounts,
+			&g.Tasks, &g.KindCounts, &g.DisplayName,
 			&sortVal,
 		); err != nil {
 			return nil, fmt.Errorf("list session records: scan: %w", err)
@@ -282,21 +282,23 @@ func (d *Driver) DeleteSession(ctx context.Context, orgID, id string) (bool, err
 	return n > 0, nil
 }
 
-// UpdateSessionName sets (or clears, when name is nil) the user-facing
-// `name` column for a single session, scoped to the caller's org. The
-// org_id predicate lives in the SQL (UpdateSessionName query), never just
-// checked beforehand, so a cross-org id can never be updated. Returns the
-// number of rows affected: 0 means no row matched (unknown id, or an id
-// that exists but belongs to a different org), which the caller (the
-// sessions handler) maps to a 404 rather than treating as success.
-func (d *Driver) UpdateSessionName(ctx context.Context, orgID, id string, name *string) (int64, error) {
+// UpdateSessionDisplayName sets (or clears, when name is nil) the
+// user-facing `display_name` column for a single session, scoped to the
+// caller's org. It targets display_name — not name — so a Console rename
+// survives ingest re-sending the harness slug every turn (PCC-970). The
+// org_id predicate lives in the SQL (UpdateSessionDisplayName query),
+// never just checked beforehand, so a cross-org id can never be updated.
+// Returns the number of rows affected: 0 means no row matched (unknown id,
+// or an id that exists but belongs to a different org), which the caller
+// (the sessions handler) maps to a 404 rather than treating as success.
+func (d *Driver) UpdateSessionDisplayName(ctx context.Context, orgID, id string, name *string) (int64, error) {
 	oid, err := orgIDFromString(orgID)
 	if err != nil {
-		return 0, fmt.Errorf("update session name: %w", err)
+		return 0, fmt.Errorf("update session display name: %w", err)
 	}
 	parsed, err := uuid.Parse(id)
 	if err != nil {
-		return 0, fmt.Errorf("update session name: invalid id %q: %w", id, err)
+		return 0, fmt.Errorf("update session display name: invalid id %q: %w", id, err)
 	}
 
 	var namePg pgtype.Text
@@ -304,13 +306,13 @@ func (d *Driver) UpdateSessionName(ctx context.Context, orgID, id string, name *
 		namePg = pgtype.Text{String: *name, Valid: true}
 	}
 
-	rows, err := d.q.UpdateSessionName(ctx, gensqlc.UpdateSessionNameParams{
-		Name:  namePg,
-		ID:    pgtype.UUID{Bytes: parsed, Valid: true},
-		OrgID: oid,
+	rows, err := d.q.UpdateSessionDisplayName(ctx, gensqlc.UpdateSessionDisplayNameParams{
+		DisplayName: namePg,
+		ID:          pgtype.UUID{Bytes: parsed, Valid: true},
+		OrgID:       oid,
 	})
 	if err != nil {
-		return 0, fmt.Errorf("update session name: %w", err)
+		return 0, fmt.Errorf("update session display name: %w", err)
 	}
 	return rows, nil
 }
@@ -360,6 +362,12 @@ func sessionRecordFromRow(row gensqlc.Session) storage.SessionRecord {
 		Model:             row.DerivedModel,
 		AuthSubject:       row.AuthSubject,
 	}
+	// DisplayName (the user's Console rename) is exposed raw. It is the
+	// top of the display-title resolution the API performs; empty means
+	// "no user title" (PCC-970).
+	if row.DisplayName.Valid {
+		s.DisplayName = row.DisplayName.String
+	}
 	// DerivedTitle is exposed raw (never falls back to the name column) so
 	// callers that want the pure folded title — e.g. the API's
 	// rollup.title — do not inherit the identity-row name.
@@ -368,7 +376,11 @@ func sessionRecordFromRow(row gensqlc.Session) storage.SessionRecord {
 	}
 	// A user-set name is the session's display title; the folded
 	// title-gen output (derived_title) is only the auto-generated
-	// fallback when no user name is set (EST-2, CC-4 carve-out).
+	// fallback when no user name is set (EST-2, CC-4 carve-out). Left as-is
+	// so `name` on the wire is unchanged for existing consumers (paper CLI,
+	// deck); the Console now resolves via display_title (PCC-970), and the
+	// resolver's `name` fallback tier is only reached when derived_title is
+	// empty — where this coalesce yields the raw name anyway.
 	if row.Name.Valid && row.Name.String != "" {
 		s.Name = row.Name.String
 	} else if row.DerivedTitle.Valid && row.DerivedTitle.String != "" {

--- a/pkg/storage/postgres/sessions_update_test.go
+++ b/pkg/storage/postgres/sessions_update_test.go
@@ -12,10 +12,10 @@ import (
 )
 
 // ptr is a small helper to take the address of a string literal inline in
-// table/spec bodies (Name *string arguments to UpdateSessionName).
+// table/spec bodies (name *string arguments to UpdateSessionDisplayName).
 func ptr(s string) *string { return &s }
 
-var _ = Describe("Driver.UpdateSessionName", func() {
+var _ = Describe("Driver.UpdateSessionDisplayName", func() {
 	var (
 		driver   storage.Driver
 		pgDriver *postgres.Driver
@@ -49,7 +49,8 @@ var _ = Describe("Driver.UpdateSessionName", func() {
 
 	// seedSession ingests a 2-node turn for the given org, returning the
 	// tapes-minted session UUID. Mirrors the sibling read/ingest suites'
-	// seeding helper.
+	// seeding helper. The envelope carries no Name, so the sessions.name
+	// column is NULL — the user title lives only in display_name.
 	seedSession := func(orgID, harnessSessionID, text string) string {
 		res, err := ingester.IngestTurn(ctx, storage.IngestTurnRequest{
 			Session: &sessions.IngestEnvelope{
@@ -73,18 +74,18 @@ var _ = Describe("Driver.UpdateSessionName", func() {
 		Expect(err).NotTo(HaveOccurred())
 	}
 
-	It("updates name and returns rowsAffected=1 when the org matches the session (CC-2)", func() {
+	It("sets display_name and returns rowsAffected=1 when the org matches the session (CC-2)", func() {
 		orgA := newTestOrgID()
 		id := seedSession(orgA, "harness-org-match", "original text")
 
-		rows, err := pgDriver.UpdateSessionName(ctx, orgA, id, ptr("My corrected title"))
+		rows, err := pgDriver.UpdateSessionDisplayName(ctx, orgA, id, ptr("My corrected title"))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(rows).To(Equal(int64(1)))
 
 		rec, err := pgDriver.GetSessionRecord(ctx, orgA, id)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(rec).NotTo(BeNil())
-		Expect(rec.Name).To(Equal("My corrected title"))
+		Expect(rec.DisplayName).To(Equal("My corrected title"))
 	})
 
 	It("does not update the row and returns rowsAffected=0 for a cross-org id (CC-2, EST-7)", func() {
@@ -92,7 +93,7 @@ var _ = Describe("Driver.UpdateSessionName", func() {
 		orgB := newTestOrgID()
 		id := seedSession(orgA, "harness-cross-org", "orgA original text")
 
-		rows, err := pgDriver.UpdateSessionName(ctx, orgB, id, ptr("hijacked title"))
+		rows, err := pgDriver.UpdateSessionDisplayName(ctx, orgB, id, ptr("hijacked title"))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(rows).To(Equal(int64(0)))
 
@@ -101,7 +102,7 @@ var _ = Describe("Driver.UpdateSessionName", func() {
 		rec, err := pgDriver.GetSessionRecord(ctx, orgA, id)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(rec).NotTo(BeNil())
-		Expect(rec.Name).NotTo(Equal("hijacked title"))
+		Expect(rec.DisplayName).NotTo(Equal("hijacked title"))
 
 		// And orgB can't even read the row (org-scoped read), reinforcing
 		// that the update predicate matches the read predicate.
@@ -115,44 +116,43 @@ var _ = Describe("Driver.UpdateSessionName", func() {
 		// A syntactically valid but never-seeded UUID.
 		unknownID := "00000000-0000-0000-0000-000000000000"
 
-		rows, err := pgDriver.UpdateSessionName(ctx, orgA, unknownID, ptr("does not matter"))
+		rows, err := pgDriver.UpdateSessionDisplayName(ctx, orgA, unknownID, ptr("does not matter"))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(rows).To(Equal(int64(0)))
 	})
 
-	It("clears name to NULL when passed nil, leaving derived_title untouched (EST-4)", func() {
+	It("clears display_name to NULL when passed nil, leaving derived_title untouched (EST-4)", func() {
 		orgA := newTestOrgID()
 		id := seedSession(orgA, "harness-clear", "clear me")
 		setDerivedTitle(id, "auto-generated title")
 
-		// Give the row a manual name first so there's something to clear.
-		rows, err := pgDriver.UpdateSessionName(ctx, orgA, id, ptr("manual title"))
+		// Give the row a user title first so there's something to clear.
+		rows, err := pgDriver.UpdateSessionDisplayName(ctx, orgA, id, ptr("manual title"))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(rows).To(Equal(int64(1)))
 
 		rec, err := pgDriver.GetSessionRecord(ctx, orgA, id)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(rec.Name).To(Equal("manual title"))
+		Expect(rec.DisplayName).To(Equal("manual title"))
 
-		// Now clear it: name=nil must NULL the column. GetSessionRecord's
-		// display-precedence falls back to derived_title when name is
-		// NULL, so assert against the raw column via SQL to isolate the
-		// storage-layer contract from the read-path's display fallback.
-		rows, err = pgDriver.UpdateSessionName(ctx, orgA, id, nil)
+		// Now clear it: name=nil must NULL the display_name column. Assert
+		// against the raw columns via SQL to isolate the storage-layer
+		// contract from the read-path's display-title resolution.
+		rows, err = pgDriver.UpdateSessionDisplayName(ctx, orgA, id, nil)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(rows).To(Equal(int64(1)))
 
-		var namePg *string
+		var displayNamePg *string
 		var derivedTitlePg *string
 		Expect(pgDriver.DB().QueryRow(ctx,
-			"SELECT name, derived_title FROM sessions WHERE id = $1", mustUUID(id),
-		).Scan(&namePg, &derivedTitlePg)).To(Succeed())
-		Expect(namePg).To(BeNil(), "name column must be NULL after clearing")
+			"SELECT display_name, derived_title FROM sessions WHERE id = $1", mustUUID(id),
+		).Scan(&displayNamePg, &derivedTitlePg)).To(Succeed())
+		Expect(displayNamePg).To(BeNil(), "display_name column must be NULL after clearing")
 		Expect(derivedTitlePg).NotTo(BeNil())
-		Expect(*derivedTitlePg).To(Equal("auto-generated title"), "clearing name must never touch derived_title")
+		Expect(*derivedTitlePg).To(Equal("auto-generated title"), "clearing display_name must never touch derived_title")
 	})
 
-	It("changes only name and leaves derived_title (and other fields) unchanged (CC-1, EST-5)", func() {
+	It("changes only display_name and leaves name, derived_title (and other fields) unchanged (CC-1, EST-5)", func() {
 		orgA := newTestOrgID()
 		id := seedSession(orgA, "harness-only-name", "only name changes")
 		setDerivedTitle(id, "unchanged derived title")
@@ -161,24 +161,28 @@ var _ = Describe("Driver.UpdateSessionName", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(before).NotTo(BeNil())
 
-		rows, err := pgDriver.UpdateSessionName(ctx, orgA, id, ptr("brand new manual name"))
+		rows, err := pgDriver.UpdateSessionDisplayName(ctx, orgA, id, ptr("brand new manual name"))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(rows).To(Equal(int64(1)))
 
-		// Raw column check: derived_title must be byte-for-byte the same
-		// row as before the update (CC-1: never write derived_title).
+		// Raw column check: neither the harness name nor derived_title is
+		// touched by a display_name write (CC-1: never write derived_title,
+		// and the durable-title fix must not disturb the harness slug).
+		var namePg *string
 		var derivedTitlePg *string
 		Expect(pgDriver.DB().QueryRow(ctx,
-			"SELECT derived_title FROM sessions WHERE id = $1", mustUUID(id),
-		).Scan(&derivedTitlePg)).To(Succeed())
+			"SELECT name, derived_title FROM sessions WHERE id = $1", mustUUID(id),
+		).Scan(&namePg, &derivedTitlePg)).To(Succeed())
+		Expect(namePg).To(BeNil(), "harness name column stays NULL (envelope carried no name)")
 		Expect(derivedTitlePg).NotTo(BeNil())
 		Expect(*derivedTitlePg).To(Equal("unchanged derived title"))
 
 		after, err := pgDriver.GetSessionRecord(ctx, orgA, id)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(after).NotTo(BeNil())
+		Expect(after.DisplayName).To(Equal("brand new manual name"))
 
-		// Other session fields untouched by the name-only mutation.
+		// Other session fields untouched by the display_name-only mutation.
 		Expect(after.HarnessID).To(Equal(before.HarnessID))
 		Expect(after.HarnessSessionID).To(Equal(before.HarnessSessionID))
 		Expect(after.TurnCount).To(Equal(before.TurnCount))
@@ -188,31 +192,35 @@ var _ = Describe("Driver.UpdateSessionName", func() {
 		Expect(after.StartedAt).To(Equal(before.StartedAt))
 	})
 
-	It("a user-set name takes display precedence over an existing derived_title (EST-2, CC-4 carve-out)", func() {
+	It("stores display_name independently of name and derived_title (PCC-970)", func() {
 		orgA := newTestOrgID()
-		id := seedSession(orgA, "harness-precedence-carveout", "precedence carve-out text")
+		id := seedSession(orgA, "harness-independent-columns", "independent columns text")
 		setDerivedTitle(id, "auto-generated title")
 
-		// Sanity: with only a derived_title and no user name, the read path
-		// must fall back to it.
+		// Sanity: with no user title and a NULL name column, the read
+		// record's Name coalesces to derived_title, and DisplayName is empty.
 		before, err := pgDriver.GetSessionRecord(ctx, orgA, id)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(before).NotTo(BeNil())
 		Expect(before.Name).To(Equal("auto-generated title"))
-		// DerivedTitle is exposed raw and never inherits the name fallback,
-		// so rollup.title carries the folded title even when Name equals it.
+		Expect(before.DisplayName).To(BeEmpty())
+		// DerivedTitle is exposed raw and never inherits the name fallback.
 		Expect(before.DerivedTitle).To(Equal("auto-generated title"))
 
-		rows, err := pgDriver.UpdateSessionName(ctx, orgA, id, ptr("user chosen title"))
+		rows, err := pgDriver.UpdateSessionDisplayName(ctx, orgA, id, ptr("user chosen title"))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(rows).To(Equal(int64(1)))
 
 		after, err := pgDriver.GetSessionRecord(ctx, orgA, id)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(after).NotTo(BeNil())
-		Expect(after.Name).To(Equal("user chosen title"),
-			"a non-empty user name must win over derived_title in the display precedence")
+		// The user title lands in display_name — a separate axis. The API's
+		// resolveDisplayTitle prefers it; the storage columns stay distinct.
+		Expect(after.DisplayName).To(Equal("user chosen title"),
+			"the user title is stored in display_name")
+		Expect(after.Name).To(Equal("auto-generated title"),
+			"the harness/coalesced name column is untouched by a display_name write")
 		Expect(after.DerivedTitle).To(Equal("auto-generated title"),
-			"DerivedTitle stays the raw folded title, independent of the user name")
+			"DerivedTitle stays the raw folded title, independent of the user title")
 	})
 })

--- a/pkg/storage/session_record.go
+++ b/pkg/storage/session_record.go
@@ -19,6 +19,13 @@ type SessionRecord struct {
 	// otherwise DerivedTitle as the fallback. Empty only when neither
 	// exists.
 	Name string
+	// DisplayName is the user-set display title (sessions.display_name),
+	// written only by the Console rename PATCH and never by ingest, so it
+	// survives an active session (unlike Name, which the envelope re-sends
+	// every turn). Empty means "no user title"; the API resolves the
+	// display title as DisplayName -> DerivedTitle -> Preview -> Name
+	// (PCC-970).
+	DisplayName string
 	// DerivedTitle is the deriver's folded session title
 	// (sessions.derived_title), generated from the conversation. Empty
 	// until title generation produces one. Unlike Name it never falls back


### PR DESCRIPTION
## What

Adds a server-resolved session display title and a durable, user-editable title to the sessions API.

- **`display_title`** (new, on every session): the label clients should render, resolved once on the server as `display_name → derived_title → preview → name → id-slice`. Resolving in one place means the console, paper CLI, and deck all render the same title instead of each re-deriving the precedence.
- **`display_name`** (new column): the user's editable title. Written only by `PATCH /v1/sessions/:id`, never by ingest — so a rename is durable even on a live session, where the capture envelope re-sends the harness `name` every turn.
- The update path (query, driver method, `sessionsReader` interface, and the PATCH body field) speaks `display_name`, so request and response name the same thing. `name` stays the raw harness identity for other consumers (paper CLI, deck).

## Notes

- No backfill needed: `display_name` defaults NULL, so existing rows resolve straight through to `derived_title`.
- Storage integration + handler unit tests updated; OpenAPI regenerated. Verified end-to-end in a local clearing.

related to PCC-970

🤖 Generated with [Claude Code](https://claude.com/claude-code)