### PR TITLE
✨ feat(pricing): price Claude Opus 5

### DIFF
--- a/pkg/sessions/pricing.go
+++ b/pkg/sessions/pricing.go
@@ -10,7 +10,7 @@ import (
 
 // DefaultPricing returns hardcoded pricing per million tokens for supported models.
 //
-// Last verified: 2026-07-09
+// Last verified: 2026-07-24
 // Sources:
 //   - Anthropic: https://platform.claude.com/docs/en/about-claude/pricing
 //   - OpenAI:    https://platform.openai.com/docs/pricing
@@ -24,6 +24,7 @@ import (
 func DefaultPricing() PricingTable {
 	return PricingTable{
 		// Anthropic
+		"claude-opus-5":     {Input: 5.00, Output: 25.00, CacheRead: 0.50, CacheWrite: 6.25},
 		"claude-fable-5":    {Input: 10.00, Output: 50.00, CacheRead: 1.00, CacheWrite: 12.50},
 		"claude-opus-4.8":   {Input: 5.00, Output: 25.00, CacheRead: 0.50, CacheWrite: 6.25},
 		"claude-opus-4.7":   {Input: 5.00, Output: 25.00, CacheRead: 0.50, CacheWrite: 6.25},

--- a/pkg/sessions/status_pricing_test.go
+++ b/pkg/sessions/status_pricing_test.go
@@ -107,6 +107,8 @@ var _ = Describe("NormalizeModel", func() {
 		}
 		pricing := sessions.DefaultPricing()
 		for _, p := range []pin{
+			{"claude-opus-5", 5.00, 25.00},
+			{"claude-opus-5[1m]", 5.00, 25.00},
 			{"claude-fable-5", 10.00, 50.00},
 			{"claude-fable-5[1m]", 10.00, 50.00},
 			{"claude-sonnet-5", 3.00, 15.00},


### PR DESCRIPTION
# 👨🏼

Refs PCC-1017

# 🤖

- Add Claude Opus 5 to the default pricing table at Anthropic's published rates.
- Cover the exact `claude-opus-5` API model ID and its `[1m]` context form.
- Refresh the Anthropic pricing verification date.

## Tests
- `nix develop -c make format`
- `nix develop -c make test`
- `nix develop -c sh -c 'GOEXPERIMENT=jsonv2 go test ./pkg/sessions'`
