### PR TITLE
✨ feat(raw-turns): repair attribution with append-only overlays

### DIFF
--- a/api/admin_attribution_repair_test.go
+++ b/api/admin_attribution_repair_test.go
@@ -1,0 +1,141 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	tapeslogger "github.com/papercomputeco/tapes/pkg/logger"
+	"github.com/papercomputeco/tapes/pkg/storage"
+	"github.com/papercomputeco/tapes/pkg/storage/inmemory"
+)
+
+type attributionRepairStub struct {
+	storage.Driver
+	req    storage.RawTurnAttributionRepairRequest
+	result storage.RawTurnAttributionRepairResult
+	err    error
+}
+
+func (s *attributionRepairStub) RepairRawTurnAttribution(
+	_ context.Context,
+	_ string,
+	req storage.RawTurnAttributionRepairRequest,
+) (storage.RawTurnAttributionRepairResult, error) {
+	s.req = req
+	return s.result, s.err
+}
+
+var _ = Describe("raw-turn attribution repair admin endpoint", func() {
+	newServer := func(driver storage.Driver) *Server {
+		s, err := NewServer(Config{ListenAddr: ":0"}, driver, tapeslogger.NewNoop())
+		Expect(err).NotTo(HaveOccurred())
+		return s
+	}
+
+	request := func(s *Server, body string) *http.Response {
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodPost,
+			"/v1/admin/raw-turns/attribution-repair", bytes.NewBufferString(body))
+		Expect(err).NotTo(HaveOccurred())
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set(orgIDHeader, "11111111-1111-1111-1111-111111111111")
+		resp, err := s.app.Test(req)
+		Expect(err).NotTo(HaveOccurred())
+		return resp
+	}
+
+	It("threads an exact correlation selector and trusted org to storage", func() {
+		stub := &attributionRepairStub{Driver: inmemory.NewDriver(), result: storage.RawTurnAttributionRepairResult{Recorded: true}}
+		resp := request(newServer(stub), `{"paper_proxy_request_id":"proxy-1","harness_id":"codex","harness_session_id":"child","thread_id":"thread","reason":"hook evidence"}`)
+		defer resp.Body.Close()
+		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+		Expect(stub.req.OrgID).To(Equal("11111111-1111-1111-1111-111111111111"))
+		Expect(stub.req.PaperProxyRequestID).To(Equal("proxy-1"))
+	})
+
+	It("rejects ambiguous selector shapes before calling storage", func() {
+		stub := &attributionRepairStub{Driver: inmemory.NewDriver()}
+		resp := request(newServer(stub), `{"raw_turn_id":1,"paper_proxy_request_id":"proxy-1","harness_id":"codex","harness_session_id":"child","reason":"evidence"}`)
+		defer resp.Body.Close()
+		Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
+		Expect(stub.req).To(Equal(storage.RawTurnAttributionRepairRequest{}))
+	})
+
+	It("rejects a session that names itself as its parent", func() {
+		stub := &attributionRepairStub{Driver: inmemory.NewDriver()}
+		resp := request(newServer(stub), `{"raw_turn_id":1,"harness_id":"codex","harness_session_id":"child","parent_harness_session_id":"child","reason":"evidence"}`)
+		defer resp.Body.Close()
+		Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
+		Expect(stub.req).To(Equal(storage.RawTurnAttributionRepairRequest{}))
+	})
+
+	It("maps missing and ambiguous correlations", func() {
+		stub := &attributionRepairStub{Driver: inmemory.NewDriver(), err: storage.ErrRawTurnNotFound}
+		resp := request(newServer(stub), `{"raw_turn_id":1,"harness_id":"codex","harness_session_id":"child","reason":"evidence"}`)
+		resp.Body.Close()
+		Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+
+		stub.err = storage.ErrRawTurnAmbiguous
+		resp = request(newServer(stub), `{"paper_proxy_request_id":"proxy-1","harness_id":"codex","harness_session_id":"child","reason":"evidence"}`)
+		defer resp.Body.Close()
+		Expect(resp.StatusCode).To(Equal(http.StatusConflict))
+	})
+
+	It("returns not implemented for a driver without the repair capability", func() {
+		resp := request(newServer(inmemory.NewDriver()), `{"raw_turn_id":1,"harness_id":"codex","harness_session_id":"child","reason":"evidence"}`)
+		defer resp.Body.Close()
+		Expect(resp.StatusCode).To(Equal(http.StatusNotImplemented))
+	})
+
+	It("returns 202 with the partial result when the correction recorded but projections are pending", func() {
+		pending := storage.RawTurnAttributionRepairResult{
+			Recorded: true,
+			ProjectionsPending: []storage.RepairPendingSession{
+				{HarnessID: "codex", HarnessSessionID: "child"},
+			},
+		}
+		stub := &attributionRepairStub{
+			Driver: inmemory.NewDriver(),
+			result: pending,
+			err:    fmt.Errorf("%w: rederive effective session: boom", storage.ErrRepairProjectionsPending),
+		}
+		resp := request(newServer(stub), `{"raw_turn_id":1,"harness_id":"codex","harness_session_id":"child","reason":"evidence"}`)
+		defer resp.Body.Close()
+		Expect(resp.StatusCode).To(Equal(http.StatusAccepted))
+		var body storage.RawTurnAttributionRepairResult
+		Expect(json.NewDecoder(resp.Body).Decode(&body)).To(Succeed())
+		Expect(body.Recorded).To(BeTrue())
+		Expect(body.ProjectionsPending).To(Equal(pending.ProjectionsPending),
+			"the response must name the sessions still awaiting the derive worker")
+	})
+
+	It("returns 200 with source_cleanup_pending when only the cosmetic source cleanup failed", func() {
+		stub := &attributionRepairStub{
+			Driver: inmemory.NewDriver(),
+			result: storage.RawTurnAttributionRepairResult{Recorded: true, SourceCleanupPending: true},
+		}
+		resp := request(newServer(stub), `{"raw_turn_id":1,"harness_id":"codex","harness_session_id":"child","reason":"evidence"}`)
+		defer resp.Body.Close()
+		Expect(resp.StatusCode).To(Equal(http.StatusOK),
+			"an applied repair with a leftover empty source row is a success, not a 500")
+		var body storage.RawTurnAttributionRepairResult
+		Expect(json.NewDecoder(resp.Body).Decode(&body)).To(Succeed())
+		Expect(body.Recorded).To(BeTrue())
+		Expect(body.SourceCleanupPending).To(BeTrue(),
+			"the response must disclose the leftover source row")
+		Expect(body.ProjectionsPending).To(BeEmpty())
+	})
+
+	It("maps unexpected storage failures to internal server error", func() {
+		stub := &attributionRepairStub{Driver: inmemory.NewDriver(), err: errors.New("boom")}
+		resp := request(newServer(stub), `{"raw_turn_id":1,"harness_id":"codex","harness_session_id":"child","reason":"evidence"}`)
+		defer resp.Body.Close()
+		Expect(resp.StatusCode).To(Equal(http.StatusInternalServerError))
+	})
+})

--- a/api/admin_handlers.go
+++ b/api/admin_handlers.go
@@ -3,12 +3,14 @@ package api
 import (
 	"context"
 	"errors"
+	"strings"
 
 	"github.com/gofiber/fiber/v2"
 
 	"github.com/papercomputeco/tapes/pkg/derive"
 	"github.com/papercomputeco/tapes/pkg/llm"
 	"github.com/papercomputeco/tapes/pkg/seed"
+	"github.com/papercomputeco/tapes/pkg/storage"
 )
 
 type seedDemoRequest struct {
@@ -108,4 +110,84 @@ func (s *Server) handleDeriveRun(c *fiber.Ctx) error {
 	}
 
 	return c.JSON(deriveRunResponse{Orgs: reports})
+}
+
+type rawTurnAttributionRepairer interface {
+	RepairRawTurnAttribution(context.Context, string, storage.RawTurnAttributionRepairRequest) (storage.RawTurnAttributionRepairResult, error)
+}
+
+// handleRawTurnAttributionRepair records an append-only attribution overlay
+// and synchronously rebuilds both affected session projections.
+//
+//	@Summary		Repair raw-turn attribution (operator)
+//	@ID			repairRawTurnAttribution
+//	@Description	Records an audited correction without modifying raw_turns, then re-derives the previous and effective sessions. Select exactly one row by raw_turn_id or paper_proxy_request_id.
+//	@Tags			admin
+//	@Accept			json
+//	@Produce		json
+//	@Param			request	body		storage.RawTurnAttributionRepairRequest	true	"Attribution repair"
+//	@Success		200		{object}	storage.RawTurnAttributionRepairResult	"Repair applied; source_cleanup_pending discloses a cosmetic leftover source session row that nothing retries automatically"
+//	@Success		202		{object}	storage.RawTurnAttributionRepairResult	"Correction recorded; projections_pending lists sessions the derive worker will converge"
+//	@Failure		400		{object}	llm.ErrorResponse	"Invalid payload or replacement attribution"
+//	@Failure		404		{object}	llm.ErrorResponse	"Raw turn not found"
+//	@Failure		409		{object}	llm.ErrorResponse	"Correlation selector is ambiguous"
+//	@Failure		500		{object}	llm.ErrorResponse	"Repair failed"
+//	@Failure		501		{object}	llm.ErrorResponse	"Driver does not support attribution repair"
+//	@Router			/v1/admin/raw-turns/attribution-repair [post]
+func (s *Server) handleRawTurnAttributionRepair(c *fiber.Ctx) error {
+	repairer, ok := s.driver.(rawTurnAttributionRepairer)
+	if !ok {
+		return c.Status(fiber.StatusNotImplemented).JSON(llm.ErrorResponse{Error: "driver does not support raw-turn attribution repair"})
+	}
+	var req storage.RawTurnAttributionRepairRequest
+	if err := c.BodyParser(&req); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(llm.ErrorResponse{Error: "invalid payload: " + err.Error()})
+	}
+	if err := validateRawTurnAttributionRepairRequest(req); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(llm.ErrorResponse{Error: err.Error()})
+	}
+	req.OrgID = orgIDFromCtx(c)
+	result, err := repairer.RepairRawTurnAttribution(c.Context(), "", req)
+	if err != nil {
+		switch {
+		case errors.Is(err, storage.ErrRawTurnNotFound):
+			return c.Status(fiber.StatusNotFound).JSON(llm.ErrorResponse{Error: err.Error()})
+		case errors.Is(err, storage.ErrRawTurnAmbiguous):
+			return c.Status(fiber.StatusConflict).JSON(llm.ErrorResponse{Error: err.Error()})
+		case errors.Is(err, storage.ErrRepairProjectionsPending):
+			// The correction committed and is effective; only the synchronous
+			// projection rebuild is outstanding, and the derive queue converges
+			// it. 202 with the result (projections_pending names the stale
+			// sessions) rather than a 500 that would misreport a recorded
+			// repair as a failure and invite a redundant retry.
+			s.logger.Warn("repair raw-turn attribution settling asynchronously", "error", err)
+			return c.Status(fiber.StatusAccepted).JSON(result)
+		default:
+			s.logger.Error("repair raw-turn attribution", "error", err)
+			return c.Status(fiber.StatusInternalServerError).JSON(llm.ErrorResponse{Error: err.Error()})
+		}
+	}
+	return c.JSON(result)
+}
+
+func validateRawTurnAttributionRepairRequest(req storage.RawTurnAttributionRepairRequest) error {
+	if (req.RawTurnID > 0) == (strings.TrimSpace(req.PaperProxyRequestID) != "") {
+		return errors.New("exactly one of raw_turn_id or paper_proxy_request_id is required")
+	}
+	if req.HarnessID == "" {
+		return errors.New("harness_id is required")
+	}
+	if req.HarnessSessionID == "" {
+		return errors.New("harness_session_id is required")
+	}
+	if req.ParentHarnessSessionID != nil && *req.ParentHarnessSessionID == "" {
+		return errors.New("parent_harness_session_id must be omitted instead of empty")
+	}
+	if req.ParentHarnessSessionID != nil && *req.ParentHarnessSessionID == req.HarnessSessionID {
+		return errors.New("a session cannot parent itself")
+	}
+	if strings.TrimSpace(req.Reason) == "" {
+		return errors.New("reason is required")
+	}
+	return nil
 }

--- a/api/api.go
+++ b/api/api.go
@@ -140,6 +140,7 @@ func NewServer(config Config, driver storage.Driver, log *slog.Logger) (*Server,
 
 	app.Post("/v1/admin/seed/demo", s.handleSeedDemo)
 	app.Post("/v1/admin/derive/run", s.handleDeriveRun)
+	app.Post("/v1/admin/raw-turns/attribution-repair", s.handleRawTurnAttributionRepair)
 
 	// API reference UI. Always mounted — the viewer JS comes from a CDN
 	// at view time, so the binary cost is negligible.

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -91,6 +91,66 @@ components:
         output_tokens:
           type: integer
       type: object
+    RawTurnAttribution:
+      properties:
+        harness_id:
+          type: string
+        harness_session_id:
+          type: string
+        parent_harness_session_id:
+          type: string
+        raw_turn_id:
+          type: integer
+        thread_id:
+          type: string
+      type: object
+    RawTurnAttributionRepairRequest:
+      properties:
+        harness_id:
+          type: string
+        harness_session_id:
+          type: string
+        paper_proxy_request_id:
+          type: string
+        parent_harness_session_id:
+          type: string
+        raw_turn_id:
+          type: integer
+        reason:
+          type: string
+        thread_id:
+          type: string
+      type: object
+    RawTurnAttributionRepairResult:
+      properties:
+        effective:
+          $ref: '#/components/schemas/RawTurnAttribution'
+        previous:
+          $ref: '#/components/schemas/RawTurnAttribution'
+        projections_pending:
+          description: |-
+            ProjectionsPending lists the sessions whose synchronous rebuild failed
+            after the correction committed. Empty on full success. When set, the
+            correction is effective at read time and the listed projections
+            converge via the derive queue (marked dirty in the correction
+            transaction); the call returns ErrRepairProjectionsPending alongside
+            this result.
+          items:
+            $ref: '#/components/schemas/RepairPendingSession'
+          type: array
+        recorded:
+          type: boolean
+        source_cleanup_pending:
+          description: |-
+            SourceCleanupPending reports that the best-effort removal of the
+            emptied previous-session row failed after the correction and both
+            projection rebuilds applied. The leftover row is cosmetic — it anchors
+            no effective turns — and nothing retries the deletion automatically:
+            the flag makes the response honest about the leftover, it is not a
+            promise of later cleanup. On its own it never accompanies an error;
+            when ProjectionsPending is empty too, the repair succeeded.
+          type: boolean
+      type: object
     RawTurnHeaderItem:
       properties:
         agent_name:
@@ -201,6 +261,13 @@ components:
           description: |-
             Subject names what was rejected: the configured OpenAPI URL, with any
             credential redacted.
+          type: string
+      type: object
+    RepairPendingSession:
+      properties:
+        harness_id:
+          type: string
+        harness_session_id:
           type: string
       type: object
     SessionDetailResponse:
@@ -887,6 +954,68 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
           description: Driver does not host the raw-turn layer
       summary: Re-derive the span projection (operator)
+      tags:
+      - admin
+  /v1/admin/raw-turns/attribution-repair:
+    post:
+      description: Records an audited correction without modifying raw_turns, then
+        re-derives the previous and effective sessions. Select exactly one row by
+        raw_turn_id or paper_proxy_request_id.
+      operationId: repairRawTurnAttribution
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RawTurnAttributionRepairRequest'
+        description: Attribution repair
+        required: true
+        x-originalParamName: request
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RawTurnAttributionRepairResult'
+          description: Repair applied; source_cleanup_pending discloses a cosmetic
+            leftover source session row that nothing retries automatically
+        "202":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RawTurnAttributionRepairResult'
+          description: Correction recorded; projections_pending lists sessions the
+            derive worker will converge
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Invalid payload or replacement attribution
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Raw turn not found
+        "409":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Correlation selector is ambiguous
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Repair failed
+        "501":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Driver does not support attribution repair
+      summary: Repair raw-turn attribution (operator)
       tags:
       - admin
   /v1/admin/seed/demo:

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -69,6 +69,77 @@ const docTemplate = `{
                 }
             }
         },
+        "/v1/admin/raw-turns/attribution-repair": {
+            "post": {
+                "description": "Records an audited correction without modifying raw_turns, then re-derives the previous and effective sessions. Select exactly one row by raw_turn_id or paper_proxy_request_id.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Repair raw-turn attribution (operator)",
+                "operationId": "repairRawTurnAttribution",
+                "parameters": [
+                    {
+                        "description": "Attribution repair",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/github_com_papercomputeco_tapes_pkg_storage.RawTurnAttributionRepairRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Repair applied; source_cleanup_pending discloses a cosmetic leftover source session row that nothing retries automatically",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_papercomputeco_tapes_pkg_storage.RawTurnAttributionRepairResult"
+                        }
+                    },
+                    "202": {
+                        "description": "Correction recorded; projections_pending lists sessions the derive worker will converge",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_papercomputeco_tapes_pkg_storage.RawTurnAttributionRepairResult"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid payload or replacement attribution",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_papercomputeco_tapes_pkg_llm.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Raw turn not found",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_papercomputeco_tapes_pkg_llm.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Correlation selector is ambiguous",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_papercomputeco_tapes_pkg_llm.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Repair failed",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_papercomputeco_tapes_pkg_llm.ErrorResponse"
+                        }
+                    },
+                    "501": {
+                        "description": "Driver does not support attribution repair",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_papercomputeco_tapes_pkg_llm.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/v1/admin/seed/demo": {
             "post": {
                 "description": "Replays the bundled demo capture corpora through the ingest write path into the caller's org, then derives the seeded sessions. Idempotent: raw-turn dedup makes repeat seeds no-ops.",
@@ -2703,6 +2774,88 @@ const docTemplate = `{
                 "sessions": {
                     "description": "Sessions is the number of demo sessions the corpora replay into.",
                     "type": "integer"
+                }
+            }
+        },
+        "github_com_papercomputeco_tapes_pkg_storage.RawTurnAttribution": {
+            "type": "object",
+            "properties": {
+                "harness_id": {
+                    "type": "string"
+                },
+                "harness_session_id": {
+                    "type": "string"
+                },
+                "parent_harness_session_id": {
+                    "type": "string"
+                },
+                "raw_turn_id": {
+                    "type": "integer"
+                },
+                "thread_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_papercomputeco_tapes_pkg_storage.RawTurnAttributionRepairRequest": {
+            "type": "object",
+            "properties": {
+                "harness_id": {
+                    "type": "string"
+                },
+                "harness_session_id": {
+                    "type": "string"
+                },
+                "paper_proxy_request_id": {
+                    "type": "string"
+                },
+                "parent_harness_session_id": {
+                    "type": "string"
+                },
+                "raw_turn_id": {
+                    "type": "integer"
+                },
+                "reason": {
+                    "type": "string"
+                },
+                "thread_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_papercomputeco_tapes_pkg_storage.RawTurnAttributionRepairResult": {
+            "type": "object",
+            "properties": {
+                "effective": {
+                    "$ref": "#/definitions/github_com_papercomputeco_tapes_pkg_storage.RawTurnAttribution"
+                },
+                "previous": {
+                    "$ref": "#/definitions/github_com_papercomputeco_tapes_pkg_storage.RawTurnAttribution"
+                },
+                "projections_pending": {
+                    "description": "ProjectionsPending lists the sessions whose synchronous rebuild failed\nafter the correction committed. Empty on full success. When set, the\ncorrection is effective at read time and the listed projections\nconverge via the derive queue (marked dirty in the correction\ntransaction); the call returns ErrRepairProjectionsPending alongside\nthis result.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_papercomputeco_tapes_pkg_storage.RepairPendingSession"
+                    }
+                },
+                "recorded": {
+                    "type": "boolean"
+                },
+                "source_cleanup_pending": {
+                    "description": "SourceCleanupPending reports that the best-effort removal of the\nemptied previous-session row failed after the correction and both\nprojection rebuilds applied. The leftover row is cosmetic — it anchors\nno effective turns — and nothing retries the deletion automatically:\nthe flag makes the response honest about the leftover, it is not a\npromise of later cleanup. On its own it never accompanies an error;\nwhen ProjectionsPending is empty too, the repair succeeded.",
+                    "type": "boolean"
+                }
+            }
+        },
+        "github_com_papercomputeco_tapes_pkg_storage.RepairPendingSession": {
+            "type": "object",
+            "properties": {
+                "harness_id": {
+                    "type": "string"
+                },
+                "harness_session_id": {
+                    "type": "string"
                 }
             }
         }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -66,6 +66,77 @@
                 }
             }
         },
+        "/v1/admin/raw-turns/attribution-repair": {
+            "post": {
+                "description": "Records an audited correction without modifying raw_turns, then re-derives the previous and effective sessions. Select exactly one row by raw_turn_id or paper_proxy_request_id.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Repair raw-turn attribution (operator)",
+                "operationId": "repairRawTurnAttribution",
+                "parameters": [
+                    {
+                        "description": "Attribution repair",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/github_com_papercomputeco_tapes_pkg_storage.RawTurnAttributionRepairRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Repair applied; source_cleanup_pending discloses a cosmetic leftover source session row that nothing retries automatically",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_papercomputeco_tapes_pkg_storage.RawTurnAttributionRepairResult"
+                        }
+                    },
+                    "202": {
+                        "description": "Correction recorded; projections_pending lists sessions the derive worker will converge",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_papercomputeco_tapes_pkg_storage.RawTurnAttributionRepairResult"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid payload or replacement attribution",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_papercomputeco_tapes_pkg_llm.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Raw turn not found",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_papercomputeco_tapes_pkg_llm.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Correlation selector is ambiguous",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_papercomputeco_tapes_pkg_llm.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Repair failed",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_papercomputeco_tapes_pkg_llm.ErrorResponse"
+                        }
+                    },
+                    "501": {
+                        "description": "Driver does not support attribution repair",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_papercomputeco_tapes_pkg_llm.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/v1/admin/seed/demo": {
             "post": {
                 "description": "Replays the bundled demo capture corpora through the ingest write path into the caller's org, then derives the seeded sessions. Idempotent: raw-turn dedup makes repeat seeds no-ops.",
@@ -2700,6 +2771,88 @@
                 "sessions": {
                     "description": "Sessions is the number of demo sessions the corpora replay into.",
                     "type": "integer"
+                }
+            }
+        },
+        "github_com_papercomputeco_tapes_pkg_storage.RawTurnAttribution": {
+            "type": "object",
+            "properties": {
+                "harness_id": {
+                    "type": "string"
+                },
+                "harness_session_id": {
+                    "type": "string"
+                },
+                "parent_harness_session_id": {
+                    "type": "string"
+                },
+                "raw_turn_id": {
+                    "type": "integer"
+                },
+                "thread_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_papercomputeco_tapes_pkg_storage.RawTurnAttributionRepairRequest": {
+            "type": "object",
+            "properties": {
+                "harness_id": {
+                    "type": "string"
+                },
+                "harness_session_id": {
+                    "type": "string"
+                },
+                "paper_proxy_request_id": {
+                    "type": "string"
+                },
+                "parent_harness_session_id": {
+                    "type": "string"
+                },
+                "raw_turn_id": {
+                    "type": "integer"
+                },
+                "reason": {
+                    "type": "string"
+                },
+                "thread_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_papercomputeco_tapes_pkg_storage.RawTurnAttributionRepairResult": {
+            "type": "object",
+            "properties": {
+                "effective": {
+                    "$ref": "#/definitions/github_com_papercomputeco_tapes_pkg_storage.RawTurnAttribution"
+                },
+                "previous": {
+                    "$ref": "#/definitions/github_com_papercomputeco_tapes_pkg_storage.RawTurnAttribution"
+                },
+                "projections_pending": {
+                    "description": "ProjectionsPending lists the sessions whose synchronous rebuild failed\nafter the correction committed. Empty on full success. When set, the\ncorrection is effective at read time and the listed projections\nconverge via the derive queue (marked dirty in the correction\ntransaction); the call returns ErrRepairProjectionsPending alongside\nthis result.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_papercomputeco_tapes_pkg_storage.RepairPendingSession"
+                    }
+                },
+                "recorded": {
+                    "type": "boolean"
+                },
+                "source_cleanup_pending": {
+                    "description": "SourceCleanupPending reports that the best-effort removal of the\nemptied previous-session row failed after the correction and both\nprojection rebuilds applied. The leftover row is cosmetic — it anchors\nno effective turns — and nothing retries the deletion automatically:\nthe flag makes the response honest about the leftover, it is not a\npromise of later cleanup. On its own it never accompanies an error;\nwhen ProjectionsPending is empty too, the repair succeeded.",
+                    "type": "boolean"
+                }
+            }
+        },
+        "github_com_papercomputeco_tapes_pkg_storage.RepairPendingSession": {
+            "type": "object",
+            "properties": {
+                "harness_id": {
+                    "type": "string"
+                },
+                "harness_session_id": {
+                    "type": "string"
                 }
             }
         }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -831,6 +831,73 @@ definitions:
         description: Sessions is the number of demo sessions the corpora replay into.
         type: integer
     type: object
+  github_com_papercomputeco_tapes_pkg_storage.RawTurnAttribution:
+    properties:
+      harness_id:
+        type: string
+      harness_session_id:
+        type: string
+      parent_harness_session_id:
+        type: string
+      raw_turn_id:
+        type: integer
+      thread_id:
+        type: string
+    type: object
+  github_com_papercomputeco_tapes_pkg_storage.RawTurnAttributionRepairRequest:
+    properties:
+      harness_id:
+        type: string
+      harness_session_id:
+        type: string
+      paper_proxy_request_id:
+        type: string
+      parent_harness_session_id:
+        type: string
+      raw_turn_id:
+        type: integer
+      reason:
+        type: string
+      thread_id:
+        type: string
+    type: object
+  github_com_papercomputeco_tapes_pkg_storage.RawTurnAttributionRepairResult:
+    properties:
+      effective:
+        $ref: '#/definitions/github_com_papercomputeco_tapes_pkg_storage.RawTurnAttribution'
+      previous:
+        $ref: '#/definitions/github_com_papercomputeco_tapes_pkg_storage.RawTurnAttribution'
+      projections_pending:
+        description: |-
+          ProjectionsPending lists the sessions whose synchronous rebuild failed
+          after the correction committed. Empty on full success. When set, the
+          correction is effective at read time and the listed projections
+          converge via the derive queue (marked dirty in the correction
+          transaction); the call returns ErrRepairProjectionsPending alongside
+          this result.
+        items:
+          $ref: '#/definitions/github_com_papercomputeco_tapes_pkg_storage.RepairPendingSession'
+        type: array
+      recorded:
+        type: boolean
+      source_cleanup_pending:
+        description: |-
+          SourceCleanupPending reports that the best-effort removal of the
+          emptied previous-session row failed after the correction and both
+          projection rebuilds applied. The leftover row is cosmetic — it anchors
+          no effective turns — and nothing retries the deletion automatically:
+          the flag makes the response honest about the leftover, it is not a
+          promise of later cleanup. On its own it never accompanies an error;
+          when ProjectionsPending is empty too, the repair succeeded.
+        type: boolean
+    type: object
+  github_com_papercomputeco_tapes_pkg_storage.RepairPendingSession:
+    properties:
+      harness_id:
+        type: string
+      harness_session_id:
+        type: string
+    type: object
 info:
   contact: {}
   description: |-
@@ -880,6 +947,57 @@ paths:
           schema:
             $ref: '#/definitions/github_com_papercomputeco_tapes_pkg_llm.ErrorResponse'
       summary: Re-derive the span projection (operator)
+      tags:
+      - admin
+  /v1/admin/raw-turns/attribution-repair:
+    post:
+      consumes:
+      - application/json
+      description: Records an audited correction without modifying raw_turns, then
+        re-derives the previous and effective sessions. Select exactly one row by
+        raw_turn_id or paper_proxy_request_id.
+      operationId: repairRawTurnAttribution
+      parameters:
+      - description: Attribution repair
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/github_com_papercomputeco_tapes_pkg_storage.RawTurnAttributionRepairRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Repair applied; source_cleanup_pending discloses a cosmetic
+            leftover source session row that nothing retries automatically
+          schema:
+            $ref: '#/definitions/github_com_papercomputeco_tapes_pkg_storage.RawTurnAttributionRepairResult'
+        "202":
+          description: Correction recorded; projections_pending lists sessions the
+            derive worker will converge
+          schema:
+            $ref: '#/definitions/github_com_papercomputeco_tapes_pkg_storage.RawTurnAttributionRepairResult'
+        "400":
+          description: Invalid payload or replacement attribution
+          schema:
+            $ref: '#/definitions/github_com_papercomputeco_tapes_pkg_llm.ErrorResponse'
+        "404":
+          description: Raw turn not found
+          schema:
+            $ref: '#/definitions/github_com_papercomputeco_tapes_pkg_llm.ErrorResponse'
+        "409":
+          description: Correlation selector is ambiguous
+          schema:
+            $ref: '#/definitions/github_com_papercomputeco_tapes_pkg_llm.ErrorResponse'
+        "500":
+          description: Repair failed
+          schema:
+            $ref: '#/definitions/github_com_papercomputeco_tapes_pkg_llm.ErrorResponse'
+        "501":
+          description: Driver does not support attribution repair
+          schema:
+            $ref: '#/definitions/github_com_papercomputeco_tapes_pkg_llm.ErrorResponse'
+      summary: Repair raw-turn attribution (operator)
       tags:
       - admin
   /v1/admin/seed/demo:

--- a/migrations/1781480000_raw_turn_attribution_corrections.down.sql
+++ b/migrations/1781480000_raw_turn_attribution_corrections.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS raw_turn_attribution_corrections;

--- a/migrations/1781480000_raw_turn_attribution_corrections.up.sql
+++ b/migrations/1781480000_raw_turn_attribution_corrections.up.sql
@@ -1,0 +1,16 @@
+-- Append-only attribution repairs for immutable raw turns. The latest row for
+-- a raw turn is its effective attribution; raw_turns itself is never updated.
+CREATE TABLE raw_turn_attribution_corrections (
+    id                        BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    org_id                    UUID NOT NULL,
+    raw_turn_id               BIGINT NOT NULL,
+    harness_id                TEXT NOT NULL,
+    harness_session_id        TEXT NOT NULL,
+    thread_id                 TEXT NOT NULL DEFAULT '',
+    parent_harness_session_id TEXT,
+    reason                    TEXT NOT NULL,
+    created_at                TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX raw_turn_attribution_corrections_latest_idx
+    ON raw_turn_attribution_corrections (org_id, raw_turn_id, id DESC);

--- a/pkg/storage/errors.go
+++ b/pkg/storage/errors.go
@@ -15,3 +15,22 @@ import "errors"
 // re-attempting it on every poll forever. Drivers wrap the underlying pg
 // error with this sentinel; callers test with errors.Is.
 var ErrInvalidContent = errors.New("invalid content for storage")
+
+var (
+	// ErrRawTurnNotFound means the requested raw turn does not exist in the
+	// caller's organization (including correlation selectors with no match).
+	ErrRawTurnNotFound = errors.New("raw turn not found")
+
+	// ErrRawTurnAmbiguous means a correlation selector matched more than one
+	// immutable raw row and therefore cannot be repaired safely.
+	ErrRawTurnAmbiguous = errors.New("raw turn selector is ambiguous")
+
+	// ErrRepairProjectionsPending means an attribution correction committed —
+	// it is already effective at read time — but at least one synchronous
+	// projection rebuild failed afterwards. The affected sessions stay queued
+	// for the derive worker (the correction transaction marks both dirty), so
+	// the projections converge without operator action. Callers should treat
+	// the repair as accepted-but-settling, not failed: the accompanying
+	// result is valid and lists the still-stale sessions.
+	ErrRepairProjectionsPending = errors.New("attribution correction recorded; projection rebuild pending")
+)

--- a/pkg/storage/postgres/derive.go
+++ b/pkg/storage/postgres/derive.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 	"sort"
 	"time"
 
@@ -16,8 +17,8 @@ import (
 	"github.com/papercomputeco/tapes/pkg/storage/postgres/gensqlc"
 )
 
-// rederivePageSize bounds the raw-turn scan batches.
-const rederivePageSize = 200
+// rederiveDiagnosticLimit matches the deriver's bound for sampled failures.
+const rederiveDiagnosticLimit = 20
 
 // rawTurnIndexEntry is the lightweight ordering record for one raw row.
 type rawTurnIndexEntry struct {
@@ -25,130 +26,83 @@ type rawTurnIndexEntry struct {
 	capturedAt time.Time
 }
 
-// RederiveFromRaw rebuilds the derived node layer from the immutable
-// raw-turn store: every raw turn is re-parsed, re-classified, and
-// re-chained with the CURRENT projection, then written back in one
-// transaction per org — upserting nodes (refreshing derived columns on
-// rows that already exist) and pruning rows in covered sessions whose
-// hashes the current derivation no longer produces (e.g. chains built
-// under a superseded projection).
+// RederiveFromRaw rebuilds every persisted session from its effective raw
+// turns. Sessions are enumerated from the read model rather than from current
+// raw attribution so a repair source that has become empty is still covered
+// and pruned.
 //
-// Memory discipline: the pass first scans a payload-free index (id +
-// capture time), sorts per org chronologically, then streams full rows
-// ONE AT A TIME through the deriver. Each turn's chain re-contains the
-// whole conversation history, so holding all turns at once is O(N²) in
-// content and OOMs a modestly-sized container; the deriver retains
-// only the deduplicated (unique-content) node set.
-//
-// The pass is idempotent: re-running against an unchanged raw layer
-// upserts the same set and prunes nothing. Raw rows are never written.
-//
-// CONCURRENCY (PCC-687 G, partial): unlike RederiveSessionLocked, this
-// whole-org pass does NOT hold the per-session derive lock, so running it
-// while the derive worker is live can still race — this pass reads the
-// whole org's raw UP FRONT, and a turn the worker writes after that read
-// but before this pass's prune is deleted as "not in my set". A write-only
-// lock does not fix this: the stale READ is the defect, so a correct fix
-// must read-and-write each session under its lock — i.e. reimplement this
-// as a loop of RederiveSessionLocked calls, trading the org-wide single
-// deriver (and its cross-session dedup + one-tx-per-org atomicity) for the
-// worker's per-session model. That trade is a design decision left for a
-// human; the session-scoped race (seed, ad-hoc re-derive) is closed by
-// RederiveSessionLocked in the meantime.
+// Each session's full read-derive-write pass runs under the same advisory lock
+// used by the derive worker and attribution repair. Holding one lock at a time
+// avoids both stale-read races and lock cycles with repair's ordered two-lock
+// acquisition. The pass is atomic per session, not per org; reports retain the
+// existing per-org shape by aggregating session reports.
 func (d *Driver) RederiveFromRaw(ctx context.Context, project string) (map[string]*derive.RederiveReport, error) {
 	if d == nil || d.conn == nil {
 		return nil, errors.New("postgres driver not open")
 	}
-
-	// Index scan: identity + timing only. Wire rows feed the chain
-	// deriver in capture order; transcript rows are routed to the
-	// reconciler, keeping only the LATEST version per (session, agent)
-	// — transcript ingest appends a new row each time a file grows.
-	byOrg := map[string][]rawTurnIndexEntry{}
-	transcriptRows := map[string]map[string]int64{} // org → fileKey → latest raw id
-	var afterID int64
-	for {
-		page, err := d.q.ListRawTurnIndex(ctx, gensqlc.ListRawTurnIndexParams{
-			AfterID:  afterID,
-			PageSize: rederivePageSize,
-		})
-		if err != nil {
-			return nil, fmt.Errorf("list raw turn index: %w", err)
-		}
-		if len(page) == 0 {
-			break
-		}
-		for _, row := range page {
-			afterID = row.ID
-			org := uuidString(row.OrgID)
-			if row.Source == storage.RawTurnSourceTranscript {
-				if transcriptRows[org] == nil {
-					transcriptRows[org] = map[string]int64{}
-				}
-				fileKey := row.HarnessSessionID + "/" + transcriptAgentKey(row.Meta)
-				if row.ID > transcriptRows[org][fileKey] {
-					transcriptRows[org][fileKey] = row.ID
-				}
-				continue
-			}
-			rec := storage.RawTurnRecord{ID: row.ID, Meta: row.Meta, ReceivedAt: row.ReceivedAt.Time}
-			byOrg[org] = append(byOrg[org], rawTurnIndexEntry{
-				id:         row.ID,
-				capturedAt: derive.CapturedAt(&rec),
-			})
-		}
+	keys, err := d.q.ListSessionsForRederive(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list sessions for rederive: %w", err)
 	}
-
-	reports := make(map[string]*derive.RederiveReport, len(byOrg))
-	for orgKey, index := range byOrg {
-		sort.SliceStable(index, func(i, j int) bool { return index[i].capturedAt.Before(index[j].capturedAt) })
-
-		dv, err := derive.NewDeriver(project)
+	reports := make(map[string]*derive.RederiveReport)
+	for _, key := range keys {
+		orgID := uuidString(key.OrgID)
+		report, err := d.RederiveSessionLocked(ctx, project, orgID, key.HarnessID, key.HarnessSessionID)
 		if err != nil {
-			return nil, fmt.Errorf("create deriver: %w", err)
+			return nil, fmt.Errorf("rederive session %s/%s/%s: %w", orgID, key.HarnessID, key.HarnessSessionID, err)
 		}
-		for _, entry := range index {
-			row, err := d.q.GetRawTurn(ctx, entry.id)
-			if err != nil {
-				return nil, fmt.Errorf("fetch raw turn %d: %w", entry.id, err)
-			}
-			rec := rawTurnRecordFromRow(rawTurnFromDeriveRow(row))
-			recoverReduction(ctx, d.reducers, d.logger, &rec)
-			dv.AddTurn(&rec)
+		displayOrg := orgDisplayKey(orgID)
+		if reports[displayOrg] == nil {
+			reports[displayOrg] = newRederiveReport()
 		}
-		set := dv.Finish()
-
-		// Fuse the causal/fork skeleton from any transcript rows. The
-		// rows come out of a map, so sort by raw id first: on no-thread-id
-		// chains the reconciler's overlap tie-break is first-wins, and a
-		// nondeterministic file order would flip which parent_tool_use_id
-		// is stamped across re-derives.
-		transcriptIDs := make([]int64, 0, len(transcriptRows[orgKey]))
-		for _, id := range transcriptRows[orgKey] {
-			transcriptIDs = append(transcriptIDs, id)
-		}
-		sort.SliceStable(transcriptIDs, func(i, j int) bool { return transcriptIDs[i] < transcriptIDs[j] })
-		var files []*derive.TranscriptFile
-		for _, id := range transcriptIDs {
-			row, err := d.q.GetRawTurn(ctx, id)
-			if err != nil {
-				return nil, fmt.Errorf("fetch transcript row %d: %w", id, err)
-			}
-			rec := rawTurnRecordFromRow(rawTurnFromDeriveRow(row))
-			file, err := derive.ParseTranscriptFile(&rec)
-			if err != nil {
-				return nil, fmt.Errorf("parse transcript row %d: %w", id, err)
-			}
-			files = append(files, file)
-		}
-		set.Report.Reconcile = derive.ReconcileTranscripts(set, files)
-
-		if err := d.writeDerivedSet(ctx, orgKey, set); err != nil {
-			return nil, fmt.Errorf("write derived set for org %s: %w", orgKey, err)
-		}
-		reports[orgDisplayKey(orgKey)] = &set.Report
+		mergeRederiveReport(reports[displayOrg], report)
 	}
 	return reports, nil
+}
+
+func newRederiveReport() *derive.RederiveReport {
+	return &derive.RederiveReport{CallKinds: map[string]int{}, NodeKinds: map[string]int{}}
+}
+
+func mergeRederiveReport(dst, src *derive.RederiveReport) {
+	dst.RawTurns += src.RawTurns
+	dst.ParsedTurns += src.ParsedTurns
+	dst.RawOnlyTurns += src.RawOnlyTurns
+	dst.Nodes += src.Nodes
+	dst.JudgedActions += src.JudgedActions
+	dst.AttachedVerdicts += src.AttachedVerdicts
+	dst.WebSummaryAttached += src.WebSummaryAttached
+	dst.PlansAttached += src.PlansAttached
+	dst.ParseFailures = appendBounded(dst.ParseFailures, src.ParseFailures, rederiveDiagnosticLimit)
+	dst.UnattachedActions = appendBounded(dst.UnattachedActions, src.UnattachedActions, rederiveDiagnosticLimit)
+	for kind, count := range src.CallKinds {
+		dst.CallKinds[kind] += count
+	}
+	for kind, count := range src.NodeKinds {
+		dst.NodeKinds[kind] += count
+	}
+	if src.Reconcile != nil {
+		if dst.Reconcile == nil {
+			dst.Reconcile = &derive.ReconcileStats{}
+		}
+		dst.Reconcile.TranscriptFiles += src.Reconcile.TranscriptFiles
+		dst.Reconcile.SubagentForks += src.Reconcile.SubagentForks
+		dst.Reconcile.ForkedChains += src.Reconcile.ForkedChains
+		dst.Reconcile.MainChainsJoined += src.Reconcile.MainChainsJoined
+		dst.Reconcile.ConversationJoined += src.Reconcile.ConversationJoined
+		dst.Reconcile.ConversationTotal += src.Reconcile.ConversationTotal
+	}
+}
+
+func appendBounded(dst, src []string, limit int) []string {
+	remaining := limit - len(dst)
+	if remaining <= 0 {
+		return dst
+	}
+	if len(src) > remaining {
+		src = src[:remaining]
+	}
+	return append(dst, src...)
 }
 
 // RederiveSession is the session-scoped sibling of RederiveFromRaw:
@@ -205,11 +159,16 @@ func (d *Driver) RederiveSession(ctx context.Context, project, orgID, harnessID,
 		if err != nil {
 			return nil, fmt.Errorf("fetch raw turn %d: %w", entry.id, err)
 		}
-		rec := rawTurnRecordFromRow(rawTurnFromDeriveRow(row))
+		rec := rawTurnRecordFromEffectiveRow(row)
 		recoverReduction(ctx, d.reducers, d.logger, &rec)
 		dv.AddTurn(&rec)
 	}
 	set := dv.Finish()
+	requestedKey := derive.SessionKey{HarnessID: harnessID, HarnessSessionID: harnessSessionID}
+	covered := slices.Contains(set.Sessions, requestedKey)
+	if !covered {
+		set.Sessions = append(set.Sessions, requestedKey)
+	}
 
 	// Fuse the causal/fork skeleton from the session's transcript rows.
 	// The rows come out of a map, so sort by raw id first: on no-thread-id
@@ -227,7 +186,7 @@ func (d *Driver) RederiveSession(ctx context.Context, project, orgID, harnessID,
 		if err != nil {
 			return nil, fmt.Errorf("fetch transcript row %d: %w", id, err)
 		}
-		rec := rawTurnRecordFromRow(rawTurnFromDeriveRow(row))
+		rec := rawTurnRecordFromEffectiveRow(row)
 		file, err := derive.ParseTranscriptFile(&rec)
 		if err != nil {
 			return nil, fmt.Errorf("parse transcript row %d: %w", id, err)

--- a/pkg/storage/postgres/export_test.go
+++ b/pkg/storage/postgres/export_test.go
@@ -6,12 +6,42 @@ import (
 
 	"github.com/jackc/pgx/v5/pgtype"
 
+	"github.com/papercomputeco/tapes/pkg/derive"
 	"github.com/papercomputeco/tapes/pkg/storage"
 	"github.com/papercomputeco/tapes/pkg/storage/postgres/gensqlc"
 )
 
 func ToMigrateDSNForTest(dsn string) string {
 	return toMigrateDSN(dsn)
+}
+
+// SetRepairRederiveForTest swaps the synchronous rebuild the attribution
+// repair flow runs for each affected session, so a test can force a
+// mid-flight rederive failure (correction committed, one projection rebuilt,
+// the other stale) — a state with no black-box trigger. Returns a restore
+// func; the ginkgo specs run sequentially, so swapping the package variable
+// is race-free.
+func SetRepairRederiveForTest(
+	fn func(*Driver, context.Context, string, string, string, string) (*derive.RederiveReport, error),
+) (restore func()) {
+	prev := repairRederive
+	repairRederive = fn
+	return func() { repairRederive = prev }
+}
+
+// SetRepairSourceCleanupForTest swaps the best-effort deletion of the emptied
+// repair source session, so a test can force a cleanup-only failure after the
+// correction and both projection rebuilds applied — like the rederive seam, a
+// state with no black-box trigger. Returns a restore func; the ginkgo specs
+// run sequentially, so swapping the package variable is race-free.
+func SetRepairSourceCleanupForTest(
+	fn func(d *Driver, ctx context.Context, orgID pgtype.UUID, harnessID, harnessSessionID string) error,
+) (restore func()) {
+	prev := repairSourceCleanup
+	repairSourceCleanup = func(d *Driver, ctx context.Context, orgID pgtype.UUID, key repairSessionKey) error {
+		return fn(d, ctx, orgID, key.harnessID, key.harnessSessionID)
+	}
+	return func() { repairSourceCleanup = prev }
 }
 
 // SpanTurnUpsertForTest runs the real UpsertSpanTurn query so a test can
@@ -96,7 +126,7 @@ func (d *Driver) RawTurnsForDeriveForTest(ctx context.Context, orgID pgtype.UUID
 		if err != nil {
 			return nil, err
 		}
-		rec := rawTurnRecordFromRow(rawTurnFromDeriveRow(row))
+		rec := rawTurnRecordFromEffectiveRow(row)
 		recoverReduction(ctx, d.reducers, d.logger, &rec)
 		recs = append(recs, rec)
 	}

--- a/pkg/storage/postgres/gensqlc/derive.sql.go
+++ b/pkg/storage/postgres/gensqlc/derive.sql.go
@@ -12,18 +12,42 @@ import (
 )
 
 const getRawTurn = `-- name: GetRawTurn :one
-SELECT id, org_id, source, provider, agent_name,
-       harness_id, harness_session_id, request_id,
-       raw_request, response, meta, session_envelope, received_at,
+SELECT r.id, r.org_id, r.source, r.provider, r.agent_name,
+       COALESCE(c.harness_id, r.harness_id) AS harness_id,
+       COALESCE(c.harness_session_id, r.harness_session_id) AS harness_session_id,
+       r.request_id, r.raw_request, r.response,
+       (CASE WHEN c.id IS NULL THEN r.meta
+             ELSE jsonb_set(r.meta, '{thread_id}', to_jsonb(c.thread_id), true)
+        END)::jsonb AS meta,
+       (CASE WHEN c.id IS NULL THEN r.session_envelope
+             WHEN c.parent_harness_session_id IS NULL THEN
+                  (COALESCE(r.session_envelope, '{}'::jsonb) - 'parent_harness_session_id') ||
+                  jsonb_build_object(
+                      'harness_id', c.harness_id,
+                      'harness_session_id', c.harness_session_id
+                  )
+             ELSE COALESCE(r.session_envelope, '{}'::jsonb) || jsonb_build_object(
+                      'harness_id', c.harness_id,
+                      'harness_session_id', c.harness_session_id,
+                      'parent_harness_session_id', c.parent_harness_session_id
+                  )
+        END)::jsonb AS session_envelope,
+       r.received_at,
        CASE
-           WHEN jsonb_typeof(response -> 'message' -> 'content') = 'array'
-                AND jsonb_array_length(response -> 'message' -> 'content') > 0
+           WHEN jsonb_typeof(r.response -> 'message' -> 'content') = 'array'
+                AND jsonb_array_length(r.response -> 'message' -> 'content') > 0
            THEN NULL
-           ELSE raw_response
+           ELSE r.raw_response
        END::bytea AS raw_response,
-       raw_response_encoding
-FROM raw_turns
-WHERE id = $1
+       r.raw_response_encoding
+FROM raw_turns r
+LEFT JOIN LATERAL (
+    SELECT id, harness_id, harness_session_id, thread_id, parent_harness_session_id
+    FROM raw_turn_attribution_corrections
+    WHERE org_id = r.org_id AND raw_turn_id = r.id
+    ORDER BY id DESC LIMIT 1
+) c ON TRUE
+WHERE r.id = $1
 `
 
 type GetRawTurnRow struct {
@@ -44,8 +68,12 @@ type GetRawTurnRow struct {
 	RawResponseEncoding string
 }
 
-// The derive read. raw_response is selected ONLY for turns whose reduction is
-// missing its content blocks — the shape the deriver skips.
+// The derive read, through the attribution-correction overlay: identity
+// columns COALESCE to the latest correction, meta's thread_id is overridden
+// when corrected, and the session envelope is rewritten to match.
+//
+// raw_response is selected ONLY for turns whose reduction is missing its
+// content blocks — the shape the deriver skips.
 //
 // The column runs to the ingest cap, so selecting it unconditionally would pull
 // megabytes through every derive read to be discarded. Selecting it never is
@@ -82,10 +110,19 @@ func (q *Queries) GetRawTurn(ctx context.Context, id int64) (GetRawTurnRow, erro
 }
 
 const listRawTurnIndex = `-- name: ListRawTurnIndex :many
-SELECT id, org_id, source, harness_id, harness_session_id, received_at, meta
-FROM raw_turns
-WHERE id > $1
-ORDER BY id
+SELECT r.id, r.org_id, r.source,
+       COALESCE(c.harness_id, r.harness_id) AS harness_id,
+       COALESCE(c.harness_session_id, r.harness_session_id) AS harness_session_id,
+       r.received_at, r.meta
+FROM raw_turns r
+LEFT JOIN LATERAL (
+    SELECT harness_id, harness_session_id
+    FROM raw_turn_attribution_corrections
+    WHERE org_id = r.org_id AND raw_turn_id = r.id
+    ORDER BY id DESC LIMIT 1
+) c ON TRUE
+WHERE r.id > $1
+ORDER BY r.id
 LIMIT $2
 `
 
@@ -125,6 +162,41 @@ func (q *Queries) ListRawTurnIndex(ctx context.Context, arg ListRawTurnIndexPara
 			&i.ReceivedAt,
 			&i.Meta,
 		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listSessionsForRederive = `-- name: ListSessionsForRederive :many
+SELECT org_id, harness_id, harness_session_id
+FROM sessions
+ORDER BY org_id, harness_id, harness_session_id
+`
+
+type ListSessionsForRederiveRow struct {
+	OrgID            pgtype.UUID
+	HarnessID        string
+	HarnessSessionID string
+}
+
+// Whole-store rederive enumerates persisted identities, including sessions
+// whose last effective raw turn was repaired away, so their stale projection
+// is still covered and pruned.
+func (q *Queries) ListSessionsForRederive(ctx context.Context) ([]ListSessionsForRederiveRow, error) {
+	rows, err := q.db.Query(ctx, listSessionsForRederive)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListSessionsForRederiveRow
+	for rows.Next() {
+		var i ListSessionsForRederiveRow
+		if err := rows.Scan(&i.OrgID, &i.HarnessID, &i.HarnessSessionID); err != nil {
 			return nil, err
 		}
 		items = append(items, i)

--- a/pkg/storage/postgres/gensqlc/derive_queue.sql.go
+++ b/pkg/storage/postgres/gensqlc/derive_queue.sql.go
@@ -143,12 +143,27 @@ func (q *Queries) ListDeriveDirty(ctx context.Context, arg ListDeriveDirtyParams
 }
 
 const listRawTurnIndexBySession = `-- name: ListRawTurnIndexBySession :many
-SELECT id, org_id, source, harness_id, harness_session_id, received_at, meta
-FROM raw_turns
-WHERE org_id = $1
-  AND harness_id = $2
-  AND harness_session_id = $3
-ORDER BY id
+SELECT r.id, r.org_id, r.source,
+       COALESCE((SELECT c.harness_id
+                 FROM raw_turn_attribution_corrections c
+                 WHERE c.org_id = r.org_id AND c.raw_turn_id = r.id
+                 ORDER BY c.id DESC LIMIT 1), r.harness_id) AS harness_id,
+       COALESCE((SELECT c.harness_session_id
+                 FROM raw_turn_attribution_corrections c
+                 WHERE c.org_id = r.org_id AND c.raw_turn_id = r.id
+                 ORDER BY c.id DESC LIMIT 1), r.harness_session_id) AS harness_session_id,
+       r.received_at, r.meta
+FROM raw_turns r
+WHERE r.org_id = $1
+  AND COALESCE((SELECT c.harness_id
+                FROM raw_turn_attribution_corrections c
+                WHERE c.org_id = r.org_id AND c.raw_turn_id = r.id
+                ORDER BY c.id DESC LIMIT 1), r.harness_id) = $2
+  AND COALESCE((SELECT c.harness_session_id
+                FROM raw_turn_attribution_corrections c
+                WHERE c.org_id = r.org_id AND c.raw_turn_id = r.id
+                ORDER BY c.id DESC LIMIT 1), r.harness_session_id) = $3
+ORDER BY r.id
 `
 
 type ListRawTurnIndexBySessionParams struct {
@@ -250,10 +265,18 @@ func (q *Queries) NextDeriveSeq(ctx context.Context) (int64, error) {
 
 const sweepDeriveDirty = `-- name: SweepDeriveDirty :execrows
 INSERT INTO derive_queue (org_id, harness_id, harness_session_id)
-SELECT DISTINCT org_id, harness_id, harness_session_id
-FROM raw_turns
-WHERE harness_session_id <> ''
-  AND received_at >= $1
+SELECT DISTINCT r.org_id,
+       COALESCE(c.harness_id, r.harness_id),
+       COALESCE(c.harness_session_id, r.harness_session_id)
+FROM raw_turns r
+LEFT JOIN LATERAL (
+    SELECT harness_id, harness_session_id
+    FROM raw_turn_attribution_corrections
+    WHERE org_id = r.org_id AND raw_turn_id = r.id
+    ORDER BY id DESC LIMIT 1
+) c ON TRUE
+WHERE COALESCE(c.harness_session_id, r.harness_session_id) <> ''
+  AND r.received_at >= $1
 ON CONFLICT (org_id, harness_id, harness_session_id) DO NOTHING
 `
 

--- a/pkg/storage/postgres/gensqlc/models.go
+++ b/pkg/storage/postgres/gensqlc/models.go
@@ -43,6 +43,18 @@ type RawTurn struct {
 	RawResponseDropped  bool
 }
 
+type RawTurnAttributionCorrection struct {
+	ID                     int64
+	OrgID                  pgtype.UUID
+	RawTurnID              int64
+	HarnessID              string
+	HarnessSessionID       string
+	ThreadID               string
+	ParentHarnessSessionID pgtype.Text
+	Reason                 string
+	CreatedAt              pgtype.Timestamptz
+}
+
 type Session struct {
 	ID                pgtype.UUID
 	OrgID             pgtype.UUID

--- a/pkg/storage/postgres/gensqlc/raw_turns.sql.go
+++ b/pkg/storage/postgres/gensqlc/raw_turns.sql.go
@@ -22,6 +22,96 @@ func (q *Queries) CountRawTurns(ctx context.Context) (int64, error) {
 	return count, err
 }
 
+const findRawTurnIDsByPaperProxyRequestID = `-- name: FindRawTurnIDsByPaperProxyRequestID :many
+SELECT id
+FROM raw_turns
+WHERE org_id = $1
+  AND session_envelope->'harness_metadata'->>'paperProxyRequestId' = $2::text
+ORDER BY id
+LIMIT 2
+`
+
+type FindRawTurnIDsByPaperProxyRequestIDParams struct {
+	OrgID               pgtype.UUID
+	PaperProxyRequestID string
+}
+
+func (q *Queries) FindRawTurnIDsByPaperProxyRequestID(ctx context.Context, arg FindRawTurnIDsByPaperProxyRequestIDParams) ([]int64, error) {
+	rows, err := q.db.Query(ctx, findRawTurnIDsByPaperProxyRequestID, arg.OrgID, arg.PaperProxyRequestID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		items = append(items, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const getRawTurnAttributionForUpdate = `-- name: GetRawTurnAttributionForUpdate :one
+SELECT r.id, r.org_id, r.session_envelope, r.received_at,
+       COALESCE(c.harness_id, r.harness_id) AS harness_id,
+       COALESCE(c.harness_session_id, r.harness_session_id) AS harness_session_id,
+       COALESCE(c.thread_id, r.meta->>'thread_id', '') AS thread_id,
+       (c.id IS NOT NULL)::boolean AS has_correction,
+       COALESCE(c.parent_harness_session_id, '') AS corrected_parent_harness_session_id,
+       COALESCE(r.session_envelope->>'parent_harness_session_id', '')::text AS raw_parent_harness_session_id
+FROM raw_turns r
+LEFT JOIN LATERAL (
+    SELECT id, harness_id, harness_session_id, thread_id, parent_harness_session_id
+    FROM raw_turn_attribution_corrections
+    WHERE org_id = r.org_id AND raw_turn_id = r.id
+    ORDER BY id DESC LIMIT 1
+) c ON TRUE
+WHERE r.org_id = $1 AND r.id = $2
+FOR UPDATE OF r
+`
+
+type GetRawTurnAttributionForUpdateParams struct {
+	OrgID     pgtype.UUID
+	RawTurnID int64
+}
+
+type GetRawTurnAttributionForUpdateRow struct {
+	ID                              int64
+	OrgID                           pgtype.UUID
+	SessionEnvelope                 []byte
+	ReceivedAt                      pgtype.Timestamptz
+	HarnessID                       string
+	HarnessSessionID                string
+	ThreadID                        string
+	HasCorrection                   bool
+	CorrectedParentHarnessSessionID string
+	RawParentHarnessSessionID       string
+}
+
+// Locks the immutable row as a serialization point for competing repairs.
+func (q *Queries) GetRawTurnAttributionForUpdate(ctx context.Context, arg GetRawTurnAttributionForUpdateParams) (GetRawTurnAttributionForUpdateRow, error) {
+	row := q.db.QueryRow(ctx, getRawTurnAttributionForUpdate, arg.OrgID, arg.RawTurnID)
+	var i GetRawTurnAttributionForUpdateRow
+	err := row.Scan(
+		&i.ID,
+		&i.OrgID,
+		&i.SessionEnvelope,
+		&i.ReceivedAt,
+		&i.HarnessID,
+		&i.HarnessSessionID,
+		&i.ThreadID,
+		&i.HasCorrection,
+		&i.CorrectedParentHarnessSessionID,
+		&i.RawParentHarnessSessionID,
+	)
+	return i, err
+}
+
 const insertRawTurn = `-- name: InsertRawTurn :execrows
 INSERT INTO raw_turns (
     org_id, source, provider, agent_name,
@@ -83,16 +173,69 @@ func (q *Queries) InsertRawTurn(ctx context.Context, arg InsertRawTurnParams) (i
 	return result.RowsAffected(), nil
 }
 
+const insertRawTurnAttributionCorrection = `-- name: InsertRawTurnAttributionCorrection :exec
+INSERT INTO raw_turn_attribution_corrections (
+    org_id, raw_turn_id, harness_id, harness_session_id, thread_id,
+    parent_harness_session_id, reason
+) VALUES (
+    $1, $2, $3,
+    $4, $5,
+    $6, $7
+)
+`
+
+type InsertRawTurnAttributionCorrectionParams struct {
+	OrgID                  pgtype.UUID
+	RawTurnID              int64
+	HarnessID              string
+	HarnessSessionID       string
+	ThreadID               string
+	ParentHarnessSessionID pgtype.Text
+	Reason                 string
+}
+
+func (q *Queries) InsertRawTurnAttributionCorrection(ctx context.Context, arg InsertRawTurnAttributionCorrectionParams) error {
+	_, err := q.db.Exec(ctx, insertRawTurnAttributionCorrection,
+		arg.OrgID,
+		arg.RawTurnID,
+		arg.HarnessID,
+		arg.HarnessSessionID,
+		arg.ThreadID,
+		arg.ParentHarnessSessionID,
+		arg.Reason,
+	)
+	return err
+}
+
 const listRawTurnHeadersBySession = `-- name: ListRawTurnHeadersBySession :many
-SELECT id, org_id, source, provider, agent_name, request_id,
-       received_at, meta,
-       COALESCE(length(raw_request::text), 0)::bigint AS request_bytes,
-       COALESCE(length(response::text), 0)::bigint AS response_bytes,
-       COALESCE(octet_length(raw_response), 0)::bigint AS raw_response_bytes,
-       raw_response_dropped
-FROM raw_turns
-WHERE org_id = $1 AND harness_id = $2 AND harness_session_id = $3
-ORDER BY id ASC
+SELECT r.id, r.org_id, r.source, r.provider, r.agent_name, r.request_id,
+       r.received_at,
+       (CASE WHEN c.id IS NULL THEN r.meta
+             ELSE jsonb_set(r.meta, '{thread_id}', to_jsonb(c.thread_id), true)
+        END)::jsonb AS meta,
+       COALESCE(length(r.raw_request::text), 0)::bigint AS request_bytes,
+       COALESCE(length(r.response::text), 0)::bigint AS response_bytes,
+       COALESCE(octet_length(r.raw_response), 0)::bigint AS raw_response_bytes,
+       r.raw_response_dropped
+FROM raw_turns r
+LEFT JOIN LATERAL (
+    SELECT id, harness_id, harness_session_id, thread_id
+    FROM raw_turn_attribution_corrections
+    WHERE org_id = r.org_id AND raw_turn_id = r.id
+    ORDER BY id DESC LIMIT 1
+) c ON TRUE
+WHERE r.org_id = $1
+  AND COALESCE((
+      SELECT c2.harness_id FROM raw_turn_attribution_corrections c2
+      WHERE c2.org_id = r.org_id AND c2.raw_turn_id = r.id
+      ORDER BY c2.id DESC LIMIT 1
+  ), r.harness_id) = $2
+  AND COALESCE((
+      SELECT c2.harness_session_id FROM raw_turn_attribution_corrections c2
+      WHERE c2.org_id = r.org_id AND c2.raw_turn_id = r.id
+      ORDER BY c2.id DESC LIMIT 1
+  ), r.harness_session_id) = $3
+ORDER BY r.id ASC
 `
 
 type ListRawTurnHeadersBySessionParams struct {
@@ -152,13 +295,37 @@ func (q *Queries) ListRawTurnHeadersBySession(ctx context.Context, arg ListRawTu
 }
 
 const listRawTurns = `-- name: ListRawTurns :many
-SELECT id, org_id, source, provider, agent_name,
-       harness_id, harness_session_id, request_id,
-       raw_request, response, meta, session_envelope, received_at,
-       raw_response, raw_response_encoding, raw_response_dropped
-FROM raw_turns
-WHERE id > $1
-ORDER BY id
+SELECT r.id, r.org_id, r.source, r.provider, r.agent_name,
+       COALESCE(c.harness_id, r.harness_id) AS harness_id,
+       COALESCE(c.harness_session_id, r.harness_session_id) AS harness_session_id,
+       r.request_id, r.raw_request, r.response,
+       (CASE WHEN c.id IS NULL THEN r.meta
+             ELSE jsonb_set(r.meta, '{thread_id}', to_jsonb(c.thread_id), true)
+        END)::jsonb AS meta,
+       (CASE WHEN c.id IS NULL THEN r.session_envelope
+             WHEN c.parent_harness_session_id IS NULL THEN
+                  (COALESCE(r.session_envelope, '{}'::jsonb) - 'parent_harness_session_id') ||
+                  jsonb_build_object(
+                      'harness_id', c.harness_id,
+                      'harness_session_id', c.harness_session_id
+                  )
+             ELSE COALESCE(r.session_envelope, '{}'::jsonb) || jsonb_build_object(
+                      'harness_id', c.harness_id,
+                      'harness_session_id', c.harness_session_id,
+                      'parent_harness_session_id', c.parent_harness_session_id
+                  )
+        END)::jsonb AS session_envelope,
+       r.received_at,
+       r.raw_response, r.raw_response_encoding, r.raw_response_dropped
+FROM raw_turns r
+LEFT JOIN LATERAL (
+    SELECT id, harness_id, harness_session_id, thread_id, parent_harness_session_id
+    FROM raw_turn_attribution_corrections
+    WHERE org_id = r.org_id AND raw_turn_id = r.id
+    ORDER BY id DESC LIMIT 1
+) c ON TRUE
+WHERE r.id > $1
+ORDER BY r.id
 LIMIT $2
 `
 
@@ -167,17 +334,36 @@ type ListRawTurnsParams struct {
 	PageSize int32
 }
 
+type ListRawTurnsRow struct {
+	ID                  int64
+	OrgID               pgtype.UUID
+	Source              string
+	Provider            string
+	AgentName           string
+	HarnessID           string
+	HarnessSessionID    string
+	RequestID           string
+	RawRequest          []byte
+	Response            []byte
+	Meta                []byte
+	SessionEnvelope     []byte
+	ReceivedAt          pgtype.Timestamptz
+	RawResponse         []byte
+	RawResponseEncoding string
+	RawResponseDropped  bool
+}
+
 // Keyset-paginated scan in insertion order, for the re-runnable deriver.
 // Pass after_id = 0 to start from the beginning.
-func (q *Queries) ListRawTurns(ctx context.Context, arg ListRawTurnsParams) ([]RawTurn, error) {
+func (q *Queries) ListRawTurns(ctx context.Context, arg ListRawTurnsParams) ([]ListRawTurnsRow, error) {
 	rows, err := q.db.Query(ctx, listRawTurns, arg.AfterID, arg.PageSize)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []RawTurn
+	var items []ListRawTurnsRow
 	for rows.Next() {
-		var i RawTurn
+		var i ListRawTurnsRow
 		if err := rows.Scan(
 			&i.ID,
 			&i.OrgID,
@@ -207,14 +393,42 @@ func (q *Queries) ListRawTurns(ctx context.Context, arg ListRawTurnsParams) ([]R
 }
 
 const listRawTurnsBySession = `-- name: ListRawTurnsBySession :many
-SELECT id, org_id, source, provider, agent_name,
-       harness_id, harness_session_id, request_id,
-       raw_request, response, meta, session_envelope, received_at,
-       raw_response, raw_response_encoding, raw_response_dropped
-FROM raw_turns
-WHERE org_id = $1
-  AND harness_session_id = $2
-ORDER BY id
+SELECT r.id, r.org_id, r.source, r.provider, r.agent_name,
+       COALESCE(c.harness_id, r.harness_id) AS harness_id,
+       COALESCE(c.harness_session_id, r.harness_session_id) AS harness_session_id,
+       r.request_id, r.raw_request, r.response,
+       (CASE WHEN c.id IS NULL THEN r.meta
+             ELSE jsonb_set(r.meta, '{thread_id}', to_jsonb(c.thread_id), true)
+        END)::jsonb AS meta,
+       (CASE WHEN c.id IS NULL THEN r.session_envelope
+             WHEN c.parent_harness_session_id IS NULL THEN
+                  (COALESCE(r.session_envelope, '{}'::jsonb) - 'parent_harness_session_id') ||
+                  jsonb_build_object(
+                      'harness_id', c.harness_id,
+                      'harness_session_id', c.harness_session_id
+                  )
+             ELSE COALESCE(r.session_envelope, '{}'::jsonb) || jsonb_build_object(
+                      'harness_id', c.harness_id,
+                      'harness_session_id', c.harness_session_id,
+                      'parent_harness_session_id', c.parent_harness_session_id
+                  )
+        END)::jsonb AS session_envelope,
+       r.received_at,
+       r.raw_response, r.raw_response_encoding, r.raw_response_dropped
+FROM raw_turns r
+LEFT JOIN LATERAL (
+    SELECT id, harness_id, harness_session_id, thread_id, parent_harness_session_id
+    FROM raw_turn_attribution_corrections
+    WHERE org_id = r.org_id AND raw_turn_id = r.id
+    ORDER BY id DESC LIMIT 1
+) c ON TRUE
+WHERE r.org_id = $1
+  AND COALESCE((
+      SELECT c2.harness_session_id FROM raw_turn_attribution_corrections c2
+      WHERE c2.org_id = r.org_id AND c2.raw_turn_id = r.id
+      ORDER BY c2.id DESC LIMIT 1
+  ), r.harness_session_id) = $2
+ORDER BY r.id
 `
 
 type ListRawTurnsBySessionParams struct {
@@ -222,16 +436,35 @@ type ListRawTurnsBySessionParams struct {
 	HarnessSessionID string
 }
 
+type ListRawTurnsBySessionRow struct {
+	ID                  int64
+	OrgID               pgtype.UUID
+	Source              string
+	Provider            string
+	AgentName           string
+	HarnessID           string
+	HarnessSessionID    string
+	RequestID           string
+	RawRequest          []byte
+	Response            []byte
+	Meta                []byte
+	SessionEnvelope     []byte
+	ReceivedAt          pgtype.Timestamptz
+	RawResponse         []byte
+	RawResponseEncoding string
+	RawResponseDropped  bool
+}
+
 // Every raw turn captured for one harness session, in insertion order.
-func (q *Queries) ListRawTurnsBySession(ctx context.Context, arg ListRawTurnsBySessionParams) ([]RawTurn, error) {
+func (q *Queries) ListRawTurnsBySession(ctx context.Context, arg ListRawTurnsBySessionParams) ([]ListRawTurnsBySessionRow, error) {
 	rows, err := q.db.Query(ctx, listRawTurnsBySession, arg.OrgID, arg.HarnessSessionID)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []RawTurn
+	var items []ListRawTurnsBySessionRow
 	for rows.Next() {
-		var i RawTurn
+		var i ListRawTurnsBySessionRow
 		if err := rows.Scan(
 			&i.ID,
 			&i.OrgID,

--- a/pkg/storage/postgres/gensqlc/sessions.sql.go
+++ b/pkg/storage/postgres/gensqlc/sessions.sql.go
@@ -11,6 +11,53 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const deleteEmptyUnreferencedSession = `-- name: DeleteEmptyUnreferencedSession :execrows
+DELETE FROM sessions s
+WHERE s.org_id = $1
+  AND s.harness_id = $2
+  AND s.harness_session_id = $3
+  AND NOT EXISTS (
+      SELECT 1
+      FROM raw_turns r
+      WHERE r.org_id = s.org_id
+        AND COALESCE((
+            SELECT c.harness_id
+            FROM raw_turn_attribution_corrections c
+            WHERE c.org_id = r.org_id AND c.raw_turn_id = r.id
+            ORDER BY c.id DESC LIMIT 1
+        ), r.harness_id) = s.harness_id
+        AND COALESCE((
+            SELECT c.harness_session_id
+            FROM raw_turn_attribution_corrections c
+            WHERE c.org_id = r.org_id AND c.raw_turn_id = r.id
+            ORDER BY c.id DESC LIMIT 1
+        ), r.harness_session_id) = s.harness_session_id
+  )
+  AND NOT EXISTS (
+      SELECT 1
+      FROM sessions child
+      WHERE child.parent_session_id = s.id
+  )
+`
+
+type DeleteEmptyUnreferencedSessionParams struct {
+	OrgID            pgtype.UUID
+	HarnessID        string
+	HarnessSessionID string
+}
+
+// Remove only the ghost identity left after attribution repair moves away its
+// final effective raw turn. A zero-turn session that still anchors child
+// lineage is a legitimate placeholder and must remain. This is deliberately
+// narrower than the public subtree-cascading DeleteSession operation.
+func (q *Queries) DeleteEmptyUnreferencedSession(ctx context.Context, arg DeleteEmptyUnreferencedSessionParams) (int64, error) {
+	result, err := q.db.Exec(ctx, deleteEmptyUnreferencedSession, arg.OrgID, arg.HarnessID, arg.HarnessSessionID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const deleteSession = `-- name: DeleteSession :execrows
 DELETE FROM sessions
 WHERE org_id = $1 AND id = $2
@@ -189,6 +236,23 @@ func (q *Queries) InsertSessionPlaceholder(ctx context.Context, arg InsertSessio
 	var id pgtype.UUID
 	err := row.Scan(&id)
 	return id, err
+}
+
+const setSessionParent = `-- name: SetSessionParent :exec
+UPDATE sessions
+SET parent_session_id = $1
+WHERE id = $2
+`
+
+type SetSessionParentParams struct {
+	ParentSessionID pgtype.UUID
+	ID              pgtype.UUID
+}
+
+// Repair supplies complete effective lineage and may deliberately clear it.
+func (q *Queries) SetSessionParent(ctx context.Context, arg SetSessionParentParams) error {
+	_, err := q.db.Exec(ctx, setSessionParent, arg.ParentSessionID, arg.ID)
+	return err
 }
 
 const updateSessionDerivedTitle = `-- name: UpdateSessionDerivedTitle :exec
@@ -407,6 +471,97 @@ func (q *Queries) UpsertSession(ctx context.Context, arg UpsertSessionParams) (S
 		arg.HarnessVersion,
 		arg.ParentSessionID,
 		arg.Now,
+		arg.HarnessMetadata,
+	)
+	var i Session
+	err := row.Scan(
+		&i.ID,
+		&i.OrgID,
+		&i.AuthSubject,
+		&i.HarnessID,
+		&i.HarnessSessionID,
+		&i.Name,
+		&i.Cwd,
+		&i.HarnessVersion,
+		&i.ParentSessionID,
+		&i.StartedAt,
+		&i.LastSeenAt,
+		&i.EndedAt,
+		&i.HarnessMetadata,
+		&i.TotalInputTokens,
+		&i.TotalOutputTokens,
+		&i.TotalCostUsd,
+		&i.TurnCount,
+		&i.DerivedStatus,
+		&i.HasGitActivity,
+		&i.ToolResultCount,
+		&i.ToolErrorCount,
+		&i.DerivedTitle,
+		&i.DerivedModel,
+		&i.ModelUsage,
+		&i.TotalTokens,
+		&i.DurationNs,
+		&i.Tasks,
+		&i.KindCounts,
+		&i.DisplayName,
+	)
+	return i, err
+}
+
+const upsertSessionForAttributionRepair = `-- name: UpsertSessionForAttributionRepair :one
+INSERT INTO sessions (
+    id, org_id, auth_subject, harness_id, harness_session_id,
+    name, cwd, harness_version, parent_session_id,
+    started_at, last_seen_at, harness_metadata
+) VALUES (
+    $1, $2, $3,
+    $4, $5,
+    $6, $7, $8,
+    $9, $10,
+    $10, $11
+)
+ON CONFLICT (org_id, harness_id, harness_session_id) DO UPDATE
+SET auth_subject      = COALESCE(NULLIF(EXCLUDED.auth_subject, ''), sessions.auth_subject),
+    started_at        = LEAST(sessions.started_at, EXCLUDED.started_at),
+    last_seen_at      = GREATEST(sessions.last_seen_at, EXCLUDED.last_seen_at),
+    harness_metadata  = sessions.harness_metadata || $11,
+    name              = COALESCE($6, sessions.name),
+    cwd               = COALESCE($7, sessions.cwd),
+    harness_version   = COALESCE($8, sessions.harness_version),
+    parent_session_id = COALESCE($9, sessions.parent_session_id)
+RETURNING id, org_id, auth_subject, harness_id, harness_session_id, name, cwd, harness_version, parent_session_id, started_at, last_seen_at, ended_at, harness_metadata, total_input_tokens, total_output_tokens, total_cost_usd, turn_count, derived_status, has_git_activity, tool_result_count, tool_error_count, derived_title, derived_model, model_usage, total_tokens, duration_ns, tasks, kind_counts, display_name
+`
+
+type UpsertSessionForAttributionRepairParams struct {
+	ID               pgtype.UUID
+	OrgID            pgtype.UUID
+	AuthSubject      string
+	HarnessID        string
+	HarnessSessionID string
+	Name             pgtype.Text
+	Cwd              pgtype.Text
+	HarnessVersion   pgtype.Text
+	ParentSessionID  pgtype.UUID
+	CapturedAt       pgtype.Timestamptz
+	HarnessMetadata  []byte
+}
+
+// Materialize the corrected session identity and expand its liveness range
+// from the repaired raw turn. LEAST/GREATEST make retries and out-of-order
+// repairs idempotent. A missing repair subject must not erase a subject already
+// attached to the target session.
+func (q *Queries) UpsertSessionForAttributionRepair(ctx context.Context, arg UpsertSessionForAttributionRepairParams) (Session, error) {
+	row := q.db.QueryRow(ctx, upsertSessionForAttributionRepair,
+		arg.ID,
+		arg.OrgID,
+		arg.AuthSubject,
+		arg.HarnessID,
+		arg.HarnessSessionID,
+		arg.Name,
+		arg.Cwd,
+		arg.HarnessVersion,
+		arg.ParentSessionID,
+		arg.CapturedAt,
 		arg.HarnessMetadata,
 	)
 	var i Session

--- a/pkg/storage/postgres/gensqlc/spans.sql.go
+++ b/pkg/storage/postgres/gensqlc/spans.sql.go
@@ -105,6 +105,12 @@ UPDATE sessions SET
     turn_count = COALESCE(f.turns, 0),
     model_usage = NULL,
     derived_title = NULL,
+    tasks = NULL,
+    kind_counts = NULL,
+    has_git_activity = false,
+    tool_result_count = 0,
+    tool_error_count = 0,
+    derived_status = 'unknown',
     derived_model = COALESCE((
         SELECT sp.model FROM spans_20260615 sp
         WHERE sp.session_id = sessions.id

--- a/pkg/storage/postgres/queries/derive.sql
+++ b/pkg/storage/postgres/queries/derive.sql
@@ -6,19 +6,40 @@ WHERE org_id = $1
   AND harness_id = $2
   AND harness_session_id = $3;
 
+-- name: ListSessionsForRederive :many
+-- Whole-store rederive enumerates persisted identities, including sessions
+-- whose last effective raw turn was repaired away, so their stale projection
+-- is still covered and pruned.
+SELECT org_id, harness_id, harness_session_id
+FROM sessions
+ORDER BY org_id, harness_id, harness_session_id;
+
 -- name: ListRawTurnIndex :many
 -- Lightweight scan for the deriver's ordering pass: identity and
 -- timing only, no payloads. meta rides along because it carries the
 -- original capture time for backfilled rows.
-SELECT id, org_id, source, harness_id, harness_session_id, received_at, meta
-FROM raw_turns
-WHERE id > sqlc.arg(after_id)
-ORDER BY id
+SELECT r.id, r.org_id, r.source,
+       COALESCE(c.harness_id, r.harness_id) AS harness_id,
+       COALESCE(c.harness_session_id, r.harness_session_id) AS harness_session_id,
+       r.received_at, r.meta
+FROM raw_turns r
+LEFT JOIN LATERAL (
+    SELECT harness_id, harness_session_id
+    FROM raw_turn_attribution_corrections
+    WHERE org_id = r.org_id AND raw_turn_id = r.id
+    ORDER BY id DESC LIMIT 1
+) c ON TRUE
+WHERE r.id > sqlc.arg(after_id)
+ORDER BY r.id
 LIMIT sqlc.arg(page_size);
 
 -- name: GetRawTurn :one
--- The derive read. raw_response is selected ONLY for turns whose reduction is
--- missing its content blocks — the shape the deriver skips.
+-- The derive read, through the attribution-correction overlay: identity
+-- columns COALESCE to the latest correction, meta's thread_id is overridden
+-- when corrected, and the session envelope is rewritten to match.
+--
+-- raw_response is selected ONLY for turns whose reduction is missing its
+-- content blocks — the shape the deriver skips.
 --
 -- The column runs to the ingest cap, so selecting it unconditionally would pull
 -- megabytes through every derive read to be discarded. Selecting it never is
@@ -31,15 +52,39 @@ LIMIT sqlc.arg(page_size);
 -- the caller re-checks authoritatively before reducing, so a false positive
 -- costs one wasted read and a false negative is impossible for the case that
 -- matters (an empty reduction always lacks content).
-SELECT id, org_id, source, provider, agent_name,
-       harness_id, harness_session_id, request_id,
-       raw_request, response, meta, session_envelope, received_at,
+SELECT r.id, r.org_id, r.source, r.provider, r.agent_name,
+       COALESCE(c.harness_id, r.harness_id) AS harness_id,
+       COALESCE(c.harness_session_id, r.harness_session_id) AS harness_session_id,
+       r.request_id, r.raw_request, r.response,
+       (CASE WHEN c.id IS NULL THEN r.meta
+             ELSE jsonb_set(r.meta, '{thread_id}', to_jsonb(c.thread_id), true)
+        END)::jsonb AS meta,
+       (CASE WHEN c.id IS NULL THEN r.session_envelope
+             WHEN c.parent_harness_session_id IS NULL THEN
+                  (COALESCE(r.session_envelope, '{}'::jsonb) - 'parent_harness_session_id') ||
+                  jsonb_build_object(
+                      'harness_id', c.harness_id,
+                      'harness_session_id', c.harness_session_id
+                  )
+             ELSE COALESCE(r.session_envelope, '{}'::jsonb) || jsonb_build_object(
+                      'harness_id', c.harness_id,
+                      'harness_session_id', c.harness_session_id,
+                      'parent_harness_session_id', c.parent_harness_session_id
+                  )
+        END)::jsonb AS session_envelope,
+       r.received_at,
        CASE
-           WHEN jsonb_typeof(response -> 'message' -> 'content') = 'array'
-                AND jsonb_array_length(response -> 'message' -> 'content') > 0
+           WHEN jsonb_typeof(r.response -> 'message' -> 'content') = 'array'
+                AND jsonb_array_length(r.response -> 'message' -> 'content') > 0
            THEN NULL
-           ELSE raw_response
+           ELSE r.raw_response
        END::bytea AS raw_response,
-       raw_response_encoding
-FROM raw_turns
-WHERE id = $1;
+       r.raw_response_encoding
+FROM raw_turns r
+LEFT JOIN LATERAL (
+    SELECT id, harness_id, harness_session_id, thread_id, parent_harness_session_id
+    FROM raw_turn_attribution_corrections
+    WHERE org_id = r.org_id AND raw_turn_id = r.id
+    ORDER BY id DESC LIMIT 1
+) c ON TRUE
+WHERE r.id = $1;

--- a/pkg/storage/postgres/queries/derive_queue.sql
+++ b/pkg/storage/postgres/queries/derive_queue.sql
@@ -64,10 +64,18 @@ FROM derive_queue;
 -- writes nodes, which is what makes it safe to run concurrently with
 -- session derives.
 INSERT INTO derive_queue (org_id, harness_id, harness_session_id)
-SELECT DISTINCT org_id, harness_id, harness_session_id
-FROM raw_turns
-WHERE harness_session_id <> ''
-  AND received_at >= sqlc.arg(active_since)
+SELECT DISTINCT r.org_id,
+       COALESCE(c.harness_id, r.harness_id),
+       COALESCE(c.harness_session_id, r.harness_session_id)
+FROM raw_turns r
+LEFT JOIN LATERAL (
+    SELECT harness_id, harness_session_id
+    FROM raw_turn_attribution_corrections
+    WHERE org_id = r.org_id AND raw_turn_id = r.id
+    ORDER BY id DESC LIMIT 1
+) c ON TRUE
+WHERE COALESCE(c.harness_session_id, r.harness_session_id) <> ''
+  AND r.received_at >= sqlc.arg(active_since)
 ON CONFLICT (org_id, harness_id, harness_session_id) DO NOTHING;
 
 -- name: ListRawTurnIndexBySession :many
@@ -75,12 +83,27 @@ ON CONFLICT (org_id, harness_id, harness_session_id) DO NOTHING;
 -- session-scoped deriver's ordering pass. Full rows are then streamed
 -- one at a time via GetRawTurn — same memory discipline as the
 -- full-org pass.
-SELECT id, org_id, source, harness_id, harness_session_id, received_at, meta
-FROM raw_turns
-WHERE org_id = $1
-  AND harness_id = $2
-  AND harness_session_id = $3
-ORDER BY id;
+SELECT r.id, r.org_id, r.source,
+       COALESCE((SELECT c.harness_id
+                 FROM raw_turn_attribution_corrections c
+                 WHERE c.org_id = r.org_id AND c.raw_turn_id = r.id
+                 ORDER BY c.id DESC LIMIT 1), r.harness_id) AS harness_id,
+       COALESCE((SELECT c.harness_session_id
+                 FROM raw_turn_attribution_corrections c
+                 WHERE c.org_id = r.org_id AND c.raw_turn_id = r.id
+                 ORDER BY c.id DESC LIMIT 1), r.harness_session_id) AS harness_session_id,
+       r.received_at, r.meta
+FROM raw_turns r
+WHERE r.org_id = $1
+  AND COALESCE((SELECT c.harness_id
+                FROM raw_turn_attribution_corrections c
+                WHERE c.org_id = r.org_id AND c.raw_turn_id = r.id
+                ORDER BY c.id DESC LIMIT 1), r.harness_id) = $2
+  AND COALESCE((SELECT c.harness_session_id
+                FROM raw_turn_attribution_corrections c
+                WHERE c.org_id = r.org_id AND c.raw_turn_id = r.id
+                ORDER BY c.id DESC LIMIT 1), r.harness_session_id) = $3
+ORDER BY r.id;
 
 -- name: NextDeriveSeq :one
 -- One cursor value per derive pass: the derive transaction's own id. Every row

--- a/pkg/storage/postgres/queries/raw_turns.sql
+++ b/pkg/storage/postgres/queries/raw_turns.sql
@@ -21,25 +21,77 @@ ON CONFLICT (org_id, request_id) WHERE request_id <> '' DO NOTHING;
 -- name: ListRawTurns :many
 -- Keyset-paginated scan in insertion order, for the re-runnable deriver.
 -- Pass after_id = 0 to start from the beginning.
-SELECT id, org_id, source, provider, agent_name,
-       harness_id, harness_session_id, request_id,
-       raw_request, response, meta, session_envelope, received_at,
-       raw_response, raw_response_encoding, raw_response_dropped
-FROM raw_turns
-WHERE id > sqlc.arg(after_id)
-ORDER BY id
+SELECT r.id, r.org_id, r.source, r.provider, r.agent_name,
+       COALESCE(c.harness_id, r.harness_id) AS harness_id,
+       COALESCE(c.harness_session_id, r.harness_session_id) AS harness_session_id,
+       r.request_id, r.raw_request, r.response,
+       (CASE WHEN c.id IS NULL THEN r.meta
+             ELSE jsonb_set(r.meta, '{thread_id}', to_jsonb(c.thread_id), true)
+        END)::jsonb AS meta,
+       (CASE WHEN c.id IS NULL THEN r.session_envelope
+             WHEN c.parent_harness_session_id IS NULL THEN
+                  (COALESCE(r.session_envelope, '{}'::jsonb) - 'parent_harness_session_id') ||
+                  jsonb_build_object(
+                      'harness_id', c.harness_id,
+                      'harness_session_id', c.harness_session_id
+                  )
+             ELSE COALESCE(r.session_envelope, '{}'::jsonb) || jsonb_build_object(
+                      'harness_id', c.harness_id,
+                      'harness_session_id', c.harness_session_id,
+                      'parent_harness_session_id', c.parent_harness_session_id
+                  )
+        END)::jsonb AS session_envelope,
+       r.received_at,
+       r.raw_response, r.raw_response_encoding, r.raw_response_dropped
+FROM raw_turns r
+LEFT JOIN LATERAL (
+    SELECT id, harness_id, harness_session_id, thread_id, parent_harness_session_id
+    FROM raw_turn_attribution_corrections
+    WHERE org_id = r.org_id AND raw_turn_id = r.id
+    ORDER BY id DESC LIMIT 1
+) c ON TRUE
+WHERE r.id > sqlc.arg(after_id)
+ORDER BY r.id
 LIMIT sqlc.arg(page_size);
 
 -- name: ListRawTurnsBySession :many
 -- Every raw turn captured for one harness session, in insertion order.
-SELECT id, org_id, source, provider, agent_name,
-       harness_id, harness_session_id, request_id,
-       raw_request, response, meta, session_envelope, received_at,
-       raw_response, raw_response_encoding, raw_response_dropped
-FROM raw_turns
-WHERE org_id = $1
-  AND harness_session_id = $2
-ORDER BY id;
+SELECT r.id, r.org_id, r.source, r.provider, r.agent_name,
+       COALESCE(c.harness_id, r.harness_id) AS harness_id,
+       COALESCE(c.harness_session_id, r.harness_session_id) AS harness_session_id,
+       r.request_id, r.raw_request, r.response,
+       (CASE WHEN c.id IS NULL THEN r.meta
+             ELSE jsonb_set(r.meta, '{thread_id}', to_jsonb(c.thread_id), true)
+        END)::jsonb AS meta,
+       (CASE WHEN c.id IS NULL THEN r.session_envelope
+             WHEN c.parent_harness_session_id IS NULL THEN
+                  (COALESCE(r.session_envelope, '{}'::jsonb) - 'parent_harness_session_id') ||
+                  jsonb_build_object(
+                      'harness_id', c.harness_id,
+                      'harness_session_id', c.harness_session_id
+                  )
+             ELSE COALESCE(r.session_envelope, '{}'::jsonb) || jsonb_build_object(
+                      'harness_id', c.harness_id,
+                      'harness_session_id', c.harness_session_id,
+                      'parent_harness_session_id', c.parent_harness_session_id
+                  )
+        END)::jsonb AS session_envelope,
+       r.received_at,
+       r.raw_response, r.raw_response_encoding, r.raw_response_dropped
+FROM raw_turns r
+LEFT JOIN LATERAL (
+    SELECT id, harness_id, harness_session_id, thread_id, parent_harness_session_id
+    FROM raw_turn_attribution_corrections
+    WHERE org_id = r.org_id AND raw_turn_id = r.id
+    ORDER BY id DESC LIMIT 1
+) c ON TRUE
+WHERE r.org_id = $1
+  AND COALESCE((
+      SELECT c2.harness_session_id FROM raw_turn_attribution_corrections c2
+      WHERE c2.org_id = r.org_id AND c2.raw_turn_id = r.id
+      ORDER BY c2.id DESC LIMIT 1
+  ), r.harness_session_id) = $2
+ORDER BY r.id;
 
 -- name: CountRawTurns :one
 SELECT COUNT(*) FROM raw_turns;
@@ -47,15 +99,34 @@ SELECT COUNT(*) FROM raw_turns;
 -- name: ListRawTurnHeadersBySession :many
 -- Operator wire log: identity + sizes, no payloads. The raw layer is
 -- the capture truth; this surfaces it without shipping the blobs.
-SELECT id, org_id, source, provider, agent_name, request_id,
-       received_at, meta,
-       COALESCE(length(raw_request::text), 0)::bigint AS request_bytes,
-       COALESCE(length(response::text), 0)::bigint AS response_bytes,
-       COALESCE(octet_length(raw_response), 0)::bigint AS raw_response_bytes,
-       raw_response_dropped
-FROM raw_turns
-WHERE org_id = $1 AND harness_id = $2 AND harness_session_id = $3
-ORDER BY id ASC;
+SELECT r.id, r.org_id, r.source, r.provider, r.agent_name, r.request_id,
+       r.received_at,
+       (CASE WHEN c.id IS NULL THEN r.meta
+             ELSE jsonb_set(r.meta, '{thread_id}', to_jsonb(c.thread_id), true)
+        END)::jsonb AS meta,
+       COALESCE(length(r.raw_request::text), 0)::bigint AS request_bytes,
+       COALESCE(length(r.response::text), 0)::bigint AS response_bytes,
+       COALESCE(octet_length(r.raw_response), 0)::bigint AS raw_response_bytes,
+       r.raw_response_dropped
+FROM raw_turns r
+LEFT JOIN LATERAL (
+    SELECT id, harness_id, harness_session_id, thread_id
+    FROM raw_turn_attribution_corrections
+    WHERE org_id = r.org_id AND raw_turn_id = r.id
+    ORDER BY id DESC LIMIT 1
+) c ON TRUE
+WHERE r.org_id = $1
+  AND COALESCE((
+      SELECT c2.harness_id FROM raw_turn_attribution_corrections c2
+      WHERE c2.org_id = r.org_id AND c2.raw_turn_id = r.id
+      ORDER BY c2.id DESC LIMIT 1
+  ), r.harness_id) = $2
+  AND COALESCE((
+      SELECT c2.harness_session_id FROM raw_turn_attribution_corrections c2
+      WHERE c2.org_id = r.org_id AND c2.raw_turn_id = r.id
+      ORDER BY c2.id DESC LIMIT 1
+  ), r.harness_session_id) = $3
+ORDER BY r.id ASC;
 
 -- name: RawTurnFidelityByIDs :many
 -- Provenance tier for a set of raw turns, for stamping the span projection.
@@ -73,3 +144,40 @@ SELECT id,
        raw_response_dropped
 FROM raw_turns
 WHERE id = ANY(sqlc.arg(ids)::bigint[]);
+
+-- name: FindRawTurnIDsByPaperProxyRequestID :many
+SELECT id
+FROM raw_turns
+WHERE org_id = sqlc.arg(org_id)
+  AND session_envelope->'harness_metadata'->>'paperProxyRequestId' = sqlc.arg(paper_proxy_request_id)::text
+ORDER BY id
+LIMIT 2;
+
+-- name: GetRawTurnAttributionForUpdate :one
+-- Locks the immutable row as a serialization point for competing repairs.
+SELECT r.id, r.org_id, r.session_envelope, r.received_at,
+       COALESCE(c.harness_id, r.harness_id) AS harness_id,
+       COALESCE(c.harness_session_id, r.harness_session_id) AS harness_session_id,
+       COALESCE(c.thread_id, r.meta->>'thread_id', '') AS thread_id,
+       (c.id IS NOT NULL)::boolean AS has_correction,
+       COALESCE(c.parent_harness_session_id, '') AS corrected_parent_harness_session_id,
+       COALESCE(r.session_envelope->>'parent_harness_session_id', '')::text AS raw_parent_harness_session_id
+FROM raw_turns r
+LEFT JOIN LATERAL (
+    SELECT id, harness_id, harness_session_id, thread_id, parent_harness_session_id
+    FROM raw_turn_attribution_corrections
+    WHERE org_id = r.org_id AND raw_turn_id = r.id
+    ORDER BY id DESC LIMIT 1
+) c ON TRUE
+WHERE r.org_id = sqlc.arg(org_id) AND r.id = sqlc.arg(raw_turn_id)
+FOR UPDATE OF r;
+
+-- name: InsertRawTurnAttributionCorrection :exec
+INSERT INTO raw_turn_attribution_corrections (
+    org_id, raw_turn_id, harness_id, harness_session_id, thread_id,
+    parent_harness_session_id, reason
+) VALUES (
+    sqlc.arg(org_id), sqlc.arg(raw_turn_id), sqlc.arg(harness_id),
+    sqlc.arg(harness_session_id), sqlc.arg(thread_id),
+    sqlc.narg(parent_harness_session_id), sqlc.arg(reason)
+);

--- a/pkg/storage/postgres/queries/sessions.sql
+++ b/pkg/storage/postgres/queries/sessions.sql
@@ -52,6 +52,65 @@ SET last_seen_at     = sqlc.arg(now),
     parent_session_id = COALESCE(sqlc.narg(parent_session_id), sessions.parent_session_id)
 RETURNING *;
 
+-- name: UpsertSessionForAttributionRepair :one
+-- Materialize the corrected session identity and expand its liveness range
+-- from the repaired raw turn. LEAST/GREATEST make retries and out-of-order
+-- repairs idempotent. A missing repair subject must not erase a subject already
+-- attached to the target session.
+INSERT INTO sessions (
+    id, org_id, auth_subject, harness_id, harness_session_id,
+    name, cwd, harness_version, parent_session_id,
+    started_at, last_seen_at, harness_metadata
+) VALUES (
+    sqlc.arg(id), sqlc.arg(org_id), sqlc.arg(auth_subject),
+    sqlc.arg(harness_id), sqlc.arg(harness_session_id),
+    sqlc.narg(name), sqlc.narg(cwd), sqlc.narg(harness_version),
+    sqlc.narg(parent_session_id), sqlc.arg(captured_at),
+    sqlc.arg(captured_at), sqlc.arg(harness_metadata)
+)
+ON CONFLICT (org_id, harness_id, harness_session_id) DO UPDATE
+SET auth_subject      = COALESCE(NULLIF(EXCLUDED.auth_subject, ''), sessions.auth_subject),
+    started_at        = LEAST(sessions.started_at, EXCLUDED.started_at),
+    last_seen_at      = GREATEST(sessions.last_seen_at, EXCLUDED.last_seen_at),
+    harness_metadata  = sessions.harness_metadata || sqlc.arg(harness_metadata),
+    name              = COALESCE(sqlc.narg(name), sessions.name),
+    cwd               = COALESCE(sqlc.narg(cwd), sessions.cwd),
+    harness_version   = COALESCE(sqlc.narg(harness_version), sessions.harness_version),
+    parent_session_id = COALESCE(sqlc.narg(parent_session_id), sessions.parent_session_id)
+RETURNING *;
+
+-- name: DeleteEmptyUnreferencedSession :execrows
+-- Remove only the ghost identity left after attribution repair moves away its
+-- final effective raw turn. A zero-turn session that still anchors child
+-- lineage is a legitimate placeholder and must remain. This is deliberately
+-- narrower than the public subtree-cascading DeleteSession operation.
+DELETE FROM sessions s
+WHERE s.org_id = sqlc.arg(org_id)
+  AND s.harness_id = sqlc.arg(harness_id)
+  AND s.harness_session_id = sqlc.arg(harness_session_id)
+  AND NOT EXISTS (
+      SELECT 1
+      FROM raw_turns r
+      WHERE r.org_id = s.org_id
+        AND COALESCE((
+            SELECT c.harness_id
+            FROM raw_turn_attribution_corrections c
+            WHERE c.org_id = r.org_id AND c.raw_turn_id = r.id
+            ORDER BY c.id DESC LIMIT 1
+        ), r.harness_id) = s.harness_id
+        AND COALESCE((
+            SELECT c.harness_session_id
+            FROM raw_turn_attribution_corrections c
+            WHERE c.org_id = r.org_id AND c.raw_turn_id = r.id
+            ORDER BY c.id DESC LIMIT 1
+        ), r.harness_session_id) = s.harness_session_id
+  )
+  AND NOT EXISTS (
+      SELECT 1
+      FROM sessions child
+      WHERE child.parent_session_id = s.id
+  );
+
 -- name: GetSessionByNaturalKey :one
 -- Lookup by the unique (org_id, harness_id, harness_session_id) index.
 -- Used by the parent-FK resolution path in ingest: when an inbound
@@ -162,3 +221,9 @@ UPDATE sessions SET kind_counts = sqlc.arg(kind_counts) WHERE id = sqlc.arg(id);
 -- derived/auto title (the read layer resolves the fallback).
 UPDATE sessions SET display_name = sqlc.narg(display_name)
 WHERE id = sqlc.arg(id) AND org_id = sqlc.arg(org_id);
+
+-- name: SetSessionParent :exec
+-- Repair supplies complete effective lineage and may deliberately clear it.
+UPDATE sessions
+SET parent_session_id = sqlc.narg(parent_session_id)
+WHERE id = sqlc.arg(id);

--- a/pkg/storage/postgres/queries/spans.sql
+++ b/pkg/storage/postgres/queries/spans.sql
@@ -230,6 +230,12 @@ UPDATE sessions SET
     turn_count = COALESCE(f.turns, 0),
     model_usage = NULL,
     derived_title = NULL,
+    tasks = NULL,
+    kind_counts = NULL,
+    has_git_activity = false,
+    tool_result_count = 0,
+    tool_error_count = 0,
+    derived_status = 'unknown',
     derived_model = COALESCE((
         SELECT sp.model FROM spans_20260615 sp
         WHERE sp.session_id = sessions.id

--- a/pkg/storage/postgres/raw_turn_attribution_repair.go
+++ b/pkg/storage/postgres/raw_turn_attribution_repair.go
@@ -1,0 +1,392 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/papercomputeco/tapes/pkg/sessions"
+	"github.com/papercomputeco/tapes/pkg/storage"
+	"github.com/papercomputeco/tapes/pkg/storage/postgres/gensqlc"
+)
+
+var _ storage.RawTurnAttributionRepairer = (*Driver)(nil)
+
+// repairRederive is the synchronous rebuild the repair flow runs for each
+// affected session. A package variable purely as a test seam: the repair
+// contract under a MID-FLIGHT rederive failure (correction committed, one
+// projection rebuilt, the other stale) is otherwise unreachable from a
+// black-box test, since RederiveSession has no injectable failure mode.
+var repairRederive = (*Driver).RederiveSession
+
+// repairSourceCleanup removes the emptied previous-session row once a repair
+// has applied. A package variable purely as a test seam, for the same reason
+// as repairRederive: a cleanup-only failure (correction committed, both
+// projections rebuilt, deletion failed) has no black-box trigger.
+var repairSourceCleanup = (*Driver).deleteEmptyUnreferencedRepairSource
+
+type repairSessionKey struct {
+	harnessID        string
+	harnessSessionID string
+}
+
+// RepairRawTurnAttribution appends an attribution correction and rebuilds both
+// affected projections. raw_turns remains byte-for-byte untouched.
+func (d *Driver) RepairRawTurnAttribution(
+	ctx context.Context,
+	project string,
+	req storage.RawTurnAttributionRepairRequest,
+) (storage.RawTurnAttributionRepairResult, error) {
+	var zero storage.RawTurnAttributionRepairResult
+	if d == nil || d.conn == nil {
+		return zero, errors.New("postgres driver not open")
+	}
+	if err := validateAttributionRepair(req); err != nil {
+		return zero, err
+	}
+	orgID, err := orgIDFromString(orgKeyForLookup(req.OrgID))
+	if err != nil {
+		return zero, fmt.Errorf("decode org_id: %w", err)
+	}
+	rawTurnID, err := d.resolveRepairRawTurnID(ctx, orgID, req)
+	if err != nil {
+		return zero, err
+	}
+
+	for {
+		observed, err := d.q.GetRawTurnAttributionForUpdate(ctx, gensqlc.GetRawTurnAttributionForUpdateParams{
+			OrgID: orgID, RawTurnID: rawTurnID,
+		})
+		if errors.Is(err, pgx.ErrNoRows) {
+			return zero, storage.ErrRawTurnNotFound
+		}
+		if err != nil {
+			return zero, fmt.Errorf("read effective raw-turn attribution: %w", err)
+		}
+
+		oldKey := repairSessionKey{observed.HarnessID, observed.HarnessSessionID}
+		newKey := repairSessionKey{req.HarnessID, req.HarnessSessionID}
+		release, err := d.acquireRepairSessionLocks(ctx, req.OrgID, oldKey, newKey)
+		if err != nil {
+			return zero, err
+		}
+
+		result, retry, err := d.recordAttributionRepair(ctx, orgID, rawTurnID, req, oldKey, newKey)
+		if retry {
+			release()
+			continue
+		}
+		if err != nil {
+			release()
+			return zero, err
+		}
+
+		_, oldErr := repairRederive(d, ctx, project, req.OrgID, oldKey.harnessID, oldKey.harnessSessionID)
+		var cleanupErr error
+		if oldErr == nil && oldKey != newKey {
+			cleanupErr = repairSourceCleanup(d, ctx, orgID, oldKey)
+		}
+		var newErr error
+		if oldKey != newKey {
+			_, newErr = repairRederive(d, ctx, project, req.OrgID, newKey.harnessID, newKey.harnessSessionID)
+		}
+
+		// The correction is already committed and effective at read time —
+		// from here the repair cannot "fail", only settle asynchronously. A
+		// rederive failure leaves that session's projection stale, but the
+		// correction transaction marked both sessions derive-dirty, and the
+		// worker cannot have cleared those marks yet (clearing requires the
+		// per-session advisory locks still held here), so the queue converges
+		// them. Re-mark under the locks anyway: it makes this path's
+		// convergence locally evident instead of resting on the transaction
+		// two calls away, at worst re-bumping dirtied_at.
+		var pendingErrs []error
+		if oldErr != nil {
+			result.ProjectionsPending = append(result.ProjectionsPending,
+				storage.RepairPendingSession{HarnessID: oldKey.harnessID, HarnessSessionID: oldKey.harnessSessionID})
+			pendingErrs = append(pendingErrs, fmt.Errorf("rederive previous session: %w", oldErr))
+		}
+		if newErr != nil {
+			result.ProjectionsPending = append(result.ProjectionsPending,
+				storage.RepairPendingSession{HarnessID: newKey.harnessID, HarnessSessionID: newKey.harnessSessionID})
+			pendingErrs = append(pendingErrs, fmt.Errorf("rederive effective session: %w", newErr))
+		}
+		for _, pending := range result.ProjectionsPending {
+			if markErr := d.MarkDeriveDirty(ctx, req.OrgID, pending.HarnessID, pending.HarnessSessionID); markErr != nil {
+				pendingErrs = append(pendingErrs, fmt.Errorf("re-mark %s/%s derive-dirty: %w", pending.HarnessID, pending.HarnessSessionID, markErr))
+			}
+		}
+		release()
+		// A cleanup failure is strictly cosmetic: the repair has applied and
+		// the emptied source row anchors no effective turns. No worker
+		// retries the deletion — the flag keeps the response honest about
+		// the leftover rather than promising later cleanup — so it must
+		// never surface as a failure of an already-applied repair.
+		result.SourceCleanupPending = cleanupErr != nil
+		if len(pendingErrs) > 0 {
+			if cleanupErr != nil {
+				pendingErrs = append(pendingErrs, cleanupErr)
+			}
+			return result, fmt.Errorf("%w: %w", storage.ErrRepairProjectionsPending, errors.Join(pendingErrs...))
+		}
+		if cleanupErr != nil {
+			d.logger.Warn("repaired source session cleanup failed; leaving empty source row",
+				"harness_id", oldKey.harnessID,
+				"harness_session_id", oldKey.harnessSessionID,
+				"error", cleanupErr)
+		}
+		return result, nil
+	}
+}
+
+func (d *Driver) deleteEmptyUnreferencedRepairSource(
+	ctx context.Context,
+	orgID pgtype.UUID,
+	key repairSessionKey,
+) error {
+	tx, err := d.conn.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin repaired source cleanup: %w", err)
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck
+	if _, err := d.q.WithTx(tx).DeleteEmptyUnreferencedSession(
+		ctx,
+		gensqlc.DeleteEmptyUnreferencedSessionParams{
+			OrgID:            orgID,
+			HarnessID:        key.harnessID,
+			HarnessSessionID: key.harnessSessionID,
+		},
+	); err != nil {
+		return fmt.Errorf("delete empty repaired source session: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit repaired source cleanup: %w", err)
+	}
+	return nil
+}
+
+func validateAttributionRepair(req storage.RawTurnAttributionRepairRequest) error {
+	if (req.RawTurnID > 0) == (strings.TrimSpace(req.PaperProxyRequestID) != "") {
+		return errors.New("exactly one of raw_turn_id or paper_proxy_request_id is required")
+	}
+	if req.HarnessID == "" {
+		return errors.New("harness_id is required")
+	}
+	if req.HarnessSessionID == "" {
+		return errors.New("harness_session_id is required")
+	}
+	if req.ParentHarnessSessionID != nil && *req.ParentHarnessSessionID == "" {
+		return errors.New("parent_harness_session_id must be omitted instead of empty")
+	}
+	if req.ParentHarnessSessionID != nil && *req.ParentHarnessSessionID == req.HarnessSessionID {
+		return errors.New("a session cannot parent itself")
+	}
+	if strings.TrimSpace(req.Reason) == "" {
+		return errors.New("reason is required")
+	}
+	return nil
+}
+
+func (d *Driver) resolveRepairRawTurnID(
+	ctx context.Context,
+	orgID pgtype.UUID,
+	req storage.RawTurnAttributionRepairRequest,
+) (int64, error) {
+	if req.RawTurnID > 0 {
+		return req.RawTurnID, nil
+	}
+	ids, err := d.q.FindRawTurnIDsByPaperProxyRequestID(ctx, gensqlc.FindRawTurnIDsByPaperProxyRequestIDParams{
+		OrgID: orgID, PaperProxyRequestID: req.PaperProxyRequestID,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("resolve paper proxy request id: %w", err)
+	}
+	switch len(ids) {
+	case 0:
+		return 0, storage.ErrRawTurnNotFound
+	case 1:
+		return ids[0], nil
+	default:
+		return 0, storage.ErrRawTurnAmbiguous
+	}
+}
+
+func (d *Driver) acquireRepairSessionLocks(
+	ctx context.Context,
+	orgID string,
+	keys ...repairSessionKey,
+) (func(), error) {
+	unique := make(map[repairSessionKey]struct{}, len(keys))
+	ordered := make([]repairSessionKey, 0, len(keys))
+	for _, key := range keys {
+		if _, ok := unique[key]; ok {
+			continue
+		}
+		unique[key] = struct{}{}
+		ordered = append(ordered, key)
+	}
+	sort.Slice(ordered, func(i, j int) bool {
+		return ordered[i].harnessID+"\x00"+ordered[i].harnessSessionID < ordered[j].harnessID+"\x00"+ordered[j].harnessSessionID
+	})
+	releases := make([]func(), 0, len(ordered))
+	for _, key := range ordered {
+		release, err := d.AcquireDeriveSessionLock(ctx, orgID, key.harnessID, key.harnessSessionID)
+		if err != nil {
+			for i := len(releases) - 1; i >= 0; i-- {
+				releases[i]()
+			}
+			return nil, fmt.Errorf("acquire repair session lock %s/%s: %w", key.harnessID, key.harnessSessionID, err)
+		}
+		releases = append(releases, release)
+	}
+	return func() {
+		for i := len(releases) - 1; i >= 0; i-- {
+			releases[i]()
+		}
+	}, nil
+}
+
+func (d *Driver) recordAttributionRepair(
+	ctx context.Context,
+	orgID pgtype.UUID,
+	rawTurnID int64,
+	req storage.RawTurnAttributionRepairRequest,
+	lockedOld, newKey repairSessionKey,
+) (storage.RawTurnAttributionRepairResult, bool, error) {
+	var zero storage.RawTurnAttributionRepairResult
+	tx, err := d.conn.Begin(ctx)
+	if err != nil {
+		return zero, false, fmt.Errorf("begin attribution repair: %w", err)
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck
+	qtx := d.q.WithTx(tx)
+	current, err := qtx.GetRawTurnAttributionForUpdate(ctx, gensqlc.GetRawTurnAttributionForUpdateParams{
+		OrgID: orgID, RawTurnID: rawTurnID,
+	})
+	if errors.Is(err, pgx.ErrNoRows) {
+		return zero, false, storage.ErrRawTurnNotFound
+	}
+	if err != nil {
+		return zero, false, fmt.Errorf("lock raw turn for repair: %w", err)
+	}
+	if current.HarnessID != lockedOld.harnessID || current.HarnessSessionID != lockedOld.harnessSessionID {
+		return zero, true, nil
+	}
+
+	previous := attributionFromRow(current)
+	effective := storage.RawTurnAttribution{
+		RawTurnID: rawTurnID, HarnessID: req.HarnessID,
+		HarnessSessionID: req.HarnessSessionID, ThreadID: req.ThreadID,
+		ParentHarnessSessionID: cloneStringPointer(req.ParentHarnessSessionID),
+	}
+	recorded := !sameAttribution(previous, effective)
+
+	var envelope sessions.IngestEnvelope
+	if len(current.SessionEnvelope) > 0 {
+		if err := json.Unmarshal(current.SessionEnvelope, &envelope); err != nil {
+			return zero, false, fmt.Errorf("decode raw session envelope: %w", err)
+		}
+	}
+	envelope.OrgID = req.OrgID
+	envelope.HarnessID = req.HarnessID
+	envelope.HarnessSessionID = req.HarnessSessionID
+	envelope.ParentHarnessSessionID = cloneStringPointer(req.ParentHarnessSessionID)
+	capturedAt := current.ReceivedAt
+	parentID, err := resolveParentSessionID(ctx, qtx, &envelope, orgID, capturedAt)
+	if err != nil {
+		return zero, false, fmt.Errorf("resolve repaired parent session: %w", err)
+	}
+	sessionID, err := newAppUUID()
+	if err != nil {
+		return zero, false, fmt.Errorf("mint repaired session uuid: %w", err)
+	}
+	metadata := []byte(envelope.HarnessMetadata)
+	if len(metadata) == 0 {
+		metadata = []byte("{}")
+	}
+	target, err := qtx.UpsertSessionForAttributionRepair(ctx, gensqlc.UpsertSessionForAttributionRepairParams{
+		ID: sessionID, OrgID: orgID, AuthSubject: envelope.AuthSubject,
+		HarnessID: req.HarnessID, HarnessSessionID: req.HarnessSessionID,
+		Name: nullStringValue(envelope.Name), Cwd: nullStringValue(envelope.Cwd),
+		HarnessVersion: nullStringValue(envelope.HarnessVersion), ParentSessionID: parentID,
+		CapturedAt: capturedAt, HarnessMetadata: metadata,
+	})
+	if err != nil {
+		return zero, false, fmt.Errorf("upsert repaired session: %w", err)
+	}
+	if err := qtx.SetSessionParent(ctx, gensqlc.SetSessionParentParams{ParentSessionID: parentID, ID: target.ID}); err != nil {
+		return zero, false, fmt.Errorf("set repaired session parent: %w", err)
+	}
+	if recorded {
+		if err := qtx.InsertRawTurnAttributionCorrection(ctx, gensqlc.InsertRawTurnAttributionCorrectionParams{
+			OrgID: orgID, RawTurnID: rawTurnID, HarnessID: req.HarnessID,
+			HarnessSessionID: req.HarnessSessionID, ThreadID: req.ThreadID,
+			ParentHarnessSessionID: textFromPointer(req.ParentHarnessSessionID), Reason: req.Reason,
+		}); err != nil {
+			return zero, false, fmt.Errorf("append raw-turn attribution correction: %w", err)
+		}
+	}
+	for _, key := range []repairSessionKey{lockedOld, newKey} {
+		if err := qtx.MarkDeriveDirty(ctx, gensqlc.MarkDeriveDirtyParams{
+			OrgID: orgID, HarnessID: key.harnessID, HarnessSessionID: key.harnessSessionID,
+		}); err != nil {
+			return zero, false, fmt.Errorf("mark repaired session dirty: %w", err)
+		}
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return zero, false, fmt.Errorf("commit attribution repair: %w", err)
+	}
+	return storage.RawTurnAttributionRepairResult{Recorded: recorded, Previous: previous, Effective: effective}, false, nil
+}
+
+func attributionFromRow(row gensqlc.GetRawTurnAttributionForUpdateRow) storage.RawTurnAttribution {
+	parent := row.RawParentHarnessSessionID
+	if row.HasCorrection {
+		parent = row.CorrectedParentHarnessSessionID
+	}
+	return storage.RawTurnAttribution{
+		RawTurnID: row.ID, HarnessID: row.HarnessID,
+		HarnessSessionID: row.HarnessSessionID, ThreadID: row.ThreadID,
+		ParentHarnessSessionID: pointerFromString(parent),
+	}
+}
+
+func sameAttribution(a, b storage.RawTurnAttribution) bool {
+	return a.HarnessID == b.HarnessID && a.HarnessSessionID == b.HarnessSessionID &&
+		a.ThreadID == b.ThreadID && pointerValue(a.ParentHarnessSessionID) == pointerValue(b.ParentHarnessSessionID)
+}
+
+func pointerValue(v *string) string {
+	if v == nil {
+		return ""
+	}
+	return *v
+}
+
+func cloneStringPointer(v *string) *string {
+	if v == nil {
+		return nil
+	}
+	cloned := *v
+	return &cloned
+}
+
+func pointerFromString(v string) *string {
+	if v == "" {
+		return nil
+	}
+	return cloneStringPointer(&v)
+}
+
+func textFromPointer(v *string) pgtype.Text {
+	if v == nil {
+		return pgtype.Text{}
+	}
+	return pgtype.Text{String: *v, Valid: true}
+}

--- a/pkg/storage/postgres/raw_turn_attribution_repair_test.go
+++ b/pkg/storage/postgres/raw_turn_attribution_repair_test.go
@@ -1,0 +1,687 @@
+package postgres_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/papercomputeco/tapes/pkg/derive"
+	"github.com/papercomputeco/tapes/pkg/sessions"
+	"github.com/papercomputeco/tapes/pkg/storage"
+	"github.com/papercomputeco/tapes/pkg/storage/postgres"
+	"github.com/papercomputeco/tapes/pkg/storage/postgres/gensqlc"
+)
+
+var _ = Describe("raw-turn attribution repair", func() {
+	var (
+		ctx    context.Context
+		driver *postgres.Driver
+		orgID  string
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		orgID = newTestOrgID()
+		var err error
+		driver, err = postgres.NewDriver(ctx, testPostgresDSN)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = driver.DB().Exec(ctx, "TRUNCATE TABLE raw_turn_attribution_corrections, derive_queue, raw_turns RESTART IDENTITY CASCADE")
+		Expect(err).NotTo(HaveOccurred())
+		_, err = driver.DB().Exec(ctx, "TRUNCATE TABLE sessions CASCADE")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		if driver != nil {
+			driver.Close()
+		}
+	})
+
+	It("records an idempotent overlay, preserves raw bytes, and rebuilds source, target, thread, and parent attribution", func() {
+		const (
+			harnessID = "codex"
+			sourceID  = "parent-session"
+			targetID  = "child-session"
+			parentID  = "root-session"
+			threadID  = "child-thread"
+		)
+
+		sourceRowID := newTestOrgID()
+		_, err := driver.DB().Exec(ctx, `
+			INSERT INTO sessions (id, org_id, auth_subject, harness_id, harness_session_id, started_at, last_seen_at)
+			VALUES ($1, $2, 'user-test', $3, $4, NOW(), NOW())`,
+			sourceRowID, orgID, harnessID, sourceID)
+		Expect(err).NotTo(HaveOccurred())
+
+		rec := storage.RawTurnRecord{
+			OrgID:            orgID,
+			Source:           storage.RawTurnSourceWire,
+			Provider:         "anthropic",
+			AgentName:        "codex",
+			HarnessID:        harnessID,
+			HarnessSessionID: sourceID,
+			RequestID:        "repair-request-1",
+			RawRequest: json.RawMessage(
+				`{"model":"claude-test","max_tokens":4096,"messages":[{"role":"user","content":"repair me"}]}`),
+			Response: json.RawMessage(
+				`{"model":"claude-test","message":{"role":"assistant","content":[{"type":"text","text":"repaired"}]},"stop_reason":"end_turn"}`),
+			Meta: json.RawMessage(`{"thread_id":"wrong-thread","future":"keep-me"}`),
+			SessionEnvelope: json.RawMessage(fmt.Sprintf(
+				`{"org_id":%q,"auth_subject":"user-test","harness_id":%q,"harness_session_id":%q,"cwd":"/tmp/project","harness_metadata":{"originator":"Codex Desktop","paperProxyRequestId":"paper-proxy-1"}}`,
+				orgID, harnessID, sourceID)),
+		}
+		inserted, err := driver.PutRawTurn(ctx, rec)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(inserted).To(BeTrue())
+
+		var rawTurnID int64
+		var beforeRequest, beforeResponse, beforeMeta, beforeEnvelope, beforeHarness, beforeSession string
+		Expect(driver.DB().QueryRow(ctx, `
+			SELECT id, raw_request::text, response::text, meta::text, session_envelope::text,
+			       harness_id, harness_session_id
+			FROM raw_turns WHERE org_id = $1 AND request_id = $2`, orgID, rec.RequestID).Scan(
+			&rawTurnID, &beforeRequest, &beforeResponse, &beforeMeta, &beforeEnvelope,
+			&beforeHarness, &beforeSession,
+		)).To(Succeed())
+
+		_, err = driver.RederiveSessionLocked(ctx, "", orgID, harnessID, sourceID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(spanTurnsForHarnessSession(ctx, driver, orgID, harnessID, sourceID)).To(Equal(1))
+
+		request := storage.RawTurnAttributionRepairRequest{
+			OrgID:                  orgID,
+			PaperProxyRequestID:    "paper-proxy-1",
+			HarnessID:              harnessID,
+			HarnessSessionID:       targetID,
+			ThreadID:               threadID,
+			ParentHarnessSessionID: &[]string{parentID}[0],
+			Reason:                 "Codex child request matched exact thread and parent evidence",
+		}
+		result, err := driver.RepairRawTurnAttribution(ctx, "", request)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Recorded).To(BeTrue())
+		Expect(result.Previous.HarnessSessionID).To(Equal(sourceID))
+		Expect(result.Effective.HarnessSessionID).To(Equal(targetID))
+		Expect(result.Effective.ThreadID).To(Equal(threadID))
+
+		var firstStartedAt, firstLastSeenAt time.Time
+		Expect(driver.DB().QueryRow(ctx, `
+			SELECT started_at, last_seen_at FROM sessions
+			WHERE org_id = $1 AND harness_id = $2 AND harness_session_id = $3`,
+			orgID, harnessID, targetID).Scan(&firstStartedAt, &firstLastSeenAt)).To(Succeed())
+
+		result, err = driver.RepairRawTurnAttribution(ctx, "", request)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Recorded).To(BeFalse(), "repeating the same repair must not append another audit row")
+		var retryStartedAt, retryLastSeenAt time.Time
+		Expect(driver.DB().QueryRow(ctx, `
+			SELECT started_at, last_seen_at FROM sessions
+			WHERE org_id = $1 AND harness_id = $2 AND harness_session_id = $3`,
+			orgID, harnessID, targetID).Scan(&retryStartedAt, &retryLastSeenAt)).To(Succeed())
+		Expect(retryStartedAt).To(Equal(firstStartedAt))
+		Expect(retryLastSeenAt).To(Equal(firstLastSeenAt), "idempotent repair must not make the session look newly active")
+
+		var corrections int
+		Expect(driver.DB().QueryRow(ctx,
+			"SELECT COUNT(*) FROM raw_turn_attribution_corrections WHERE org_id = $1 AND raw_turn_id = $2",
+			orgID, rawTurnID).Scan(&corrections)).To(Succeed())
+		Expect(corrections).To(Equal(1))
+
+		var afterRequest, afterResponse, afterMeta, afterEnvelope, afterHarness, afterSession string
+		Expect(driver.DB().QueryRow(ctx, `
+			SELECT raw_request::text, response::text, meta::text, session_envelope::text,
+			       harness_id, harness_session_id
+			FROM raw_turns WHERE org_id = $1 AND id = $2`, orgID, rawTurnID).Scan(
+			&afterRequest, &afterResponse, &afterMeta, &afterEnvelope, &afterHarness, &afterSession,
+		)).To(Succeed())
+		Expect([]string{afterRequest, afterResponse, afterMeta, afterEnvelope, afterHarness, afterSession}).To(Equal(
+			[]string{beforeRequest, beforeResponse, beforeMeta, beforeEnvelope, beforeHarness, beforeSession},
+		), "repair must not rewrite immutable raw-turn columns")
+
+		rawRows, err := driver.ListRawTurns(ctx, 0, 10)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rawRows).To(HaveLen(1))
+		Expect(rawRows[0].HarnessID).To(Equal(harnessID))
+		Expect(rawRows[0].HarnessSessionID).To(Equal(targetID))
+		Expect(rawRows[0].Meta).To(MatchJSON(`{"thread_id":"child-thread","future":"keep-me"}`))
+		var effectiveEnvelope sessions.IngestEnvelope
+		Expect(json.Unmarshal(rawRows[0].SessionEnvelope, &effectiveEnvelope)).To(Succeed())
+		Expect(effectiveEnvelope.HarnessID).To(Equal(harnessID))
+		Expect(effectiveEnvelope.HarnessSessionID).To(Equal(targetID))
+		Expect(effectiveEnvelope.ParentHarnessSessionID).NotTo(BeNil())
+		Expect(*effectiveEnvelope.ParentHarnessSessionID).To(Equal(parentID))
+		Expect(effectiveEnvelope.Cwd).To(Equal("/tmp/project"), "unrepaired envelope fields must survive the overlay")
+
+		var corpus bytes.Buffer
+		Expect(derive.WriteCorpus(&corpus, rawRows)).To(Succeed())
+		wire, transcripts, err := derive.LoadCorpus(&corpus)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(transcripts).To(BeEmpty())
+		Expect(wire).To(HaveLen(1))
+		var replayEnvelope sessions.IngestEnvelope
+		Expect(json.Unmarshal(wire[0].SessionEnvelope, &replayEnvelope)).To(Succeed())
+		Expect(replayEnvelope.HarnessID).To(Equal(harnessID))
+		Expect(replayEnvelope.HarnessSessionID).To(Equal(targetID))
+		Expect(replayEnvelope.ParentHarnessSessionID).NotTo(BeNil())
+		Expect(*replayEnvelope.ParentHarnessSessionID).To(Equal(parentID),
+			"dump-corpus replay must carry the effective repaired parent")
+
+		sessionRows, err := gensqlc.New(driver.DB()).ListRawTurnsBySession(ctx, gensqlc.ListRawTurnsBySessionParams{
+			OrgID: mustUUID(orgID), HarnessSessionID: targetID,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(sessionRows).To(HaveLen(1))
+		Expect(sessionRows[0].HarnessID).To(Equal(harnessID))
+		Expect(sessionRows[0].HarnessSessionID).To(Equal(targetID))
+		Expect(sessionRows[0].Meta).To(MatchJSON(`{"thread_id":"child-thread","future":"keep-me"}`))
+		Expect(sessionRows[0].SessionEnvelope).To(MatchJSON(rawRows[0].SessionEnvelope))
+
+		headers, err := driver.ListRawTurnHeaders(ctx, orgID, harnessID, targetID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(headers).To(HaveLen(1))
+		Expect(headers[0].Meta).To(MatchJSON(`{"thread_id":"child-thread","future":"keep-me"}`))
+
+		Expect(spanTurnsForHarnessSession(ctx, driver, orgID, harnessID, sourceID)).To(BeZero(),
+			"moving the only raw turn must clear the old projection")
+		Expect(spanTurnsForHarnessSession(ctx, driver, orgID, harnessID, targetID)).To(Equal(1))
+		source, err := driver.GetSessionRecordByHarness(ctx, orgID, harnessID, sourceID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(source).To(BeNil(), "moving the final effective turn must remove the ghost source identity")
+		listed, err := driver.ListSessionRecords(ctx, orgID, storage.SessionListOpts{Limit: 10})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(listed).NotTo(ContainElement(HaveField("HarnessSessionID", sourceID)))
+
+		var gotThread string
+		Expect(driver.DB().QueryRow(ctx, `
+			SELECT sp.thread_id
+			FROM spans_20260615 sp
+			JOIN sessions s ON s.id = sp.session_id
+			WHERE s.org_id = $1 AND s.harness_id = $2 AND s.harness_session_id = $3
+			  AND sp.kind = 'llm' AND sp.raw_turn_id = $4`,
+			orgID, harnessID, targetID, rawTurnID).Scan(&gotThread)).To(Succeed())
+		Expect(gotThread).To(Equal(threadID))
+
+		var gotParent string
+		Expect(driver.DB().QueryRow(ctx, `
+			SELECT parent.harness_session_id
+			FROM sessions child
+			JOIN sessions parent ON parent.id = child.parent_session_id
+			WHERE child.org_id = $1 AND child.harness_id = $2 AND child.harness_session_id = $3`,
+			orgID, harnessID, targetID).Scan(&gotParent)).To(Succeed())
+		Expect(gotParent).To(Equal(parentID))
+	})
+
+	It("synthesizes an effective envelope when the immutable raw row had none", func() {
+		const (
+			harnessID = "codex"
+			sourceID  = "envelope-less-source"
+			targetID  = "envelope-less-target"
+		)
+		_, err := driver.DB().Exec(ctx, `
+			INSERT INTO sessions (id, org_id, auth_subject, harness_id, harness_session_id, started_at, last_seen_at)
+			VALUES ($1, $2, 'user-test', $3, $4, NOW(), NOW())`,
+			newTestOrgID(), orgID, harnessID, sourceID)
+		Expect(err).NotTo(HaveOccurred())
+
+		inserted, err := driver.PutRawTurn(ctx, storage.RawTurnRecord{
+			OrgID: orgID, Source: storage.RawTurnSourceWire, Provider: "anthropic", AgentName: "codex",
+			HarnessID: harnessID, HarnessSessionID: sourceID, RequestID: "repair-envelope-less",
+			RawRequest: json.RawMessage(
+				`{"model":"claude-test","max_tokens":4096,"messages":[{"role":"user","content":"repair envelope"}]}`),
+			Response: json.RawMessage(
+				`{"model":"claude-test","message":{"role":"assistant","content":[{"type":"text","text":"repaired"}]},"stop_reason":"end_turn"}`),
+			Meta: json.RawMessage(`{"thread_id":"wrong-thread"}`),
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(inserted).To(BeTrue())
+
+		rawTurnID := rawTurnIDForRequest(ctx, driver, orgID, "repair-envelope-less")
+		_, err = driver.RepairRawTurnAttribution(ctx, "", storage.RawTurnAttributionRepairRequest{
+			OrgID: orgID, RawTurnID: rawTurnID, HarnessID: harnessID,
+			HarnessSessionID: targetID, ThreadID: "correct-thread", Reason: "exact identity evidence",
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		rows, err := driver.ListRawTurns(ctx, 0, 10)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rows).To(HaveLen(1))
+		Expect(rows[0].SessionEnvelope).To(MatchJSON(
+			`{"harness_id":"codex","harness_session_id":"envelope-less-target"}`))
+		var storedEnvelope *string
+		Expect(driver.DB().QueryRow(ctx,
+			"SELECT session_envelope::text FROM raw_turns WHERE org_id = $1 AND id = $2",
+			orgID, rawTurnID).Scan(&storedEnvelope)).To(Succeed())
+		Expect(storedEnvelope).To(BeNil(), "read-time repair must not materialize an envelope in raw_turns")
+	})
+
+	It("expands target liveness across out-of-order repairs without erasing its auth subject", func() {
+		const (
+			harnessID = "codex"
+			targetID  = "ordered-target"
+			earlyID   = "ordered-source-early"
+			lateID    = "ordered-source-late"
+		)
+		early := time.Date(2026, time.July, 10, 8, 0, 0, 0, time.UTC)
+		middle := early.Add(2 * time.Hour)
+		late := early.Add(4 * time.Hour)
+		_, err := driver.DB().Exec(ctx, `
+			INSERT INTO sessions (
+				id, org_id, auth_subject, harness_id, harness_session_id,
+				started_at, last_seen_at
+			) VALUES
+				($1, $2, 'source-early', $3, $4, $5, $5),
+				($6, $2, 'source-late', $3, $7, $8, $8),
+				($9, $2, 'target-subject', $3, $10, $11, $11)`,
+			newTestOrgID(), orgID, harnessID, earlyID, early,
+			newTestOrgID(), lateID, late,
+			newTestOrgID(), targetID, middle)
+		Expect(err).NotTo(HaveOccurred())
+
+		earlyTurnID := putAttributionRepairTurn(ctx, driver, orgID, harnessID, earlyID, "ordered-early")
+		lateTurnID := putAttributionRepairTurn(ctx, driver, orgID, harnessID, lateID, "ordered-late")
+		_, err = driver.DB().Exec(ctx,
+			"UPDATE raw_turns SET received_at = $1 WHERE org_id = $2 AND id = $3",
+			early, orgID, earlyTurnID)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = driver.DB().Exec(ctx,
+			"UPDATE raw_turns SET received_at = $1 WHERE org_id = $2 AND id = $3",
+			late, orgID, lateTurnID)
+		Expect(err).NotTo(HaveOccurred())
+
+		repair := func(rawTurnID int64) {
+			_, err := driver.RepairRawTurnAttribution(ctx, "", storage.RawTurnAttributionRepairRequest{
+				OrgID: orgID, RawTurnID: rawTurnID, HarnessID: harnessID,
+				HarnessSessionID: targetID, ThreadID: "target-thread", Reason: "ordered repair evidence",
+			})
+			Expect(err).NotTo(HaveOccurred())
+		}
+		repair(lateTurnID)
+		repair(earlyTurnID)
+
+		var startedAt, lastSeenAt time.Time
+		var authSubject string
+		Expect(driver.DB().QueryRow(ctx, `
+			SELECT started_at, last_seen_at, auth_subject
+			FROM sessions
+			WHERE org_id = $1 AND harness_id = $2 AND harness_session_id = $3`,
+			orgID, harnessID, targetID).Scan(&startedAt, &lastSeenAt, &authSubject)).To(Succeed())
+		Expect(startedAt).To(BeTemporally("==", early))
+		Expect(lastSeenAt).To(BeTemporally("==", late))
+		Expect(authSubject).To(Equal("target-subject"),
+			"a repair without envelope auth must preserve the target's existing subject")
+
+		repair(earlyTurnID)
+		var retryStartedAt, retryLastSeenAt time.Time
+		Expect(driver.DB().QueryRow(ctx, `
+			SELECT started_at, last_seen_at
+			FROM sessions
+			WHERE org_id = $1 AND harness_id = $2 AND harness_session_id = $3`,
+			orgID, harnessID, targetID).Scan(&retryStartedAt, &retryLastSeenAt)).To(Succeed())
+		Expect(retryStartedAt).To(BeTemporally("==", early))
+		Expect(retryLastSeenAt).To(BeTemporally("==", late))
+	})
+
+	It("keeps an empty repair source that still anchors child lineage", func() {
+		const (
+			harnessID = "codex"
+			sourceID  = "placeholder-parent"
+			childID   = "placeholder-child"
+			targetID  = "placeholder-target"
+		)
+		sourceRowID := newTestOrgID()
+		_, err := driver.DB().Exec(ctx, `
+			INSERT INTO sessions (
+				id, org_id, auth_subject, harness_id, harness_session_id,
+				parent_session_id, started_at, last_seen_at
+			) VALUES
+				($1, $2, 'parent-subject', $3, $4, NULL, NOW(), NOW()),
+				($5, $2, 'child-subject', $3, $6, $1, NOW(), NOW())`,
+			sourceRowID, orgID, harnessID, sourceID, newTestOrgID(), childID)
+		Expect(err).NotTo(HaveOccurred())
+		rawTurnID := putAttributionRepairTurn(ctx, driver, orgID, harnessID, sourceID, "placeholder-parent-turn")
+
+		_, err = driver.RepairRawTurnAttribution(ctx, "", storage.RawTurnAttributionRepairRequest{
+			OrgID: orgID, RawTurnID: rawTurnID, HarnessID: harnessID,
+			HarnessSessionID: targetID, ThreadID: "target-thread", Reason: "child lineage evidence",
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		source, err := driver.GetSessionRecordByHarness(ctx, orgID, harnessID, sourceID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(source).NotTo(BeNil(), "a referenced zero-turn parent remains a legitimate placeholder")
+		var childParentID string
+		Expect(driver.DB().QueryRow(ctx, `
+			SELECT parent_session_id::text FROM sessions
+			WHERE org_id = $1 AND harness_id = $2 AND harness_session_id = $3`,
+			orgID, harnessID, childID).Scan(&childParentID)).To(Succeed())
+		Expect(childParentID).To(Equal(sourceRowID))
+	})
+
+	It("keeps a repair source while another effective raw turn remains", func() {
+		const (
+			harnessID = "codex"
+			sourceID  = "partially-moved-source"
+			targetID  = "partially-moved-target"
+		)
+		_, err := driver.DB().Exec(ctx, `
+			INSERT INTO sessions (
+				id, org_id, auth_subject, harness_id, harness_session_id,
+				started_at, last_seen_at
+			) VALUES ($1, $2, 'source-subject', $3, $4, NOW(), NOW())`,
+			newTestOrgID(), orgID, harnessID, sourceID)
+		Expect(err).NotTo(HaveOccurred())
+		movedTurnID := putAttributionRepairTurn(ctx, driver, orgID, harnessID, sourceID, "partially-moved")
+		putAttributionRepairTurn(ctx, driver, orgID, harnessID, sourceID, "stays-on-source")
+		_, err = driver.RederiveSessionLocked(ctx, "", orgID, harnessID, sourceID)
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = driver.RepairRawTurnAttribution(ctx, "", storage.RawTurnAttributionRepairRequest{
+			OrgID: orgID, RawTurnID: movedTurnID, HarnessID: harnessID,
+			HarnessSessionID: targetID, ThreadID: "target-thread", Reason: "single-turn evidence",
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		source, err := driver.GetSessionRecordByHarness(ctx, orgID, harnessID, sourceID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(source).NotTo(BeNil())
+		Expect(spanTurnsForHarnessSession(ctx, driver, orgID, harnessID, sourceID)).To(Equal(1))
+	})
+
+	It("rejects missing rows and invalid replacement fields without writing an audit record", func() {
+		_, err := driver.RepairRawTurnAttribution(ctx, "", storage.RawTurnAttributionRepairRequest{
+			OrgID: orgID, RawTurnID: 999, HarnessID: "codex", HarnessSessionID: "child", Reason: "evidence",
+		})
+		Expect(err).To(MatchError(storage.ErrRawTurnNotFound))
+
+		_, err = driver.RepairRawTurnAttribution(ctx, "", storage.RawTurnAttributionRepairRequest{
+			OrgID: orgID, RawTurnID: 999, HarnessID: "", HarnessSessionID: "child", Reason: "",
+		})
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError(ContainSubstring("harness_id")))
+
+		self := "child"
+		_, err = driver.RepairRawTurnAttribution(ctx, "", storage.RawTurnAttributionRepairRequest{
+			OrgID: orgID, RawTurnID: 999, HarnessID: "codex", HarnessSessionID: self,
+			ParentHarnessSessionID: &self, Reason: "invalid lineage",
+		})
+		Expect(err).To(MatchError(ContainSubstring("cannot parent itself")))
+
+		var corrections int
+		Expect(driver.DB().QueryRow(ctx, "SELECT COUNT(*) FROM raw_turn_attribution_corrections").Scan(&corrections)).To(Succeed())
+		Expect(corrections).To(BeZero())
+	})
+
+	It("reports pending projections and converges via the derive queue when a synchronous rederive fails", func() {
+		const (
+			harnessID = "codex"
+			sourceID  = "pending-source"
+			targetID  = "pending-target"
+		)
+		_, err := driver.DB().Exec(ctx, `
+			INSERT INTO sessions (id, org_id, auth_subject, harness_id, harness_session_id, started_at, last_seen_at)
+			VALUES ($1, $2, 'user-test', $3, $4, NOW(), NOW())`,
+			newTestOrgID(), orgID, harnessID, sourceID)
+		Expect(err).NotTo(HaveOccurred())
+		rawTurnID := putAttributionRepairTurn(ctx, driver, orgID, harnessID, sourceID, "pending-request")
+		_, err = driver.RederiveSessionLocked(ctx, "", orgID, harnessID, sourceID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(spanTurnsForHarnessSession(ctx, driver, orgID, harnessID, sourceID)).To(Equal(1))
+
+		// Fail ONLY the second (effective-session) rebuild: the previous
+		// session's projection has already been rebuilt when the failure
+		// hits, so the resulting state is genuinely partial.
+		restore := postgres.SetRepairRederiveForTest(func(
+			d *postgres.Driver, ctx context.Context, project, org, hid, hsid string,
+		) (*derive.RederiveReport, error) {
+			if hsid == targetID {
+				return nil, errors.New("injected rederive failure")
+			}
+			return d.RederiveSession(ctx, project, org, hid, hsid)
+		})
+		defer restore()
+
+		result, err := driver.RepairRawTurnAttribution(ctx, "", storage.RawTurnAttributionRepairRequest{
+			OrgID: orgID, RawTurnID: rawTurnID, HarnessID: harnessID,
+			HarnessSessionID: targetID, ThreadID: "pending-thread", Reason: "pending evidence",
+		})
+		Expect(err).To(MatchError(storage.ErrRepairProjectionsPending))
+		Expect(err.Error()).To(ContainSubstring("injected rederive failure"))
+		Expect(result.Recorded).To(BeTrue(), "the correction committed before the rebuild failed")
+		Expect(result.Effective.HarnessSessionID).To(Equal(targetID))
+		Expect(result.ProjectionsPending).To(ConsistOf(
+			storage.RepairPendingSession{HarnessID: harnessID, HarnessSessionID: targetID}))
+
+		// The partial state is real: the correction is effective at read
+		// time, the old projection is already cleared, and the target's is
+		// stale (empty) until the queue converges it.
+		rows, err := driver.ListRawTurns(ctx, 0, 10)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rows).To(HaveLen(1))
+		Expect(rows[0].HarnessSessionID).To(Equal(targetID))
+		Expect(spanTurnsForHarnessSession(ctx, driver, orgID, harnessID, sourceID)).To(BeZero())
+		Expect(spanTurnsForHarnessSession(ctx, driver, orgID, harnessID, targetID)).To(BeZero())
+
+		// The stale session is queued for the worker...
+		entry, err := driver.GetDeriveDirty(ctx, orgID, harnessID, targetID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(entry).NotTo(BeNil(), "a failed synchronous rebuild must leave the session derive-dirty")
+
+		// ...and once the transient failure clears, the queue path converges
+		// exactly the way the worker does: rederive under the session lock,
+		// then clear the entry.
+		restore()
+		_, err = driver.RederiveSessionLocked(ctx, "", orgID, entry.HarnessID, entry.HarnessSessionID)
+		Expect(err).NotTo(HaveOccurred())
+		cleared, err := driver.ClearDeriveDirty(ctx, *entry)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cleared).To(BeTrue())
+		Expect(spanTurnsForHarnessSession(ctx, driver, orgID, harnessID, targetID)).To(Equal(1))
+	})
+
+	It("returns the applied result with source_cleanup_pending when only the source cleanup fails", func() {
+		const (
+			harnessID = "codex"
+			sourceID  = "cleanup-source"
+			targetID  = "cleanup-target"
+		)
+		_, err := driver.DB().Exec(ctx, `
+			INSERT INTO sessions (id, org_id, auth_subject, harness_id, harness_session_id, started_at, last_seen_at)
+			VALUES ($1, $2, 'user-test', $3, $4, NOW(), NOW())`,
+			newTestOrgID(), orgID, harnessID, sourceID)
+		Expect(err).NotTo(HaveOccurred())
+		rawTurnID := putAttributionRepairTurn(ctx, driver, orgID, harnessID, sourceID, "cleanup-request")
+		_, err = driver.RederiveSessionLocked(ctx, "", orgID, harnessID, sourceID)
+		Expect(err).NotTo(HaveOccurred())
+
+		restore := postgres.SetRepairSourceCleanupForTest(func(
+			*postgres.Driver, context.Context, pgtype.UUID, string, string,
+		) error {
+			return errors.New("injected cleanup failure")
+		})
+		defer restore()
+
+		result, err := driver.RepairRawTurnAttribution(ctx, "", storage.RawTurnAttributionRepairRequest{
+			OrgID: orgID, RawTurnID: rawTurnID, HarnessID: harnessID,
+			HarnessSessionID: targetID, ThreadID: "cleanup-thread", Reason: "cleanup evidence",
+		})
+		Expect(err).NotTo(HaveOccurred(),
+			"a cosmetic cleanup failure must not surface an already-applied repair as an error")
+		Expect(result.Recorded).To(BeTrue())
+		Expect(result.Effective.HarnessSessionID).To(Equal(targetID))
+		Expect(result.SourceCleanupPending).To(BeTrue())
+		Expect(result.ProjectionsPending).To(BeEmpty(),
+			"both projections rebuilt; only the leftover source row is outstanding")
+
+		// The repair genuinely applied: raw reads and both projections agree,
+		// and only the emptied source row is left behind.
+		rows, err := driver.ListRawTurns(ctx, 0, 10)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rows).To(HaveLen(1))
+		Expect(rows[0].HarnessSessionID).To(Equal(targetID))
+		Expect(spanTurnsForHarnessSession(ctx, driver, orgID, harnessID, sourceID)).To(BeZero())
+		Expect(spanTurnsForHarnessSession(ctx, driver, orgID, harnessID, targetID)).To(Equal(1))
+		source, err := driver.GetSessionRecordByHarness(ctx, orgID, harnessID, sourceID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(source).NotTo(BeNil(), "the skipped cleanup leaves the empty source row in place")
+	})
+
+	It("keeps the pending contract and joins the cleanup error when cleanup and the effective rederive both fail", func() {
+		const (
+			harnessID = "codex"
+			sourceID  = "combined-source"
+			targetID  = "combined-target"
+		)
+		_, err := driver.DB().Exec(ctx, `
+			INSERT INTO sessions (id, org_id, auth_subject, harness_id, harness_session_id, started_at, last_seen_at)
+			VALUES ($1, $2, 'user-test', $3, $4, NOW(), NOW())`,
+			newTestOrgID(), orgID, harnessID, sourceID)
+		Expect(err).NotTo(HaveOccurred())
+		rawTurnID := putAttributionRepairTurn(ctx, driver, orgID, harnessID, sourceID, "combined-request")
+		_, err = driver.RederiveSessionLocked(ctx, "", orgID, harnessID, sourceID)
+		Expect(err).NotTo(HaveOccurred())
+
+		restoreRederive := postgres.SetRepairRederiveForTest(func(
+			d *postgres.Driver, ctx context.Context, project, org, hid, hsid string,
+		) (*derive.RederiveReport, error) {
+			if hsid == targetID {
+				return nil, errors.New("injected rederive failure")
+			}
+			return d.RederiveSession(ctx, project, org, hid, hsid)
+		})
+		defer restoreRederive()
+		restoreCleanup := postgres.SetRepairSourceCleanupForTest(func(
+			*postgres.Driver, context.Context, pgtype.UUID, string, string,
+		) error {
+			return errors.New("injected cleanup failure")
+		})
+		defer restoreCleanup()
+
+		result, err := driver.RepairRawTurnAttribution(ctx, "", storage.RawTurnAttributionRepairRequest{
+			OrgID: orgID, RawTurnID: rawTurnID, HarnessID: harnessID,
+			HarnessSessionID: targetID, ThreadID: "combined-thread", Reason: "combined evidence",
+		})
+		Expect(err).To(MatchError(storage.ErrRepairProjectionsPending))
+		Expect(err.Error()).To(ContainSubstring("injected rederive failure"))
+		Expect(err.Error()).To(ContainSubstring("injected cleanup failure"),
+			"the cleanup failure must stay joined into the pending error, not lost")
+		Expect(result.Recorded).To(BeTrue())
+		Expect(result.SourceCleanupPending).To(BeTrue())
+		Expect(result.ProjectionsPending).To(ConsistOf(
+			storage.RepairPendingSession{HarnessID: harnessID, HarnessSessionID: targetID}))
+
+		entry, err := driver.GetDeriveDirty(ctx, orgID, harnessID, targetID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(entry).NotTo(BeNil(), "the stale projection must remain queued for the derive worker")
+	})
+
+	It("serializes a whole-org rederive with attribution repair", func() {
+		const (
+			harnessID = "codex"
+			sourceID  = "race-source"
+			targetID  = "race-target"
+		)
+		_, err := driver.DB().Exec(ctx, `
+			INSERT INTO sessions (id, org_id, auth_subject, harness_id, harness_session_id, started_at, last_seen_at)
+			VALUES ($1, $2, 'user-test', $3, $4, NOW(), NOW())`,
+			newTestOrgID(), orgID, harnessID, sourceID)
+		Expect(err).NotTo(HaveOccurred())
+
+		rec := storage.RawTurnRecord{
+			OrgID: orgID, Source: storage.RawTurnSourceWire, Provider: "anthropic", AgentName: "codex",
+			HarnessID: harnessID, HarnessSessionID: sourceID, RequestID: "repair-race-request",
+			RawRequest: json.RawMessage(`{"model":"claude-test","max_tokens":4096,"messages":[{"role":"user","content":"race"}]}`),
+			Response:   json.RawMessage(`{"model":"claude-test","message":{"role":"assistant","content":[{"type":"text","text":"serialized"}]},"stop_reason":"end_turn"}`),
+			Meta:       json.RawMessage(`{"thread_id":"wrong-thread"}`),
+			SessionEnvelope: json.RawMessage(fmt.Sprintf(
+				`{"org_id":%q,"auth_subject":"user-test","harness_id":%q,"harness_session_id":%q}`,
+				orgID, harnessID, sourceID)),
+		}
+		inserted, err := driver.PutRawTurn(ctx, rec)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(inserted).To(BeTrue())
+		_, err = driver.RederiveSessionLocked(ctx, "", orgID, harnessID, sourceID)
+		Expect(err).NotTo(HaveOccurred())
+
+		release, acquired, err := driver.TryDeriveSessionLock(ctx, orgID, harnessID, sourceID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(acquired).To(BeTrue())
+		var releaseOnce sync.Once
+		releaseHeldLock := func() { releaseOnce.Do(release) }
+		DeferCleanup(releaseHeldLock)
+
+		rederiveDone := make(chan error, 1)
+		go func() {
+			_, err := driver.RederiveFromRaw(ctx, "")
+			rederiveDone <- err
+		}()
+		Consistently(rederiveDone, 200*time.Millisecond).ShouldNot(Receive(),
+			"whole-org rederive must wait for the same session lock as repair and the worker")
+
+		repairDone := make(chan error, 1)
+		go func() {
+			_, err := driver.RepairRawTurnAttribution(ctx, "", storage.RawTurnAttributionRepairRequest{
+				OrgID: orgID, RawTurnID: rawTurnIDForRequest(ctx, driver, orgID, rec.RequestID),
+				HarnessID: harnessID, HarnessSessionID: targetID, ThreadID: "correct-thread", Reason: "race evidence",
+			})
+			repairDone <- err
+		}()
+		releaseHeldLock()
+
+		Eventually(rederiveDone).Should(Receive(BeNil()))
+		Eventually(repairDone).Should(Receive(BeNil()))
+		Expect(spanTurnsForHarnessSession(ctx, driver, orgID, harnessID, sourceID)).To(BeZero())
+		Expect(spanTurnsForHarnessSession(ctx, driver, orgID, harnessID, targetID)).To(Equal(1))
+		var gotThread string
+		Expect(driver.DB().QueryRow(ctx, `
+			SELECT sp.thread_id FROM spans_20260615 sp
+			JOIN sessions s ON s.id = sp.session_id
+			WHERE s.org_id = $1 AND s.harness_id = $2 AND s.harness_session_id = $3
+			  AND sp.kind = 'llm'`, orgID, harnessID, targetID).Scan(&gotThread)).To(Succeed())
+		Expect(gotThread).To(Equal("correct-thread"))
+	})
+})
+
+func rawTurnIDForRequest(ctx context.Context, driver *postgres.Driver, orgID, requestID string) int64 {
+	var id int64
+	Expect(driver.DB().QueryRow(ctx,
+		"SELECT id FROM raw_turns WHERE org_id = $1 AND request_id = $2", orgID, requestID).Scan(&id)).To(Succeed())
+	return id
+}
+
+func putAttributionRepairTurn(
+	ctx context.Context,
+	driver *postgres.Driver,
+	orgID, harnessID, harnessSessionID, requestID string,
+) int64 {
+	inserted, err := driver.PutRawTurn(ctx, storage.RawTurnRecord{
+		OrgID: orgID, Source: storage.RawTurnSourceWire, Provider: "anthropic", AgentName: "codex",
+		HarnessID: harnessID, HarnessSessionID: harnessSessionID, RequestID: requestID,
+		RawRequest: json.RawMessage(
+			`{"model":"claude-test","max_tokens":4096,"messages":[{"role":"user","content":"repair"}]}`),
+		Response: json.RawMessage(
+			`{"model":"claude-test","message":{"role":"assistant","content":[{"type":"text","text":"repaired"}]},"stop_reason":"end_turn"}`),
+		Meta: json.RawMessage(`{"thread_id":"source-thread"}`),
+	})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(inserted).To(BeTrue())
+	return rawTurnIDForRequest(ctx, driver, orgID, requestID)
+}
+
+func spanTurnsForHarnessSession(ctx context.Context, driver *postgres.Driver, orgID, harnessID, harnessSessionID string) int {
+	var count int
+	Expect(driver.DB().QueryRow(ctx, `
+		SELECT COUNT(*)
+		FROM span_turns_20260615 st
+		JOIN sessions s ON s.id = st.session_id
+		WHERE s.org_id = $1 AND s.harness_id = $2 AND s.harness_session_id = $3`,
+		orgID, harnessID, harnessSessionID).Scan(&count)).To(Succeed())
+	return count
+}

--- a/pkg/storage/postgres/raw_turns.go
+++ b/pkg/storage/postgres/raw_turns.go
@@ -121,7 +121,7 @@ func (d *Driver) CountRawTurns(ctx context.Context) (int64, error) {
 	return d.q.CountRawTurns(ctx)
 }
 
-func rawTurnRecordFromRow(row gensqlc.RawTurn) storage.RawTurnRecord {
+func rawTurnRecordFromRow(row gensqlc.ListRawTurnsRow) storage.RawTurnRecord {
 	return storage.RawTurnRecord{
 		ID:               row.ID,
 		OrgID:            uuidString(row.OrgID),
@@ -143,8 +143,9 @@ func rawTurnRecordFromRow(row gensqlc.RawTurn) storage.RawTurnRecord {
 	}
 }
 
-// rawTurnFromDeriveRow widens the narrow GetRawTurn projection to the full row
-// shape so both paths share one converter.
+// rawTurnRecordFromEffectiveRow converts the GetRawTurn projection — the raw
+// row as seen through the latest attribution correction — to the record shape
+// the deriver consumes.
 //
 // GetRawTurn selects raw_response only for turns whose reduction is missing
 // its content blocks (see the query). The deriver reads the reduced `response`
@@ -155,10 +156,10 @@ func rawTurnRecordFromRow(row gensqlc.RawTurn) storage.RawTurnRecord {
 // RawResponseDropped is not selected at all: it is a fidelity marker for the
 // projection, not an input to derivation, and it is zero here because the
 // query didn't ask — which is not the same as the row not having it.
-func rawTurnFromDeriveRow(row gensqlc.GetRawTurnRow) gensqlc.RawTurn {
-	return gensqlc.RawTurn{
+func rawTurnRecordFromEffectiveRow(row gensqlc.GetRawTurnRow) storage.RawTurnRecord {
+	return storage.RawTurnRecord{
 		ID:               row.ID,
-		OrgID:            row.OrgID,
+		OrgID:            uuidString(row.OrgID),
 		Source:           row.Source,
 		Provider:         row.Provider,
 		AgentName:        row.AgentName,
@@ -169,7 +170,7 @@ func rawTurnFromDeriveRow(row gensqlc.GetRawTurnRow) gensqlc.RawTurn {
 		Response:         row.Response,
 		Meta:             row.Meta,
 		SessionEnvelope:  row.SessionEnvelope,
-		ReceivedAt:       row.ReceivedAt,
+		ReceivedAt:       row.ReceivedAt.Time,
 
 		RawResponse:         row.RawResponse,
 		RawResponseEncoding: row.RawResponseEncoding,

--- a/pkg/storage/postgres/spans.go
+++ b/pkg/storage/postgres/spans.go
@@ -212,34 +212,32 @@ func writeSpanSet(
 	if len(coveredSessions) == 0 {
 		return nil
 	}
-	if len(keepTraces) > 0 {
-		if _, err := qtx.PruneSpanLinks(ctx, gensqlc.PruneSpanLinksParams{
-			OrgID:            orgID,
-			SessionIds:       coveredSessions,
-			KeepFromTraceIds: keepLinkFromTrace,
-			KeepFromSpanIds:  keepLinkFromSpan,
-			KeepToTraceIds:   keepLinkToTrace,
-			KeepToSpanIds:    keepLinkToSpan,
-			KeepFromIos:      keepLinkFromIO,
-			KeepToIos:        keepLinkToIO,
-		}); err != nil {
-			return fmt.Errorf("prune span links: %w", err)
-		}
-		if _, err := qtx.PruneSpans(ctx, gensqlc.PruneSpansParams{
-			OrgID:        orgID,
-			SessionIds:   coveredSessions,
-			KeepTraceIds: keepSpanTraceIDs,
-			KeepSpanIds:  keepSpanIDs,
-		}); err != nil {
-			return fmt.Errorf("prune spans: %w", err)
-		}
-		if _, err := qtx.PruneSpanTurns(ctx, gensqlc.PruneSpanTurnsParams{
-			OrgID:        orgID,
-			SessionIds:   coveredSessions,
-			KeepTraceIds: keepTraces,
-		}); err != nil {
-			return fmt.Errorf("prune span turns: %w", err)
-		}
+	if _, err := qtx.PruneSpanLinks(ctx, gensqlc.PruneSpanLinksParams{
+		OrgID:            orgID,
+		SessionIds:       coveredSessions,
+		KeepFromTraceIds: keepLinkFromTrace,
+		KeepFromSpanIds:  keepLinkFromSpan,
+		KeepToTraceIds:   keepLinkToTrace,
+		KeepToSpanIds:    keepLinkToSpan,
+		KeepFromIos:      keepLinkFromIO,
+		KeepToIos:        keepLinkToIO,
+	}); err != nil {
+		return fmt.Errorf("prune span links: %w", err)
+	}
+	if _, err := qtx.PruneSpans(ctx, gensqlc.PruneSpansParams{
+		OrgID:        orgID,
+		SessionIds:   coveredSessions,
+		KeepTraceIds: keepSpanTraceIDs,
+		KeepSpanIds:  keepSpanIDs,
+	}); err != nil {
+		return fmt.Errorf("prune spans: %w", err)
+	}
+	if _, err := qtx.PruneSpanTurns(ctx, gensqlc.PruneSpanTurnsParams{
+		OrgID:        orgID,
+		SessionIds:   coveredSessions,
+		KeepTraceIds: keepTraces,
+	}); err != nil {
+		return fmt.Errorf("prune span turns: %w", err)
 	}
 	if err := qtx.FoldSessionRollupsFromSpans(ctx, coveredSessions); err != nil {
 		return fmt.Errorf("fold session rollups: %w", err)

--- a/pkg/storage/raw_turn.go
+++ b/pkg/storage/raw_turn.go
@@ -116,3 +116,68 @@ type RawTurnStore interface {
 	// CountRawTurns reports the total number of raw rows.
 	CountRawTurns(ctx context.Context) (int64, error)
 }
+
+// RawTurnAttribution is the effective, repairable attribution projected over
+// an immutable raw turn. Raw payload and envelope bytes remain untouched.
+type RawTurnAttribution struct {
+	RawTurnID              int64   `json:"raw_turn_id"`
+	HarnessID              string  `json:"harness_id"`
+	HarnessSessionID       string  `json:"harness_session_id"`
+	ThreadID               string  `json:"thread_id"`
+	ParentHarnessSessionID *string `json:"parent_harness_session_id,omitempty"`
+}
+
+// RawTurnAttributionRepairRequest selects exactly one raw row and supplies a
+// complete replacement attribution. OrgID is supplied by the trusted caller
+// context, never by an HTTP request body.
+type RawTurnAttributionRepairRequest struct {
+	OrgID                  string  `json:"-"`
+	RawTurnID              int64   `json:"raw_turn_id,omitempty"`
+	PaperProxyRequestID    string  `json:"paper_proxy_request_id,omitempty"`
+	HarnessID              string  `json:"harness_id"`
+	HarnessSessionID       string  `json:"harness_session_id"`
+	ThreadID               string  `json:"thread_id"`
+	ParentHarnessSessionID *string `json:"parent_harness_session_id,omitempty"`
+	Reason                 string  `json:"reason"`
+}
+
+// RepairPendingSession names one harness session whose projection rebuild
+// did not complete synchronously during a repair. The session is already
+// queued for the derive worker, which converges it.
+type RepairPendingSession struct {
+	HarnessID        string `json:"harness_id"`
+	HarnessSessionID string `json:"harness_session_id"`
+}
+
+type RawTurnAttributionRepairResult struct {
+	Recorded  bool               `json:"recorded"`
+	Previous  RawTurnAttribution `json:"previous"`
+	Effective RawTurnAttribution `json:"effective"`
+
+	// ProjectionsPending lists the sessions whose synchronous rebuild failed
+	// after the correction committed. Empty on full success. When set, the
+	// correction is effective at read time and the listed projections
+	// converge via the derive queue (marked dirty in the correction
+	// transaction); the call returns ErrRepairProjectionsPending alongside
+	// this result.
+	ProjectionsPending []RepairPendingSession `json:"projections_pending,omitempty"`
+
+	// SourceCleanupPending reports that the best-effort removal of the
+	// emptied previous-session row failed after the correction and both
+	// projection rebuilds applied. The leftover row is cosmetic — it anchors
+	// no effective turns — and nothing retries the deletion automatically:
+	// the flag makes the response honest about the leftover, it is not a
+	// promise of later cleanup. On its own it never accompanies an error;
+	// when ProjectionsPending is empty too, the repair succeeded.
+	SourceCleanupPending bool `json:"source_cleanup_pending,omitempty"`
+}
+
+// RawTurnAttributionRepairer is an optional storage capability for audited,
+// append-only corrections to raw-turn attribution.
+//
+// When the returned error matches ErrRepairProjectionsPending the result is
+// still meaningful: the correction committed, and ProjectionsPending names
+// the sessions the derive worker will converge.
+type RawTurnAttributionRepairer interface {
+	RepairRawTurnAttribution(context.Context, string, RawTurnAttributionRepairRequest) (RawTurnAttributionRepairResult, error)
+}


### PR DESCRIPTION
## Summary
- Adds an append-only attribution-corrections overlay: `POST /v1/admin/raw-turns/attribution-repair` records an audited correction (effective `harness_session_id`, injected `meta.thread_id`, parent lineage) without ever mutating `raw_turns` — the latest correction projects through reads, corpus replay, and derivation.
- Repairs rederive synchronously: source and target session rebuilds serialize with the derive worker locks so a repair cannot leave either projection stale.
- An emptied source session row is removed only when no effective turn or child lineage still references it (guarded delete).
- Rollback is supersession: a newer correction wins; the audit trail is permanent.

## How it works
Corrections live in `raw_turn_attribution_corrections` (migration `1781480000`). Latest-wins laterals overlay the effective identity at read time in the derive/read queries (`queries/derive.sql`, `queries/raw_turns.sql`, `queries/derive_queue.sql`), so the deriver and the raw-turn read surface see the corrected row while storage stays byte-for-byte immutable. Target-session liveness expands across repaired turns without erasing an existing auth subject.

## Test plan
- [x] Full `GOEXPERIMENT=jsonv2 go test ./...` with a postgres DSN — green (repair flow, overlay reads, guarded delete, no-op detection, re-issue rederive)
- [x] golangci-lint v2.8.0, sqlc v1.30.0 generate-check, regenerated OpenAPI docs include the repair endpoint
- [x] Claude corpora/goldens byte-unchanged

part of PCC-1021