### PR TITLE
🔧 fix(api): gate session liveness on recency, not derived status

### DIFF
--- a/api/sessions_handlers.go
+++ b/api/sessions_handlers.go
@@ -95,10 +95,13 @@ type SessionItem struct {
 	// the session id (the primary key, always set for a stored row).
 	DisplayTitle string `json:"display_title"`
 	// Live is a runtime presence signal, not a projection fact: true when
-	// the session was seen within the liveness window AND the deriver has
-	// not marked it terminal. Computed at response time from last_seen_at,
-	// so the console renders it directly instead of inferring "running"
-	// from recency itself (keeps the console dumb; RFD 00007 §C).
+	// the session has no recorded end and was seen within the liveness
+	// window. Keyed on ended_at + last_seen_at recency (both ingest-fresh),
+	// never on the derived status: an interactive session folds to a
+	// terminal status (an end_turn assistant reply reads as "completed")
+	// after every turn while still open, so status cannot gate liveness.
+	// Computed at response time so the console renders it directly instead
+	// of inferring "running" itself (RFD 00007 §C).
 	Live bool `json:"live"`
 	// Rollup is the deriver-owned projection over the session's spans.
 	Rollup SessionRollup `json:"rollup"`
@@ -108,16 +111,6 @@ type SessionItem struct {
 // read as live. Server config now (mirrors the console's old 5-minute
 // client-side window) so liveness is decided in one place.
 const sessionLiveWindow = 5 * time.Minute
-
-// terminalStatus reports whether a derived status is a settled outcome, in
-// which case the session is done regardless of recency.
-func terminalStatus(s string) bool {
-	switch s {
-	case "completed", "failed", "abandoned":
-		return true
-	}
-	return false
-}
 
 // SessionRollup is the deriver-owned session projection — status, title,
 // counts, and spend, all folded from the span layer at derive time.
@@ -246,7 +239,7 @@ func sessionItemFromStorage(s storage.SessionRecord, now time.Time) SessionItem 
 		Name:             s.Name,
 		DisplayName:      s.DisplayName,
 		DisplayTitle:     resolveSessionDisplayTitle(s),
-		Live:             now.Sub(s.LastSeenAt) < sessionLiveWindow && !terminalStatus(s.DerivedStatus),
+		Live:             s.EndedAt == nil && now.Sub(s.LastSeenAt) < sessionLiveWindow,
 		Rollup: SessionRollup{
 			Status:     s.DerivedStatus,
 			Title:      s.DerivedTitle,

--- a/api/sessions_handlers_test.go
+++ b/api/sessions_handlers_test.go
@@ -656,3 +656,43 @@ var _ = Describe("sort and direction params on GET /v1/sessions", func() {
 		Expect(next.Val).To(Equal(first.SortVal))
 	})
 })
+
+var _ = Describe("sessionItemFromStorage liveness", func() {
+	now := time.Date(2026, 7, 24, 12, 0, 0, 0, time.UTC)
+	recent := now.Add(-30 * time.Second) // inside the 5m window
+	stale := now.Add(-10 * time.Minute)  // outside the 5m window
+	ended := now.Add(-1 * time.Minute)   // an explicit close, recently
+
+	liveOf := func(s storage.SessionRecord) bool {
+		return sessionItemFromStorage(s, now).Live
+	}
+
+	It("stays live between turns even though the last turn folded to a terminal status", func() {
+		// The regression this guards: an interactive session reads
+		// derived_status=completed after every end_turn while still open.
+		// Liveness must key on recency + ended_at, never on that status.
+		Expect(liveOf(storage.SessionRecord{
+			ID: "s1", LastSeenAt: recent, EndedAt: nil, DerivedStatus: "completed",
+		})).To(BeTrue())
+	})
+
+	It("ignores every terminal status value for a recent, unended session", func() {
+		for _, status := range []string{"completed", "failed", "abandoned", "unknown", ""} {
+			Expect(liveOf(storage.SessionRecord{
+				ID: "s", LastSeenAt: recent, EndedAt: nil, DerivedStatus: status,
+			})).To(BeTrue(), "status %q should not gate liveness", status)
+		}
+	})
+
+	It("is not live once seen outside the liveness window", func() {
+		Expect(liveOf(storage.SessionRecord{
+			ID: "s2", LastSeenAt: stale, EndedAt: nil, DerivedStatus: "completed",
+		})).To(BeFalse())
+	})
+
+	It("is not live once the session has a recorded end, even if recently seen", func() {
+		Expect(liveOf(storage.SessionRecord{
+			ID: "s3", LastSeenAt: recent, EndedAt: &ended, DerivedStatus: "completed",
+		})).To(BeFalse())
+	})
+})

--- a/pkg/derive/worker/metrics.go
+++ b/pkg/derive/worker/metrics.go
@@ -80,9 +80,15 @@ func NewMetrics() *Metrics {
 			Help: "Derives whose session was re-dirtied mid-derive and stayed queued.",
 		}),
 		DeriveDuration: prometheus.NewHistogram(prometheus.HistogramOpts{
-			Name:    "tapes_derive_worker_derive_duration_seconds",
-			Help:    "Wall time of one session derive (read + derive + persist).",
-			Buckets: prometheus.DefBuckets,
+			Name: "tapes_derive_worker_derive_duration_seconds",
+			Help: "Wall time of one session derive (read + derive + persist).",
+			// A full re-derivation is O(all turns), so large sessions run
+			// well past DefBuckets' 10s ceiling (some tenants average >20s).
+			// Extend the tail to 120s so p95/p99 reflect the real slow
+			// derivations instead of pegging at the top bucket.
+			Buckets: []float64{
+				.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 20, 30, 60, 120,
+			},
 		}),
 		UnknownCalls: prometheus.NewCounter(prometheus.CounterOpts{
 			Name: "tapes_derive_worker_unknown_call_kinds_total",


### PR DESCRIPTION
## Summary

- Session `live` no longer flips false between turns. An interactive session folds to a terminal `derived_status` (an `end_turn` assistant reply reads as `completed`) after **every** turn while still open, and the old `live` formula ANDed `!terminalStatus(derived_status)` — so an active session read not-live between turns, and the console (which gates its content poll on `live`) stopped refreshing until reload.
- `live` is now a **lifecycle** signal keyed on recency + `ended_at`, never on the turn-outcome status: `live = ended_at == nil && now - last_seen_at < 5m`. `last_seen_at` is ingest-fresh, so liveness is real-time and independent of derive lag.
- This is PCC-946's **Option 1 (recency-dominant)**. It restores the pre-span-model dwell behavior; the console needs no change (it already renders the flag). The one residual — a truly-exited session reads live for up to the 5m window — is later resolved by a real session-close signal populating `ended_at`, which this formula already consumes, so it lights up with no further API change.
- Rider commit: widen the derive-duration histogram past `DefBuckets`' 10s ceiling (→120s) so the slow-derive tail (a full re-derivation is O(all turns); some tenants average >20s) shows up in p95/p99 instead of pegging at the top bucket.

## How it works

`sessionItemFromStorage` computes `Live` once per response from the ingest-written session row. Dropping the `!terminalStatus(...)` conjunct decouples "is the session still open?" from "how did the last turn end?" — the latter stays available separately as `rollup.status`. `terminalStatus` had no other caller and is deleted.

## Behavior matrix (recent session, seen within the 5m window)

| ended_at | last turn | before | after |
|---|---|---|---|
| null | `end_turn` → completed | **not live** | **live** |
| null | failed / abandoned | not live | live |
| null | mid-generation | live | live |
| set | any | live | **not live** |
| — | last seen > 5m ago | not live | not live |

## Test plan

- [x] `make test` — API Suite 116/116, including 4 new liveness specs (recent + unended + `completed` → live; no terminal-status value gates liveness; stale → not live; `ended_at` set → not live)
- [x] `make format` (golangci-lint) clean
- [ ] CI `make e2e-test` — no e2e surface touched (pure read-model computation + metric bucket boundaries)

Fixes PCC-946
