### PR TITLE
🔧 fix(merkle): catalog Codex <environment_context> as a harness wrapper tag

### DIFF
--- a/pkg/merkle/projection.go
+++ b/pkg/merkle/projection.go
@@ -46,6 +46,13 @@ var HarnessTags = []string{
 	"tool-use-id",
 	"output-file",
 	"task-id",
+	// Codex's opening environment-framing wrapper. A Codex session
+	// prepends a text block wrapping its cwd/shell/current_date/timezone/
+	// filesystem framing in <environment_context>…</environment_context>.
+	// Those values (clock, timezone, cwd) drift between turns; stripping
+	// the outer tag removes the whole nested block so they cannot ride
+	// into the chain hash or the embedding render.
+	"environment_context",
 }
 
 // ProjectContent returns the projection of content blocks used when

--- a/pkg/merkle/projection_test.go
+++ b/pkg/merkle/projection_test.go
@@ -51,14 +51,12 @@ var _ = Describe("ProjectContent", func() {
 	})
 
 	It("strips every harness tag the spec lists", func() {
-		// Each tag wraps a marker so we can prove the strip happened.
-		tags := []string{
-			"system-reminder",
-			"command-name", "command-message", "command-args",
-			"local-command-stdout", "local-command-stderr", "local-command-caveat",
-		}
+		// Iterate merkle.HarnessTags directly so this stays a canonical
+		// "every catalogued tag gets stripped" guard: new entries (the
+		// Phase-2 wrappers, environment_context, anything added later) are
+		// covered automatically instead of drifting from a hardcoded subset.
 		var body strings.Builder
-		for _, t := range tags {
+		for _, t := range merkle.HarnessTags {
 			body.WriteString("<" + t + ">drop-" + t + "</" + t + ">\n")
 		}
 		body.WriteString("keep")
@@ -67,6 +65,40 @@ var _ = Describe("ProjectContent", func() {
 
 		Expect(projected).To(HaveLen(1))
 		Expect(projected[0].Text).To(Equal("keep"))
+	})
+
+	It("strips Codex's <environment_context> wrapper with its nested volatile children", func() {
+		// A Codex session prepends an environment-framing block whose
+		// values (current_date, timezone, cwd) drift between turns. The
+		// outer strip must swallow the whole nested block so none of it
+		// reaches the projection.
+		env := strings.Join([]string{
+			"<environment_context>",
+			"  <cwd>/home/fedora/git/paper-forest/groves</cwd>",
+			"  <shell>zsh</shell>",
+			"  <current_date>2026-07-22</current_date>",
+			"  <timezone>UTC</timezone>",
+			"  <filesystem><workspace_roots><root>/home/x</root></workspace_roots>" +
+				"<permission_profile type=\"managed\">full</permission_profile></filesystem>",
+			"</environment_context>",
+			"",
+			"Hey Codex!",
+		}, "\n")
+
+		projected := merkle.ProjectContent([]llm.ContentBlock{{Type: "text", Text: env}})
+
+		Expect(projected).To(HaveLen(1))
+		Expect(projected[0].Text).To(Equal("Hey Codex!"))
+	})
+
+	It("hashes two Codex turns identically when only the environment_context values drift", func() {
+		day1 := "<environment_context><current_date>2026-07-22</current_date>" +
+			"<timezone>UTC</timezone></environment_context>\n\nsame ask"
+		day2 := "<environment_context><current_date>2026-07-23</current_date>" +
+			"<timezone>PST</timezone></environment_context>\n\nsame ask"
+
+		Expect(merkle.ProjectContent([]llm.ContentBlock{{Type: "text", Text: day1}})).
+			To(Equal(merkle.ProjectContent([]llm.ContentBlock{{Type: "text", Text: day2}})))
 	})
 
 	It("collapses a blank line inserted between paragraphs (PCC-562 57a58 case)", func() {


### PR DESCRIPTION
🧍This is a minor update to improve the session summary derivation for newer GPT models. There are more fixes to come as I find ways to improve it but this will help improve the data from this beginning block on the start of sessions. 🧍

🤖

## Summary
Codex sessions prepend a `<environment_context>` block to their opening (cwd, shell, current_date, timezone, filesystem/permission profile). It wasn't in `merkle.HarnessTags`, so the projection never stripped it — its volatile values (clock, timezone, cwd) rode into the chain hash and the embedding render, and it leaked as raw prose in the console.

- Add `environment_context` to `HarnessTags`. Stripping the outer tag drops the whole nested block (`stripTaggedSpan` cuts to the first `</environment_context>`), so those volatile children can no longer fracture the chain hash or pollute the embed render.

## Impact / rollout
Projections are computed at derive time, so **existing Codex sessions must be re-derived** (`RederiveFromRaw`) to pick up the new tag; new ingests get it automatically. The raw layer is untouched — no capture-side release needed.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `gofmt -l` — clean
- [x] `go test ./pkg/merkle/...` — passes, including 2 new specs: strips `<environment_context>` with its nested volatile children; produces an identical chain-hash projection when only clock/timezone/cwd drift
- [ ] Postgres integration tests (`pkg/spanembed`, `pkg/storage/postgres`) require Dagger's Postgres service (`dagger call test`) and aren't runnable in the agent loop — unrelated to this change, which touches only `pkg/merkle`

related to PCC-881