### PR TITLE
🧹 chore(logger): replace Charm logger with slog

### DIFF
--- a/cmd/tapes/dev/embedspans.go
+++ b/cmd/tapes/dev/embedspans.go
@@ -22,7 +22,6 @@ type embedSpansCommander struct {
 	postgresDSN string
 	orgID       string
 	batchSize   int
-	debug       bool
 
 	embeddingProvider   string
 	embeddingTarget     string
@@ -116,11 +115,6 @@ func newEmbedSpansCmd() *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			var err error
-			cmder.debug, err = cmd.Flags().GetBool("debug")
-			if err != nil {
-				return fmt.Errorf("could not get debug flag: %w", err)
-			}
 			return cmder.run(cmd)
 		},
 	}
@@ -137,7 +131,7 @@ func newEmbedSpansCmd() *cobra.Command {
 }
 
 func (c *embedSpansCommander) run(cmd *cobra.Command) error {
-	c.logger = logger.New(logger.WithDebug(c.debug))
+	c.logger = logger.FromContext(cmd.Context())
 	ctx := cmd.Context()
 
 	if c.postgresDSN == "" {

--- a/cmd/tapes/dev/embedspans.go
+++ b/cmd/tapes/dev/embedspans.go
@@ -137,7 +137,7 @@ func newEmbedSpansCmd() *cobra.Command {
 }
 
 func (c *embedSpansCommander) run(cmd *cobra.Command) error {
-	c.logger = logger.New(logger.WithDebug(c.debug), logger.WithPretty(true))
+	c.logger = logger.New(logger.WithDebug(c.debug))
 	ctx := cmd.Context()
 
 	if c.postgresDSN == "" {

--- a/cmd/tapes/local/local.go
+++ b/cmd/tapes/local/local.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"os"
 	"os/exec"
@@ -19,10 +20,11 @@ import (
 	"github.com/papercomputeco/tapes/pkg/cliui"
 	"github.com/papercomputeco/tapes/pkg/config"
 	"github.com/papercomputeco/tapes/pkg/dotdir"
+	"github.com/papercomputeco/tapes/pkg/logger"
 )
 
 // verboseDocker controls whether the raw `docker ...` invocations and their
-// stdout are echoed. Off by default for a clean bootstrap; enabled by -d/--debug.
+// stdout are echoed. Off by default for a clean bootstrap; enabled at debug level.
 var verboseDocker bool
 
 const (
@@ -135,9 +137,7 @@ func (c *localCommander) loadConfigDir(cmd *cobra.Command) error {
 		return fmt.Errorf("could not get config-dir flag: %w", err)
 	}
 	c.configDir = configDir
-	if debug, derr := cmd.Flags().GetBool("debug"); derr == nil {
-		verboseDocker = debug
-	}
+	verboseDocker = logger.SettingsFromContext(cmd.Context()).Level == slog.LevelDebug
 	return nil
 }
 

--- a/cmd/tapes/logging_test.go
+++ b/cmd/tapes/logging_test.go
@@ -1,0 +1,98 @@
+package tapescmder
+
+import (
+	"bytes"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/papercomputeco/tapes/pkg/logger"
+)
+
+var _ = Describe("update notice", func() {
+	It("omits ANSI when color is disabled", func() {
+		var output bytes.Buffer
+		printUpdateNotice(&output, "v1.2.3", false)
+
+		Expect(output.String()).To(And(
+			ContainSubstring("v1.2.3"),
+			Not(ContainSubstring("\x1b[")),
+		))
+	})
+
+	It("includes ANSI when color is enabled", func() {
+		var output bytes.Buffer
+		printUpdateNotice(&output, "v1.2.3", true)
+
+		Expect(output.String()).To(ContainSubstring("\x1b["))
+	})
+})
+
+var _ = Describe("logging flags", func() {
+	It("registers the logging controls with defaults", func() {
+		cmd := NewTapesCmd()
+
+		Expect(cmd.PersistentFlags().Lookup("log-level").DefValue).To(Equal("info"))
+		Expect(cmd.PersistentFlags().Lookup("log-format").DefValue).To(Equal("auto"))
+		Expect(cmd.PersistentFlags().Lookup("log-color").DefValue).To(Equal("auto"))
+		Expect(cmd.PersistentFlags().Lookup("debug").Deprecated).NotTo(BeEmpty())
+	})
+
+	It("maps the deprecated debug shorthand to debug level", func() {
+		cmd := NewTapesCmd()
+		Expect(cmd.PersistentFlags().Set("debug", "true")).To(Succeed())
+
+		settings, err := resolveLoggingSettings(cmd, "info", "auto", "auto")
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(settings.Level).To(Equal(slog.LevelDebug))
+	})
+
+	It("prefers an explicit log level over the debug shorthand", func() {
+		cmd := NewTapesCmd()
+		Expect(cmd.PersistentFlags().Set("debug", "true")).To(Succeed())
+		Expect(cmd.PersistentFlags().Set("log-level", "error")).To(Succeed())
+
+		settings, err := resolveLoggingSettings(cmd, "error", "json", "never")
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(settings).To(Equal(logger.Settings{
+			Level:  slog.LevelError,
+			Format: logger.FormatJSON,
+			Color:  logger.ColorNever,
+		}))
+	})
+
+	It("rejects invalid flag values", func() {
+		cmd := NewTapesCmd()
+
+		_, err := resolveLoggingSettings(cmd, "trace", "auto", "auto")
+		Expect(err).To(MatchError(ContainSubstring("invalid log level")))
+	})
+
+	It("lets a valid CLI value override an invalid config value", func() {
+		originalLogger := slog.Default()
+		DeferCleanup(slog.SetDefault, originalLogger)
+
+		configDir := GinkgoT().TempDir()
+		Expect(os.WriteFile(filepath.Join(configDir, "config.toml"), []byte(`[logging]
+level = "verbose"
+`), 0o600)).To(Succeed())
+
+		cmd := NewTapesCmd()
+		cmd.SetOut(&bytes.Buffer{})
+		cmd.SetErr(&bytes.Buffer{})
+		cmd.SetArgs([]string{
+			"--config-dir", configDir,
+			"--disable-telemetry",
+			"--disable-update-check",
+			"--log-level", "error",
+			"version",
+		})
+
+		Expect(cmd.Execute()).To(Succeed())
+	})
+})

--- a/cmd/tapes/search/search.go
+++ b/cmd/tapes/search/search.go
@@ -31,7 +31,6 @@ type searchCommander struct {
 	spans       bool
 	orgID       string
 	apiTarget   string
-	debug       bool
 	resultCount int
 
 	logger *slog.Logger
@@ -89,12 +88,7 @@ func NewSearchCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmder.query = args[0]
 
-			var err error
-			cmder.debug, err = cmd.Flags().GetBool("debug")
-			if err != nil {
-				return fmt.Errorf("could not get debug flag: %w", err)
-			}
-
+			cmder.logger = logger.FromContext(cmd.Context())
 			if err := cmder.run(); err != nil {
 				return err
 			}
@@ -114,8 +108,6 @@ func NewSearchCmd() *cobra.Command {
 }
 
 func (c *searchCommander) run() error {
-	c.logger = logger.New(logger.WithDebug(c.debug))
-
 	// Span search is the only mode; the deprecated --spans flag is
 	// accepted as a no-op for muscle memory.
 	return c.runSpans()

--- a/cmd/tapes/search/search.go
+++ b/cmd/tapes/search/search.go
@@ -114,7 +114,7 @@ func NewSearchCmd() *cobra.Command {
 }
 
 func (c *searchCommander) run() error {
-	c.logger = logger.New(logger.WithDebug(c.debug), logger.WithPretty(true))
+	c.logger = logger.New(logger.WithDebug(c.debug))
 
 	// Span search is the only mode; the deprecated --spans flag is
 	// accepted as a no-op for muscle memory.

--- a/cmd/tapes/serve/api/api.go
+++ b/cmd/tapes/serve/api/api.go
@@ -23,7 +23,6 @@ type apiCommander struct {
 	flags config.FlagSet
 
 	listen      string
-	debug       bool
 	postgresDSN string
 	webUI       bool
 
@@ -129,12 +128,6 @@ func newAPICmd(cmder *apiCommander) *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			var err error
-			cmder.debug, err = cmd.Flags().GetBool("debug")
-			if err != nil {
-				return fmt.Errorf("could not get debug flag: %w", err)
-			}
-
 			telemetry.FromContext(cmd.Context()).CaptureServerStarted("api")
 			return cmder.run(cmd.Context())
 		},
@@ -157,7 +150,7 @@ func newAPICmd(cmder *apiCommander) *cobra.Command {
 }
 
 func (c *apiCommander) run(ctx context.Context) error {
-	c.logger = logger.New(logger.WithDebug(c.debug))
+	c.logger = logger.FromContext(ctx)
 
 	driver, err := postgres.NewDriver(ctx, c.postgresDSN)
 	if err != nil {

--- a/cmd/tapes/serve/api/api.go
+++ b/cmd/tapes/serve/api/api.go
@@ -157,7 +157,7 @@ func newAPICmd(cmder *apiCommander) *cobra.Command {
 }
 
 func (c *apiCommander) run(ctx context.Context) error {
-	c.logger = logger.New(logger.WithDebug(c.debug), logger.WithPretty(true))
+	c.logger = logger.New(logger.WithDebug(c.debug))
 
 	driver, err := postgres.NewDriver(ctx, c.postgresDSN)
 	if err != nil {

--- a/cmd/tapes/serve/deriveworker/deriveworker.go
+++ b/cmd/tapes/serve/deriveworker/deriveworker.go
@@ -161,7 +161,7 @@ func NewDeriveWorkerCmd() *cobra.Command {
 }
 
 func (c *deriveWorkerCommander) run(ctx context.Context) error {
-	c.logger = logger.New(logger.WithDebug(c.debug), logger.WithPretty(true))
+	c.logger = logger.New(logger.WithDebug(c.debug))
 
 	// Bound the transient allocation overshoot of a large session derive
 	// to the container budget (PCC-767): the live set fits, but the

--- a/cmd/tapes/serve/deriveworker/deriveworker.go
+++ b/cmd/tapes/serve/deriveworker/deriveworker.go
@@ -25,7 +25,6 @@ import (
 type deriveWorkerCommander struct {
 	flags config.FlagSet
 
-	debug       bool
 	postgresDSN string
 	project     string
 
@@ -136,12 +135,6 @@ func NewDeriveWorkerCmd() *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			var err error
-			cmder.debug, err = cmd.Flags().GetBool("debug")
-			if err != nil {
-				return fmt.Errorf("could not get debug flag: %w", err)
-			}
-
 			telemetry.FromContext(cmd.Context()).CaptureServerStarted("derive-worker")
 			return cmder.run(cmd.Context())
 		},
@@ -161,7 +154,7 @@ func NewDeriveWorkerCmd() *cobra.Command {
 }
 
 func (c *deriveWorkerCommander) run(ctx context.Context) error {
-	c.logger = logger.New(logger.WithDebug(c.debug))
+	c.logger = logger.FromContext(ctx)
 
 	// Bound the transient allocation overshoot of a large session derive
 	// to the container budget (PCC-767): the live set fits, but the

--- a/cmd/tapes/serve/embedworker/embedworker.go
+++ b/cmd/tapes/serve/embedworker/embedworker.go
@@ -27,7 +27,6 @@ import (
 type embedWorkerCommander struct {
 	flags config.FlagSet
 
-	debug       bool
 	postgresDSN string
 
 	interval      string
@@ -162,12 +161,6 @@ func NewEmbedWorkerCmd() *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			var err error
-			cmder.debug, err = cmd.Flags().GetBool("debug")
-			if err != nil {
-				return fmt.Errorf("could not get debug flag: %w", err)
-			}
-
 			telemetry.FromContext(cmd.Context()).CaptureServerStarted("embed-worker")
 			return cmder.run(cmd.Context())
 		},
@@ -189,7 +182,7 @@ func NewEmbedWorkerCmd() *cobra.Command {
 }
 
 func (c *embedWorkerCommander) run(ctx context.Context) error {
-	c.logger = logger.New(logger.WithDebug(c.debug))
+	c.logger = logger.FromContext(ctx)
 
 	if c.postgresDSN == "" {
 		return errors.New("embed worker requires a postgres DSN (--postgres or storage.postgres_dsn)")

--- a/cmd/tapes/serve/embedworker/embedworker.go
+++ b/cmd/tapes/serve/embedworker/embedworker.go
@@ -189,7 +189,7 @@ func NewEmbedWorkerCmd() *cobra.Command {
 }
 
 func (c *embedWorkerCommander) run(ctx context.Context) error {
-	c.logger = logger.New(logger.WithDebug(c.debug), logger.WithPretty(true))
+	c.logger = logger.New(logger.WithDebug(c.debug))
 
 	if c.postgresDSN == "" {
 		return errors.New("embed worker requires a postgres DSN (--postgres or storage.postgres_dsn)")

--- a/cmd/tapes/serve/ingest/ingest.go
+++ b/cmd/tapes/serve/ingest/ingest.go
@@ -150,7 +150,7 @@ func NewIngestCmd() *cobra.Command {
 }
 
 func (c *ingestCommander) run() error {
-	c.logger = logger.New(logger.WithDebug(c.debug), logger.WithPretty(true))
+	c.logger = logger.New(logger.WithDebug(c.debug))
 
 	driver, err := postgres.NewDriver(context.TODO(), c.postgresDSN)
 	if err != nil {

--- a/cmd/tapes/serve/ingest/ingest.go
+++ b/cmd/tapes/serve/ingest/ingest.go
@@ -21,7 +21,6 @@ type ingestCommander struct {
 	flags config.FlagSet
 
 	listen      string
-	debug       bool
 	postgresDSN string
 	project     string
 
@@ -126,12 +125,7 @@ func NewIngestCmd() *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			var err error
-			cmder.debug, err = cmd.Flags().GetBool("debug")
-			if err != nil {
-				return fmt.Errorf("could not get debug flag: %w", err)
-			}
-
+			cmder.logger = logger.FromContext(cmd.Context())
 			telemetry.FromContext(cmd.Context()).CaptureServerStarted("ingest")
 			return cmder.run()
 		},
@@ -150,8 +144,6 @@ func NewIngestCmd() *cobra.Command {
 }
 
 func (c *ingestCommander) run() error {
-	c.logger = logger.New(logger.WithDebug(c.debug))
-
 	driver, err := postgres.NewDriver(context.TODO(), c.postgresDSN)
 	if err != nil {
 		return err

--- a/cmd/tapes/serve/proxy/proxy.go
+++ b/cmd/tapes/serve/proxy/proxy.go
@@ -23,7 +23,6 @@ type proxyCommander struct {
 	listen       string
 	upstream     string
 	providerType string
-	debug        bool
 	postgresDSN  string
 	project      string
 
@@ -130,12 +129,7 @@ func NewProxyCmd() *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			var err error
-			cmder.debug, err = cmd.Flags().GetBool("debug")
-			if err != nil {
-				return fmt.Errorf("could not get debug flag: %w", err)
-			}
-
+			cmder.logger = logger.FromContext(cmd.Context())
 			telemetry.FromContext(cmd.Context()).CaptureServerStarted("proxy")
 			return cmder.run()
 		},
@@ -156,8 +150,6 @@ func NewProxyCmd() *cobra.Command {
 }
 
 func (c *proxyCommander) run() error {
-	c.logger = logger.New(logger.WithDebug(c.debug))
-
 	driver, err := postgres.NewDriver(context.TODO(), c.postgresDSN)
 	if err != nil {
 		return err

--- a/cmd/tapes/serve/proxy/proxy.go
+++ b/cmd/tapes/serve/proxy/proxy.go
@@ -156,7 +156,7 @@ func NewProxyCmd() *cobra.Command {
 }
 
 func (c *proxyCommander) run() error {
-	c.logger = logger.New(logger.WithDebug(c.debug), logger.WithPretty(true))
+	c.logger = logger.New(logger.WithDebug(c.debug))
 
 	driver, err := postgres.NewDriver(context.TODO(), c.postgresDSN)
 	if err != nil {

--- a/cmd/tapes/serve/serve.go
+++ b/cmd/tapes/serve/serve.go
@@ -2,7 +2,6 @@
 package servecmder
 
 import (
-	"fmt"
 	"os/signal"
 	"syscall"
 	"time"
@@ -24,7 +23,6 @@ import (
 type ServeCommander struct {
 	flags config.FlagSet
 	stack Stack
-	debug bool
 
 	refresh time.Duration
 }
@@ -80,11 +78,6 @@ func NewServeCmd() *cobra.Command {
 			return cmder.stack.Resolve(cmd, cmder.flags)
 		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			var err error
-			cmder.debug, err = cmd.Flags().GetBool("debug")
-			if err != nil {
-				return fmt.Errorf("could not get debug flag: %w", err)
-			}
 			telemetry.FromContext(cmd.Context()).CaptureServerStarted("both")
 
 			return cmder.run(cmd)
@@ -104,7 +97,7 @@ func NewServeCmd() *cobra.Command {
 }
 
 func (c *ServeCommander) run(cmd *cobra.Command) error {
-	c.stack.Logger = logger.New(logger.WithDebug(c.debug))
+	c.stack.Logger = logger.FromContext(cmd.Context())
 	c.configureCassettes(cmd)
 
 	// Signal-aware context: a SIGINT/SIGTERM cancels it, which stops the

--- a/cmd/tapes/serve/serve.go
+++ b/cmd/tapes/serve/serve.go
@@ -104,7 +104,7 @@ func NewServeCmd() *cobra.Command {
 }
 
 func (c *ServeCommander) run(cmd *cobra.Command) error {
-	c.stack.Logger = logger.New(logger.WithDebug(c.debug), logger.WithPretty(true))
+	c.stack.Logger = logger.New(logger.WithDebug(c.debug))
 	c.configureCassettes(cmd)
 
 	// Signal-aware context: a SIGINT/SIGTERM cancels it, which stops the

--- a/cmd/tapes/start/start.go
+++ b/cmd/tapes/start/start.go
@@ -335,9 +335,9 @@ func (c *startCommander) runForeground(ctx context.Context) error {
 	}
 	defer logFile.Close()
 
-	prettyLogger := logger.New(logger.WithDebug(c.debug), logger.WithPretty(true), logger.WithWriter(os.Stdout))
+	consoleLogger := logger.New(logger.WithDebug(c.debug), logger.WithWriter(os.Stdout))
 	jsonLogger := logger.New(logger.WithDebug(c.debug), logger.WithJSON(true), logger.WithWriter(logFile))
-	log := logger.Multi(prettyLogger, jsonLogger)
+	log := logger.Multi(consoleLogger, jsonLogger)
 
 	return c.runServices(ctx, manager, log, false)
 }

--- a/cmd/tapes/start/start.go
+++ b/cmd/tapes/start/start.go
@@ -57,7 +57,7 @@ Examples:
 )
 
 type startCommander struct {
-	debug         bool
+	logSettings   logger.Settings
 	configDir     string
 	logs          bool
 	daemon        bool
@@ -104,11 +104,8 @@ func NewStartCmd() *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmder.logSettings = logger.SettingsFromContext(cmd.Context())
 			var err error
-			cmder.debug, err = cmd.Flags().GetBool("debug")
-			if err != nil {
-				return fmt.Errorf("could not get debug flag: %w", err)
-			}
 			cmder.configDir, err = cmd.Flags().GetString("config-dir")
 			if err != nil {
 				return fmt.Errorf("could not get config-dir flag: %w", err)
@@ -335,8 +332,8 @@ func (c *startCommander) runForeground(ctx context.Context) error {
 	}
 	defer logFile.Close()
 
-	consoleLogger := logger.New(logger.WithDebug(c.debug), logger.WithWriter(os.Stdout))
-	jsonLogger := logger.New(logger.WithDebug(c.debug), logger.WithJSON(true), logger.WithWriter(logFile))
+	consoleLogger := c.logSettings.New(logger.WithWriter(os.Stdout))
+	jsonLogger := c.logSettings.New(logger.WithFormat(logger.FormatJSON), logger.WithWriter(logFile))
 	log := logger.Multi(consoleLogger, jsonLogger)
 
 	return c.runServices(ctx, manager, log, false)
@@ -354,7 +351,8 @@ func (c *startCommander) runDaemon(ctx context.Context) error {
 	}
 	defer logFile.Close()
 
-	log := logger.New(logger.WithDebug(c.debug), logger.WithJSON(true), logger.WithWriter(logFile))
+	logSettings := c.logSettings.WithDefaultFormat(logger.FormatJSON)
+	log := logSettings.New(logger.WithWriter(logFile))
 
 	return c.runServices(ctx, manager, log, true)
 }
@@ -581,18 +579,7 @@ func (c *startCommander) spawnDaemon(ctx context.Context, manager *start.Manager
 		return fmt.Errorf("opening log file: %w", err)
 	}
 
-	args := []string{"start", "--daemon"}
-	if c.debug {
-		args = append(args, "--debug")
-	}
-	if c.configDir != "" {
-		args = append(args, "--config-dir", c.configDir)
-	}
-	if c.postgresDSN != "" {
-		args = append(args, "--postgres", c.postgresDSN)
-	}
-
-	cmd := exec.CommandContext(ctx, execPath, args...)
+	cmd := exec.CommandContext(ctx, execPath, c.daemonArgs()...)
 	cmd.Stdout = logFile
 	cmd.Stderr = logFile
 
@@ -609,6 +596,23 @@ func (c *startCommander) spawnDaemon(ctx context.Context, manager *start.Manager
 	c.daemonDone = done
 
 	return logFile.Close()
+}
+
+func (c *startCommander) daemonArgs() []string {
+	args := []string{
+		"start",
+		"--daemon",
+		"--log-level", strings.ToLower(c.logSettings.Level.String()),
+		"--log-format", string(c.logSettings.Format),
+		"--log-color", string(c.logSettings.Color),
+	}
+	if c.configDir != "" {
+		args = append(args, "--config-dir", c.configDir)
+	}
+	if c.postgresDSN != "" {
+		args = append(args, "--postgres", c.postgresDSN)
+	}
+	return args
 }
 
 func (c *startCommander) waitForDaemon(ctx context.Context, manager *start.Manager) (*start.State, error) {

--- a/cmd/tapes/start/start_test.go
+++ b/cmd/tapes/start/start_test.go
@@ -3,6 +3,7 @@ package startcmder
 import (
 	"bytes"
 	"context"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -14,8 +15,32 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/papercomputeco/tapes/pkg/credentials"
+	"github.com/papercomputeco/tapes/pkg/logger"
 	"github.com/papercomputeco/tapes/pkg/start"
 )
+
+var _ = Describe("daemonArgs", func() {
+	It("propagates resolved logging settings", func() {
+		cmder := &startCommander{
+			logSettings: logger.Settings{
+				Level:  slog.LevelWarn,
+				Format: logger.FormatJSON,
+				Color:  logger.ColorNever,
+			},
+			configDir:   "/tmp/tapes",
+			postgresDSN: "postgres://example",
+		}
+
+		Expect(cmder.daemonArgs()).To(Equal([]string{
+			"start", "--daemon",
+			"--log-level", "warn",
+			"--log-format", "json",
+			"--log-color", "never",
+			"--config-dir", "/tmp/tapes",
+			"--postgres", "postgres://example",
+		}))
+	})
+})
 
 var _ = Describe("runLogs", func() {
 	var tmpDir string

--- a/cmd/tapes/tapes.go
+++ b/cmd/tapes/tapes.go
@@ -149,7 +149,7 @@ func preRun(cmd *cobra.Command, args []string) error {
 // execution. Viper handles the flag > env > config file precedence for the
 // telemetry.disabled setting.
 func initTelemetry(cmd *cobra.Command, _ []string) error {
-	initTelemLogger := logger.New(logger.WithDebug(true), logger.WithPretty(true))
+	initTelemLogger := logger.New(logger.WithDebug(true))
 	configDir, _ := cmd.Flags().GetString("config-dir")
 
 	v, err := config.InitViper(configDir)

--- a/cmd/tapes/tapes.go
+++ b/cmd/tapes/tapes.go
@@ -2,7 +2,10 @@
 package tapescmder
 
 import (
+	"fmt"
+	"io"
 	"log/slog"
+	"os"
 
 	"github.com/spf13/cobra"
 
@@ -76,6 +79,21 @@ var tapesFlags = config.FlagSet{
 		ViperKey:    "update.disabled",
 		Description: "Disable checking for new versions",
 	},
+	config.FlagLogLevel: {
+		Name:        "log-level",
+		ViperKey:    "logging.level",
+		Description: "Minimum log level (debug, info, warn, error)",
+	},
+	config.FlagLogFormat: {
+		Name:        "log-format",
+		ViperKey:    "logging.format",
+		Description: "Log format (auto, console, text, json)",
+	},
+	config.FlagLogColor: {
+		Name:        "log-color",
+		ViperKey:    "logging.color",
+		Description: "Console log color mode (auto, always, never)",
+	},
 }
 
 func NewTapesCmd() *cobra.Command {
@@ -88,7 +106,12 @@ func NewTapesCmd() *cobra.Command {
 	}
 
 	// Global flags
+	defaults := config.NewDefaultConfig()
 	cmd.PersistentFlags().BoolP("debug", "d", false, "Enable debug logging")
+	_ = cmd.PersistentFlags().MarkDeprecated("debug", "use --log-level=debug instead")
+	cmd.PersistentFlags().String("log-level", defaults.Logging.Level, "Minimum log level (debug, info, warn, error)")
+	cmd.PersistentFlags().String("log-format", defaults.Logging.Format, "Log format (auto, console, text, json)")
+	cmd.PersistentFlags().String("log-color", defaults.Logging.Color, "Console log color mode (auto, always, never)")
 	cmd.PersistentFlags().String("config-dir", "", "Override path to .tapes/ config directory")
 	cmd.PersistentFlags().Bool("disable-telemetry", false, "Disable anonymous usage telemetry")
 	cmd.PersistentFlags().Bool("disable-update-check", false, "Disable checking for new versions")
@@ -123,24 +146,61 @@ func NewTapesCmd() *cobra.Command {
 func preRun(cmd *cobra.Command, args []string) error {
 	configDir, _ := cmd.Flags().GetString("config-dir")
 	v, err := config.InitViper(configDir)
-
-	updateDisabled := false
-	if err == nil {
-		config.BindRegisteredFlags(v, cmd, tapesFlags, []string{
-			config.FlagUpdateCheckDisabled,
-		})
-		updateDisabled = v.GetBool("update.disabled")
+	if err != nil {
+		return fmt.Errorf("loading config: %w", err)
 	}
 
-	if !updateDisabled {
+	config.BindRegisteredFlags(v, cmd, tapesFlags, []string{
+		config.FlagUpdateCheckDisabled,
+		config.FlagTelemetryDisabled,
+		config.FlagLogLevel,
+		config.FlagLogFormat,
+		config.FlagLogColor,
+	})
+
+	settings, err := resolveLoggingSettings(cmd, v.GetString("logging.level"), v.GetString("logging.format"), v.GetString("logging.color"))
+	if err != nil {
+		return err
+	}
+	cmd.SetContext(logger.WithSettings(cmd.Context(), settings))
+	slog.SetDefault(settings.New())
+
+	if !v.GetBool("update.disabled") {
 		if msg := update.CheckForUpdate(utils.Version); msg != "" {
-			println("\033[33;1mTapes Update Available!\033[0m")
-			println("\033[34m" + utils.Version + " → " + msg + "\033[0m")
-			println("\033[37mRun: curl -sSfL https://download.tapes.dev/install | bash\033[0m")
+			printUpdateNotice(os.Stderr, msg, logger.ColorEnabled(os.Stderr, settings.Color))
 		}
 	}
 
-	return initTelemetry(cmd, args)
+	return initTelemetry(cmd, args, configDir, v.GetBool("telemetry.disabled"))
+}
+
+func printUpdateNotice(w io.Writer, version string, color bool) {
+	if color {
+		fmt.Fprintln(w, "\033[33;1mTapes Update Available!\033[0m")
+		fmt.Fprintf(w, "\033[34m%s → %s\033[0m\n", utils.Version, version)
+		fmt.Fprintln(w, "\033[37mRun: curl -sSfL https://download.tapes.dev/install | bash\033[0m")
+		return
+	}
+
+	fmt.Fprintln(w, "Tapes Update Available!")
+	fmt.Fprintf(w, "%s → %s\n", utils.Version, version)
+	fmt.Fprintln(w, "Run: curl -sSfL https://download.tapes.dev/install | bash")
+}
+
+func resolveLoggingSettings(cmd *cobra.Command, level, format, color string) (logger.Settings, error) {
+	debug, err := cmd.Root().PersistentFlags().GetBool("debug")
+	if err != nil {
+		return logger.Settings{}, fmt.Errorf("could not get debug flag: %w", err)
+	}
+	if debug && !cmd.Root().PersistentFlags().Changed("log-level") {
+		level = "debug"
+	}
+
+	settings, err := logger.ParseSettings(level, format, color)
+	if err != nil {
+		return logger.Settings{}, err
+	}
+	return settings, nil
 }
 
 // initTelemetry initializes anonymous telemetry and stores the client in the
@@ -148,23 +208,12 @@ func preRun(cmd *cobra.Command, args []string) error {
 // flag, env var, or CI detection — errors during init never block command
 // execution. Viper handles the flag > env > config file precedence for the
 // telemetry.disabled setting.
-func initTelemetry(cmd *cobra.Command, _ []string) error {
-	initTelemLogger := logger.New(logger.WithDebug(true))
-	configDir, _ := cmd.Flags().GetString("config-dir")
-
-	v, err := config.InitViper(configDir)
-	if err != nil {
-		initTelemLogger.Warn("Could not initiate telemetry, continuing", "error", err)
-		return nil
-	}
-
-	config.BindRegisteredFlags(v, cmd, tapesFlags, []string{
-		config.FlagTelemetryDisabled,
-	})
+func initTelemetry(cmd *cobra.Command, _ []string, configDir string, disabled bool) error {
+	initTelemLogger := logger.FromContext(cmd.Context())
 
 	// Single check covers --disable-telemetry flag, TAPES_TELEMETRY_DISABLED
 	// env var, and config.toml [telemetry] disabled setting.
-	if v.GetBool("telemetry.disabled") {
+	if disabled {
 		return nil
 	}
 

--- a/cmd/tapes/tapes_suite_test.go
+++ b/cmd/tapes/tapes_suite_test.go
@@ -1,0 +1,13 @@
+package tapescmder
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestTapesCommand(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Tapes Command Suite")
+}

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	charm.land/lipgloss/v2 v2.0.0
 	github.com/BurntSushi/toml v1.6.0
 	github.com/charmbracelet/glamour v0.10.0
-	github.com/charmbracelet/log v0.4.2
 	github.com/charmbracelet/x/ansi v0.11.6
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/getkin/kin-openapi v0.142.0
@@ -17,6 +16,7 @@ require (
 	github.com/golang-migrate/migrate/v4 v4.19.1
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.8.0
+	github.com/lmittmann/tint v1.2.0
 	github.com/modelcontextprotocol/go-sdk v1.2.0
 	github.com/muesli/termenv v0.16.0
 	github.com/onsi/ginkgo/v2 v2.27.4
@@ -59,7 +59,6 @@ require (
 	github.com/dlclark/regexp2 v1.11.0 // indirect
 	github.com/docker/docker v28.5.2+incompatible // indirect
 	github.com/docker/go-connections v0.6.0 // indirect
-	github.com/go-logfmt/logfmt v0.6.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-openapi/jsonpointer v0.22.5 // indirect
 	github.com/go-openapi/jsonreference v0.19.6 // indirect
@@ -116,7 +115,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.40.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
-	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect
 	golang.org/x/net v0.50.0 // indirect
 	golang.org/x/oauth2 v0.32.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -46,8 +46,6 @@ github.com/charmbracelet/glamour v0.10.0 h1:MtZvfwsYCx8jEPFJm3rIBFIMZUfUJ765oX8V
 github.com/charmbracelet/glamour v0.10.0/go.mod h1:f+uf+I/ChNmqo087elLnVdCiVgjSKWuXa/l6NU2ndYk=
 github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834 h1:ZR7e0ro+SZZiIZD7msJyA+NjkCNNavuiPBLgerbOziE=
 github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834/go.mod h1:aKC/t2arECF6rNOnaKaVU6y4t4ZeHQzqfxedE/VkVhA=
-github.com/charmbracelet/log v0.4.2 h1:hYt8Qj6a8yLnvR+h7MwsJv/XvmBJXiueUcI3cIxsyig=
-github.com/charmbracelet/log v0.4.2/go.mod h1:qifHGX/tc7eluv2R6pWIpyHDDrrb/AG71Pf2ysQu5nw=
 github.com/charmbracelet/ultraviolet v0.0.0-20260205113103-524a6607adb8 h1:eyFRbAmexyt43hVfeyBofiGSEmJ7krjLOYt/9CF5NKA=
 github.com/charmbracelet/ultraviolet v0.0.0-20260205113103-524a6607adb8/go.mod h1:SQpCTRNBtzJkwku5ye4S3HEuthAlGy2n9VXZnWkEW98=
 github.com/charmbracelet/x/ansi v0.11.6 h1:GhV21SiDz/45W9AnV2R61xZMRri5NlLnl6CVF7ihZW8=
@@ -104,8 +102,6 @@ github.com/gkampitakis/go-diff v1.3.2 h1:Qyn0J9XJSDTgnsgHRdz9Zp24RaJeKMUHg2+PDZZ
 github.com/gkampitakis/go-diff v1.3.2/go.mod h1:LLgOrpqleQe26cte8s36HTWcTmMEur6OPYerdAAS9tk=
 github.com/gkampitakis/go-snaps v0.5.15 h1:amyJrvM1D33cPHwVrjo9jQxX8g/7E2wYdZ+01KS3zGE=
 github.com/gkampitakis/go-snaps v0.5.15/go.mod h1:HNpx/9GoKisdhw9AFOBT1N7DBs9DiHo/hGheFGBZ+mc=
-github.com/go-logfmt/logfmt v0.6.0 h1:wGYYu3uicYdqXVgoYbvnkrPVXkuLM1p1ifugDMEdRi4=
-github.com/go-logfmt/logfmt v0.6.0/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
@@ -194,6 +190,8 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
 github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
+github.com/lmittmann/tint v1.2.0 h1:AogHRHy8HUJUnNJBHJlYa+fR4YY8mko2cnCp67xn9JY=
+github.com/lmittmann/tint v1.2.0/go.mod h1:HIS3gSy7qNwGCj+5oRjAutErFBl4BzdQP6cJZ0NfMwE=
 github.com/lucasb-eyer/go-colorful v1.3.0 h1:2/yBRLdWBZKrf7gB40FoiKfAWYQ0lqNcbuQwVHXptag=
 github.com/lucasb-eyer/go-colorful v1.3.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -79,6 +79,9 @@ func ValidConfigKeys() []string {
 		"embedding.dimensions",
 		"opencode.provider",
 		"opencode.model",
+		"logging.level",
+		"logging.format",
+		"logging.color",
 		"telemetry.disabled",
 		"update.disabled",
 	}
@@ -155,6 +158,9 @@ func (c *Configer) LoadConfig() (*Config, error) {
 	// synthesize from defaults.
 	merged.Version = cfg.Version
 	merged.Cassettes = cfg.Cassettes
+	if err := validateLoggingConfig(merged.Logging); err != nil {
+		return nil, err
+	}
 
 	return merged, nil
 }
@@ -167,6 +173,9 @@ func (c *Configer) SaveConfig(cfg *Config) error {
 
 	if c.targetPath == "" {
 		return errors.New("cannot save empty target path")
+	}
+	if err := validateLoggingConfig(cfg.Logging); err != nil {
+		return err
 	}
 
 	var buf bytes.Buffer
@@ -218,6 +227,9 @@ func (c *Configer) SetConfigValue(key string, value string) error {
 	// Preserve fields which are not scalar set/get keys.
 	updated.Version = cfg.Version
 	updated.Cassettes = cfg.Cassettes
+	if err := validateLoggingConfig(updated.Logging); err != nil {
+		return err
+	}
 
 	return c.SaveConfig(updated)
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -78,6 +78,20 @@ dimensions = 768
 			Expect(cfg.Embedding.Dimensions).To(Equal(uint(768)))
 		})
 
+		It("rejects invalid resolved logging settings", func() {
+			data := `[logging]
+level = "verbose"
+`
+			Expect(os.WriteFile(filepath.Join(tmpDir, "config.toml"), []byte(data), 0o600)).To(Succeed())
+
+			c, err := config.NewConfiger(tmpDir)
+			Expect(err).NotTo(HaveOccurred())
+
+			cfg, err := c.LoadConfig()
+			Expect(err).To(MatchError(ContainSubstring("invalid logging config")))
+			Expect(cfg).To(BeNil())
+		})
+
 		It("loads all config fields", func() {
 			data := `version = 0
 
@@ -458,6 +472,9 @@ listen = ":7070"
 				"embedding.dimensions",
 				"opencode.provider",
 				"opencode.model",
+				"logging.level",
+				"logging.format",
+				"logging.color",
 			))
 		})
 
@@ -476,6 +493,9 @@ listen = ":7070"
 			Expect(config.IsValidConfigKey("client.api_target")).To(BeTrue())
 			Expect(config.IsValidConfigKey("opencode.provider")).To(BeTrue())
 			Expect(config.IsValidConfigKey("opencode.model")).To(BeTrue())
+			Expect(config.IsValidConfigKey("logging.level")).To(BeTrue())
+			Expect(config.IsValidConfigKey("logging.format")).To(BeTrue())
+			Expect(config.IsValidConfigKey("logging.color")).To(BeTrue())
 		})
 
 		It("returns false for invalid keys", func() {
@@ -520,6 +540,11 @@ listen = ":7070"
 					Target:     "http://localhost:11434",
 					Model:      "nomic-embed-text",
 					Dimensions: 1024,
+				},
+				Logging: config.LoggingConfig{
+					Level:  "info",
+					Format: "auto",
+					Color:  "auto",
 				},
 			}
 
@@ -696,6 +721,9 @@ var _ = Describe("NewDefaultConfig", func() {
 		Expect(cfg.Embedding.Target).To(Equal("http://localhost:11434"))
 		Expect(cfg.Embedding.Model).To(Equal("embeddinggemma"))
 		Expect(cfg.Embedding.Dimensions).To(Equal(uint(768)))
+		Expect(cfg.Logging.Level).To(Equal("info"))
+		Expect(cfg.Logging.Format).To(Equal("auto"))
+		Expect(cfg.Logging.Color).To(Equal("auto"))
 	})
 })
 
@@ -724,6 +752,9 @@ var _ = Describe("InitViper", func() {
 		Expect(v.GetString("api.listen")).To(Equal(defaults.API.Listen))
 		Expect(v.GetString("client.proxy_target")).To(Equal(defaults.Client.ProxyTarget))
 		Expect(v.GetString("client.api_target")).To(Equal(defaults.Client.APITarget))
+		Expect(v.GetString("logging.level")).To(Equal("info"))
+		Expect(v.GetString("logging.format")).To(Equal("auto"))
+		Expect(v.GetString("logging.color")).To(Equal("auto"))
 	})
 
 	It("reads config file values over defaults", func() {
@@ -745,29 +776,38 @@ upstream = "https://api.anthropic.com"
 	})
 
 	It("respects environment variables with TAPES_ prefix", func() {
-		os.Setenv("TAPES_PROXY_PROVIDER", "openai")
-		defer os.Unsetenv("TAPES_PROXY_PROVIDER")
+		Expect(os.Setenv("TAPES_PROXY_PROVIDER", "openai")).To(Succeed())
+		DeferCleanup(os.Unsetenv, "TAPES_PROXY_PROVIDER")
+		Expect(os.Setenv("TAPES_LOGGING_LEVEL", "warn")).To(Succeed())
+		DeferCleanup(os.Unsetenv, "TAPES_LOGGING_LEVEL")
 
 		v, err := config.InitViper(tmpDir)
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(v.GetString("proxy.provider")).To(Equal("openai"))
+		Expect(v.GetString("logging.level")).To(Equal("warn"))
 	})
 
 	It("env vars take precedence over config file values", func() {
 		data := `[proxy]
 provider = "anthropic"
+
+[logging]
+level = "verbose"
 `
 		err := os.WriteFile(filepath.Join(tmpDir, "config.toml"), []byte(data), 0o600)
 		Expect(err).NotTo(HaveOccurred())
 
-		os.Setenv("TAPES_PROXY_PROVIDER", "openai")
-		defer os.Unsetenv("TAPES_PROXY_PROVIDER")
+		Expect(os.Setenv("TAPES_PROXY_PROVIDER", "openai")).To(Succeed())
+		DeferCleanup(os.Unsetenv, "TAPES_PROXY_PROVIDER")
+		Expect(os.Setenv("TAPES_LOGGING_LEVEL", "error")).To(Succeed())
+		DeferCleanup(os.Unsetenv, "TAPES_LOGGING_LEVEL")
 
 		v, err := config.InitViper(tmpDir)
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(v.GetString("proxy.provider")).To(Equal("openai"))
+		Expect(v.GetString("logging.level")).To(Equal("error"))
 	})
 })
 

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -13,6 +13,10 @@ const (
 	defaultEmbeddingModel      = "embeddinggemma"
 	defaultEmbeddingDimensions = 768
 	defaultEmbeddingTarget     = "http://localhost:11434"
+
+	defaultLogLevel  = "info"
+	defaultLogFormat = "auto"
+	defaultLogColor  = "auto"
 )
 
 // NewDefaultConfig returns a Config with sane defaults for all fields.
@@ -42,6 +46,11 @@ func NewDefaultConfig() *Config {
 			Target:     defaultUpstream,
 			Model:      defaultEmbeddingModel,
 			Dimensions: defaultEmbeddingDimensions,
+		},
+		Logging: LoggingConfig{
+			Level:  defaultLogLevel,
+			Format: defaultLogFormat,
+			Color:  defaultLogColor,
 		},
 	}
 }

--- a/pkg/config/flags.go
+++ b/pkg/config/flags.go
@@ -55,6 +55,9 @@ const (
 	FlagProxyTarget         = "proxy-target"
 	FlagTelemetryDisabled   = "telemetry-disabled"
 	FlagUpdateCheckDisabled = "update-check-disabled"
+	FlagLogLevel            = "log-level"
+	FlagLogFormat           = "log-format"
+	FlagLogColor            = "log-color"
 	FlagCassettes           = "cassettes"
 
 	FlagIngestListen = "ingest-listen"

--- a/pkg/config/logging.go
+++ b/pkg/config/logging.go
@@ -1,0 +1,25 @@
+package config
+
+import (
+	"fmt"
+
+	"github.com/papercomputeco/tapes/pkg/logger"
+)
+
+func validateLoggingConfig(logging LoggingConfig) error {
+	defaults := NewDefaultConfig().Logging
+	if logging.Level == "" {
+		logging.Level = defaults.Level
+	}
+	if logging.Format == "" {
+		logging.Format = defaults.Format
+	}
+	if logging.Color == "" {
+		logging.Color = defaults.Color
+	}
+
+	if _, err := logger.ParseSettings(logging.Level, logging.Format, logging.Color); err != nil {
+		return fmt.Errorf("invalid logging config: %w", err)
+	}
+	return nil
+}

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -12,8 +12,9 @@ type Config struct {
 	VectorStore VectorStoreConfig `toml:"vector_store"  mapstructure:"vector_store"`
 	Embedding   EmbeddingConfig   `toml:"embedding"     mapstructure:"embedding"`
 	OpenCode    OpenCodeConfig    `toml:"opencode"      mapstructure:"opencode"`
+	Logging     LoggingConfig     `toml:"logging"       mapstructure:"logging"`
 	Telemetry   TelemetryConfig   `toml:"telemetry"     mapstructure:"telemetry"`
-	Update      UpdateConfig      `toml:"update" mapstructure:"update"`
+	Update      UpdateConfig      `toml:"update"        mapstructure:"update"`
 	// Cassettes contains exact OpenAPI document URLs for externally managed cassettes.
 	Cassettes []string `toml:"cassettes" mapstructure:"cassettes"`
 }
@@ -69,6 +70,13 @@ type OpenCodeConfig struct {
 	Model    string `toml:"model,omitempty"    mapstructure:"model"`
 }
 
+// LoggingConfig holds process-wide logging settings.
+type LoggingConfig struct {
+	Level  string `toml:"level,omitempty"  mapstructure:"level"`
+	Format string `toml:"format,omitempty" mapstructure:"format"`
+	Color  string `toml:"color,omitempty"  mapstructure:"color"`
+}
+
 // TelemetryConfig holds anonymous telemetry settings.
 type TelemetryConfig struct {
 	Disabled bool `toml:"disabled,omitempty" mapstructure:"disabled"`
@@ -99,6 +107,10 @@ var configKeySet = map[string]bool{
 	"embedding.dimensions":  true,
 	"opencode.provider":     true,
 	"opencode.model":        true,
+
+	"logging.level":  true,
+	"logging.format": true,
+	"logging.color":  true,
 
 	"storage.postgres_dsn": true,
 

--- a/pkg/config/viper.go
+++ b/pkg/config/viper.go
@@ -105,6 +105,11 @@ func setViperDefaults(v *viper.Viper) {
 	v.SetDefault("opencode.provider", d.OpenCode.Provider)
 	v.SetDefault("opencode.model", d.OpenCode.Model)
 
+	// Logging
+	v.SetDefault("logging.level", d.Logging.Level)
+	v.SetDefault("logging.format", d.Logging.Format)
+	v.SetDefault("logging.color", d.Logging.Color)
+
 	// Telemetry
 	v.SetDefault("telemetry.disabled", d.Telemetry.Disabled)
 

--- a/pkg/logger/config.go
+++ b/pkg/logger/config.go
@@ -32,7 +32,7 @@ func (c *config) buildHandler() slog.Handler {
 		return tint.NewTextHandler(w, &tint.Options{
 			Level:      slog.LevelDebug,
 			AddSource:  c.source,
-			TimeFormat: time.Kitchen,
+			TimeFormat: time.StampMilli,
 		})
 	}
 

--- a/pkg/logger/config.go
+++ b/pkg/logger/config.go
@@ -3,15 +3,16 @@ package logger
 import (
 	"io"
 	"log/slog"
+	"time"
 
-	charmlog "github.com/charmbracelet/log"
+	"github.com/lmittmann/tint"
 )
 
 // config holds the resolved logger configuration.
 type config struct {
 	level   slog.Level
 	writers []io.Writer
-	pretty  bool
+	debug   bool
 	json    bool
 	source  bool
 }
@@ -20,14 +21,18 @@ type config struct {
 func (c *config) buildHandler() slog.Handler {
 	w := c.writer()
 
-	if c.pretty {
-		return c.newCharmHandler(w)
-	}
-
 	if c.json {
 		return slog.NewJSONHandler(w, &slog.HandlerOptions{
 			Level:     c.level,
 			AddSource: c.source,
+		})
+	}
+
+	if c.debug {
+		return tint.NewTextHandler(w, &tint.Options{
+			Level:      slog.LevelDebug,
+			AddSource:  c.source,
+			TimeFormat: time.Kitchen,
 		})
 	}
 
@@ -44,28 +49,4 @@ func (c *config) writer() io.Writer {
 		return c.writers[0]
 	}
 	return io.MultiWriter(c.writers...)
-}
-
-// newCharmHandler creates a charmbracelet/log handler configured as an slog.Handler.
-func (c *config) newCharmHandler(w io.Writer) slog.Handler {
-	var charmLevel charmlog.Level
-	switch {
-	case c.level <= slog.LevelDebug:
-		charmLevel = charmlog.DebugLevel
-	case c.level <= slog.LevelInfo:
-		charmLevel = charmlog.InfoLevel
-	case c.level <= slog.LevelWarn:
-		charmLevel = charmlog.WarnLevel
-	default:
-		charmLevel = charmlog.ErrorLevel
-	}
-
-	l := charmlog.NewWithOptions(w, charmlog.Options{
-		Level:           charmLevel,
-		ReportTimestamp: true,
-		ReportCaller:    c.source,
-	})
-
-	// *charmlog.Logger implements slog.Handler directly.
-	return l
 }

--- a/pkg/logger/config.go
+++ b/pkg/logger/config.go
@@ -3,36 +3,62 @@ package logger
 import (
 	"io"
 	"log/slog"
+	"os"
 	"time"
 
 	"github.com/lmittmann/tint"
+	"golang.org/x/term"
 )
 
 // config holds the resolved logger configuration.
 type config struct {
-	level   slog.Level
+	level   slog.Leveler
 	writers []io.Writer
-	debug   bool
-	json    bool
+	format  Format
+	color   ColorMode
 	source  bool
 }
 
-// buildHandler returns the appropriate slog.Handler for the configuration.
+// buildHandler returns handlers configured independently for each writer so
+// auto format and color decisions reflect the actual destination.
 func (c *config) buildHandler() slog.Handler {
-	w := c.writer()
+	handlers := make([]slog.Handler, len(c.writers))
+	for index, writer := range c.writers {
+		handlers[index] = c.buildHandlerForWriter(writer)
+	}
+	if len(handlers) == 1 {
+		return handlers[0]
+	}
+	return &multiHandler{handlers: handlers}
+}
 
-	if c.json {
+func (c *config) buildHandlerForWriter(w io.Writer) slog.Handler {
+	format := c.format
+	if format == FormatAuto {
+		if c.color == ColorAlways || isTerminal(w) {
+			format = FormatConsole
+		} else {
+			format = FormatText
+		}
+	}
+
+	switch format {
+	case FormatAuto, FormatText:
+		return slog.NewTextHandler(w, &slog.HandlerOptions{
+			Level:     c.level,
+			AddSource: c.source,
+		})
+	case FormatJSON:
 		return slog.NewJSONHandler(w, &slog.HandlerOptions{
 			Level:     c.level,
 			AddSource: c.source,
 		})
-	}
-
-	if c.debug {
+	case FormatConsole:
 		return tint.NewTextHandler(w, &tint.Options{
-			Level:      slog.LevelDebug,
+			Level:      c.level,
 			AddSource:  c.source,
 			TimeFormat: time.StampMilli,
+			NoColor:    !ColorEnabled(w, c.color),
 		})
 	}
 
@@ -42,11 +68,28 @@ func (c *config) buildHandler() slog.Handler {
 	})
 }
 
-// writer returns the resolved io.Writer. If multiple writers were configured,
-// they are combined via io.MultiWriter.
-func (c *config) writer() io.Writer {
-	if len(c.writers) == 1 {
-		return c.writers[0]
+// ColorEnabled reports whether color should be emitted to w under mode.
+func ColorEnabled(w io.Writer, mode ColorMode) bool {
+	switch mode {
+	case ColorAlways:
+		return true
+	case ColorNever:
+		return false
+	case ColorAuto:
+		if _, disabled := os.LookupEnv("NO_COLOR"); disabled {
+			return false
+		}
+		return isTerminal(w)
 	}
-	return io.MultiWriter(c.writers...)
+
+	return false
+}
+
+type fileDescriptorWriter interface {
+	Fd() uintptr
+}
+
+func isTerminal(w io.Writer) bool {
+	fdWriter, ok := w.(fileDescriptorWriter)
+	return ok && term.IsTerminal(int(fdWriter.Fd()))
 }

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -1,7 +1,7 @@
 // Package logger provides opinionated logging capabilities for the tapes system.
 //
-// It builds on Go's log/slog, with colorized debug output and structured JSON
-// for services. All public constructors return *slog.Logger directly — no
+// It builds on Go's log/slog, with terminal-aware console output and structured
+// JSON for services. All public constructors return *slog.Logger directly — no
 // custom interface.
 package logger
 
@@ -13,11 +13,13 @@ import (
 
 // New creates a *slog.Logger configured by the given options.
 //
-// Defaults: Info level, writes to os.Stdout, slog.TextHandler.
+// Defaults: Info level, auto format and color, writes to os.Stderr.
 func New(opts ...Option) *slog.Logger {
 	cfg := &config{
 		level:   slog.LevelInfo,
-		writers: []io.Writer{os.Stdout},
+		writers: []io.Writer{os.Stderr},
+		format:  FormatAuto,
+		color:   ColorAuto,
 	}
 
 	for _, opt := range opts {

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -1,8 +1,8 @@
 // Package logger provides opinionated logging capabilities for the tapes system.
 //
-// It builds on Go's log/slog, with pluggable handlers for pretty CLI output
-// (via charmbracelet/log) and structured JSON for services. All public
-// constructors return *slog.Logger directly — no custom interface.
+// It builds on Go's log/slog, with colorized debug output and structured JSON
+// for services. All public constructors return *slog.Logger directly — no
+// custom interface.
 package logger
 
 import (

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -34,7 +34,7 @@ var _ = Describe("Logger", func() {
 			Expect(buf.String()).To(And(
 				ContainSubstring("debug msg"),
 				ContainSubstring("\x1b["),
-				MatchRegexp(`\d{1,2}:\d{2}(AM|PM)`),
+				MatchRegexp(`[A-Z][a-z]{2}\s+\d{1,2} \d{2}:\d{2}:\d{2}\.\d{3}`),
 			))
 		})
 

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -26,9 +26,14 @@ var _ = Describe("Logger", func() {
 			Expect(output).To(ContainSubstring("value"))
 		})
 
-		It("uses tint at debug level", func() {
+		It("uses tint for console output", func() {
 			var buf bytes.Buffer
-			l := logger.New(logger.WithWriter(&buf), logger.WithDebug(true))
+			l := logger.New(
+				logger.WithWriter(&buf),
+				logger.WithLevel(slog.LevelDebug),
+				logger.WithFormat(logger.FormatConsole),
+				logger.WithColor(logger.ColorAlways),
+			)
 			l.Debug("debug msg")
 
 			Expect(buf.String()).To(And(
@@ -38,9 +43,48 @@ var _ = Describe("Logger", func() {
 			))
 		})
 
+		It("forces console colors for redirected auto output", func() {
+			var buf bytes.Buffer
+			l := logger.New(
+				logger.WithWriter(&buf),
+				logger.WithFormat(logger.FormatAuto),
+				logger.WithColor(logger.ColorAlways),
+			)
+			l.Info("forced color")
+
+			Expect(buf.String()).To(ContainSubstring("\x1b["))
+		})
+
+		It("omits color from redirected console output by default", func() {
+			var buf bytes.Buffer
+			l := logger.New(
+				logger.WithWriter(&buf),
+				logger.WithFormat(logger.FormatConsole),
+				logger.WithColor(logger.ColorAuto),
+			)
+			l.Info("redirected")
+
+			Expect(buf.String()).To(And(
+				ContainSubstring("redirected"),
+				Not(ContainSubstring("\x1b[")),
+			))
+		})
+
+		It("honors the never color policy", func() {
+			var buf bytes.Buffer
+			l := logger.New(
+				logger.WithWriter(&buf),
+				logger.WithFormat(logger.FormatConsole),
+				logger.WithColor(logger.ColorNever),
+			)
+			l.Info("plain console")
+
+			Expect(buf.String()).NotTo(ContainSubstring("\x1b["))
+		})
+
 		It("filters debug when not enabled", func() {
 			var buf bytes.Buffer
-			l := logger.New(logger.WithWriter(&buf), logger.WithDebug(false))
+			l := logger.New(logger.WithWriter(&buf), logger.WithLevel(slog.LevelInfo))
 			l.Debug("hidden")
 
 			Expect(buf.String()).To(BeEmpty())
@@ -48,7 +92,7 @@ var _ = Describe("Logger", func() {
 
 		It("creates a JSON logger", func() {
 			var buf bytes.Buffer
-			l := logger.New(logger.WithWriter(&buf), logger.WithJSON(true))
+			l := logger.New(logger.WithWriter(&buf), logger.WithFormat(logger.FormatJSON))
 			l.Info("structured", "count", 42)
 
 			var parsed map[string]any
@@ -70,9 +114,9 @@ var _ = Describe("Logger", func() {
 			))
 		})
 
-		It("keeps JSON output in debug mode", func() {
+		It("keeps JSON output at debug level", func() {
 			var buf bytes.Buffer
-			l := logger.New(logger.WithWriter(&buf), logger.WithJSON(true), logger.WithDebug(true))
+			l := logger.New(logger.WithWriter(&buf), logger.WithFormat(logger.FormatJSON), logger.WithLevel(slog.LevelDebug))
 			l.Debug("structured debug")
 
 			var parsed map[string]any
@@ -84,10 +128,22 @@ var _ = Describe("Logger", func() {
 
 		It("includes source in debug output", func() {
 			var buf bytes.Buffer
-			l := logger.New(logger.WithWriter(&buf), logger.WithDebug(true), logger.WithSource(true))
+			l := logger.New(logger.WithWriter(&buf), logger.WithLevel(slog.LevelDebug), logger.WithSource(true))
 			l.Debug("with source")
 
 			Expect(buf.String()).To(ContainSubstring("logger_test.go"))
+		})
+
+		It("filters at an explicitly configured level", func() {
+			var buf bytes.Buffer
+			l := logger.New(logger.WithWriter(&buf), logger.WithLevel(slog.LevelWarn))
+			l.Info("hidden")
+			l.Warn("visible")
+
+			Expect(buf.String()).To(And(
+				Not(ContainSubstring("hidden")),
+				ContainSubstring("visible"),
+			))
 		})
 
 		It("supports multiple writers", func() {
@@ -103,6 +159,35 @@ var _ = Describe("Logger", func() {
 			l := logger.New()
 			// Verify it's a real *slog.Logger by calling Handler()
 			Expect(l.Handler()).NotTo(BeNil())
+		})
+	})
+
+	Describe("Settings", func() {
+		It("parses supported values", func() {
+			settings, err := logger.ParseSettings("warn", "json", "never")
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(settings.Level).To(Equal(slog.LevelWarn))
+			Expect(settings.Format).To(Equal(logger.FormatJSON))
+			Expect(settings.Color).To(Equal(logger.ColorNever))
+		})
+
+		It("rejects invalid values", func() {
+			_, err := logger.ParseSettings("verbose", "json", "never")
+			Expect(err).To(MatchError(ContainSubstring("invalid log level")))
+
+			_, err = logger.ParseSettings("info", "yaml", "never")
+			Expect(err).To(MatchError(ContainSubstring("invalid log format")))
+
+			_, err = logger.ParseSettings("info", "text", "sometimes")
+			Expect(err).To(MatchError(ContainSubstring("invalid log color")))
+		})
+
+		It("round trips through context", func() {
+			settings := logger.Settings{Level: slog.LevelError, Format: logger.FormatJSON, Color: logger.ColorNever}
+			ctx := logger.WithSettings(context.Background(), settings)
+
+			Expect(logger.SettingsFromContext(ctx)).To(Equal(settings))
 		})
 	})
 
@@ -146,7 +231,7 @@ var _ = Describe("Logger", func() {
 
 		It("supports With on multi logger", func() {
 			var buf bytes.Buffer
-			l := logger.New(logger.WithWriter(&buf), logger.WithJSON(true))
+			l := logger.New(logger.WithWriter(&buf), logger.WithFormat(logger.FormatJSON))
 			multi := logger.Multi(l)
 
 			child := multi.With("component", "test")
@@ -161,7 +246,7 @@ var _ = Describe("Logger", func() {
 
 		It("supports WithGroup on multi logger", func() {
 			var buf bytes.Buffer
-			l := logger.New(logger.WithWriter(&buf), logger.WithJSON(true))
+			l := logger.New(logger.WithWriter(&buf), logger.WithFormat(logger.FormatJSON))
 			multi := logger.Multi(l)
 
 			child := multi.WithGroup("request")
@@ -186,7 +271,7 @@ var _ = Describe("Logger", func() {
 	Describe("With", func() {
 		It("binds fields to child logger", func() {
 			var buf bytes.Buffer
-			l := logger.New(logger.WithWriter(&buf), logger.WithJSON(true))
+			l := logger.New(logger.WithWriter(&buf), logger.WithFormat(logger.FormatJSON))
 			child := l.With("service", "proxy")
 			child.Info("started")
 
@@ -202,7 +287,7 @@ var _ = Describe("Logger", func() {
 	Describe("WithGroup", func() {
 		It("nests keys under group", func() {
 			var buf bytes.Buffer
-			l := logger.New(logger.WithWriter(&buf), logger.WithJSON(true))
+			l := logger.New(logger.WithWriter(&buf), logger.WithFormat(logger.FormatJSON))
 			child := l.WithGroup("request")
 			child.Info("processed", "method", "GET")
 

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -26,12 +26,16 @@ var _ = Describe("Logger", func() {
 			Expect(output).To(ContainSubstring("value"))
 		})
 
-		It("respects debug level", func() {
+		It("uses tint at debug level", func() {
 			var buf bytes.Buffer
 			l := logger.New(logger.WithWriter(&buf), logger.WithDebug(true))
 			l.Debug("debug msg")
 
-			Expect(buf.String()).To(ContainSubstring("debug msg"))
+			Expect(buf.String()).To(And(
+				ContainSubstring("debug msg"),
+				ContainSubstring("\x1b["),
+				MatchRegexp(`\d{1,2}:\d{2}(AM|PM)`),
+			))
 		})
 
 		It("filters debug when not enabled", func() {
@@ -54,12 +58,36 @@ var _ = Describe("Logger", func() {
 			Expect(parsed["count"]).To(BeNumerically("==", 42))
 		})
 
-		It("creates a pretty logger", func() {
+		It("uses native text output when debug is disabled", func() {
 			var buf bytes.Buffer
-			l := logger.New(logger.WithWriter(&buf), logger.WithPretty(true))
-			l.Info("pretty output")
+			l := logger.New(logger.WithWriter(&buf))
+			l.Info("text output")
 
-			Expect(buf.String()).To(ContainSubstring("pretty output"))
+			Expect(buf.String()).To(And(
+				ContainSubstring("level=INFO"),
+				ContainSubstring("msg=\"text output\""),
+				Not(ContainSubstring("\x1b[")),
+			))
+		})
+
+		It("keeps JSON output in debug mode", func() {
+			var buf bytes.Buffer
+			l := logger.New(logger.WithWriter(&buf), logger.WithJSON(true), logger.WithDebug(true))
+			l.Debug("structured debug")
+
+			var parsed map[string]any
+			err := json.Unmarshal(buf.Bytes(), &parsed)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(parsed["level"]).To(Equal("DEBUG"))
+			Expect(parsed["msg"]).To(Equal("structured debug"))
+		})
+
+		It("includes source in debug output", func() {
+			var buf bytes.Buffer
+			l := logger.New(logger.WithWriter(&buf), logger.WithDebug(true), logger.WithSource(true))
+			l.Debug("with source")
+
+			Expect(buf.String()).To(ContainSubstring("logger_test.go"))
 		})
 
 		It("supports multiple writers", func() {

--- a/pkg/logger/multi.go
+++ b/pkg/logger/multi.go
@@ -7,7 +7,7 @@ import (
 )
 
 // multiHandler fans out log records to multiple slog.Handler instances.
-// Used by the start command to write pretty output to stdout and JSON to a
+// Used by the start command to write console output to stdout and JSON to a
 // log file simultaneously.
 type multiHandler struct {
 	handlers []slog.Handler

--- a/pkg/logger/options.go
+++ b/pkg/logger/options.go
@@ -8,41 +8,65 @@ import (
 // Option configures a Logger created with New.
 type Option func(*config)
 
+// WithLevel sets the minimum enabled log level.
+func WithLevel(level slog.Leveler) Option {
+	return func(c *config) {
+		c.level = level
+	}
+}
+
+// WithFormat sets the log record format.
+func WithFormat(format Format) Option {
+	return func(c *config) {
+		c.format = format
+	}
+}
+
+// WithColor sets the console color policy.
+func WithColor(color ColorMode) Option {
+	return func(c *config) {
+		c.color = color
+	}
+}
+
 // WithDebug sets the log level to Debug when true, Info otherwise.
-func WithDebug(debug bool) Option {
-	return func(c *config) {
-		c.debug = debug
-		if debug {
-			c.level = slog.LevelDebug
-		} else {
-			c.level = slog.LevelInfo
-		}
-	}
-}
-
-// WithPretty is retained for source compatibility. Output formatting is now
-// selected by WithDebug: debug logs use tint and normal logs use slog text.
 //
-// Deprecated: use WithDebug to enable colorized debug output.
-func WithPretty(_ bool) Option {
-	return func(_ *config) {}
-}
-
-// WithJSON enables slog's JSON handler for structured service logs.
-func WithJSON(json bool) Option {
-	return func(c *config) {
-		c.json = json
+// Deprecated: use WithLevel.
+func WithDebug(debug bool) Option {
+	if debug {
+		return WithLevel(slog.LevelDebug)
 	}
+	return WithLevel(slog.LevelInfo)
 }
 
-// WithWriter overrides the output writer. Defaults to os.Stdout.
+// WithPretty selects tint console output when true and native text when false.
+//
+// Deprecated: use WithFormat.
+func WithPretty(pretty bool) Option {
+	if pretty {
+		return WithFormat(FormatConsole)
+	}
+	return WithFormat(FormatText)
+}
+
+// WithJSON selects JSON output when true and native text when false.
+//
+// Deprecated: use WithFormat.
+func WithJSON(json bool) Option {
+	if json {
+		return WithFormat(FormatJSON)
+	}
+	return WithFormat(FormatText)
+}
+
+// WithWriter overrides the output writer. Defaults to os.Stderr.
 func WithWriter(w io.Writer) Option {
 	return func(c *config) {
 		c.writers = []io.Writer{w}
 	}
 }
 
-// WithWriters sets multiple output writers (combined via io.MultiWriter).
+// WithWriters sets multiple output writers with per-destination handlers.
 func WithWriters(w ...io.Writer) Option {
 	return func(c *config) {
 		c.writers = w

--- a/pkg/logger/options.go
+++ b/pkg/logger/options.go
@@ -11,6 +11,7 @@ type Option func(*config)
 // WithDebug sets the log level to Debug when true, Info otherwise.
 func WithDebug(debug bool) Option {
 	return func(c *config) {
+		c.debug = debug
 		if debug {
 			c.level = slog.LevelDebug
 		} else {
@@ -19,12 +20,12 @@ func WithDebug(debug bool) Option {
 	}
 }
 
-// WithPretty enables the charmbracelet/log handler for colorized,
-// human-friendly CLI output.
-func WithPretty(pretty bool) Option {
-	return func(c *config) {
-		c.pretty = pretty
-	}
+// WithPretty is retained for source compatibility. Output formatting is now
+// selected by WithDebug: debug logs use tint and normal logs use slog text.
+//
+// Deprecated: use WithDebug to enable colorized debug output.
+func WithPretty(_ bool) Option {
+	return func(_ *config) {}
 }
 
 // WithJSON enables slog's JSON handler for structured service logs.

--- a/pkg/logger/settings.go
+++ b/pkg/logger/settings.go
@@ -1,0 +1,147 @@
+package logger
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+)
+
+// Format controls how log records are rendered.
+type Format string
+
+const (
+	FormatAuto    Format = "auto"
+	FormatConsole Format = "console"
+	FormatText    Format = "text"
+	FormatJSON    Format = "json"
+)
+
+// ColorMode controls whether console logs contain ANSI color sequences.
+type ColorMode string
+
+const (
+	ColorAuto   ColorMode = "auto"
+	ColorAlways ColorMode = "always"
+	ColorNever  ColorMode = "never"
+)
+
+// Settings are the independently resolved logging concerns shared by a command.
+type Settings struct {
+	Level  slog.Level
+	Format Format
+	Color  ColorMode
+}
+
+// DefaultSettings returns the default logging settings.
+func DefaultSettings() Settings {
+	return Settings{
+		Level:  slog.LevelInfo,
+		Format: FormatAuto,
+		Color:  ColorAuto,
+	}
+}
+
+// ParseSettings validates and resolves user-facing logging values.
+func ParseSettings(level, format, color string) (Settings, error) {
+	parsedLevel, err := ParseLevel(level)
+	if err != nil {
+		return Settings{}, err
+	}
+	parsedFormat, err := ParseFormat(format)
+	if err != nil {
+		return Settings{}, err
+	}
+	parsedColor, err := ParseColorMode(color)
+	if err != nil {
+		return Settings{}, err
+	}
+
+	return Settings{Level: parsedLevel, Format: parsedFormat, Color: parsedColor}, nil
+}
+
+// ParseLevel parses one of the supported minimum log levels.
+func ParseLevel(value string) (slog.Level, error) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "debug":
+		return slog.LevelDebug, nil
+	case "info":
+		return slog.LevelInfo, nil
+	case "warn":
+		return slog.LevelWarn, nil
+	case "error":
+		return slog.LevelError, nil
+	default:
+		return 0, fmt.Errorf("invalid log level %q (expected debug, info, warn, or error)", value)
+	}
+}
+
+// ParseFormat parses a supported log output format.
+func ParseFormat(value string) (Format, error) {
+	switch Format(strings.ToLower(strings.TrimSpace(value))) {
+	case FormatAuto:
+		return FormatAuto, nil
+	case FormatConsole:
+		return FormatConsole, nil
+	case FormatText:
+		return FormatText, nil
+	case FormatJSON:
+		return FormatJSON, nil
+	default:
+		return "", fmt.Errorf("invalid log format %q (expected auto, console, text, or json)", value)
+	}
+}
+
+// ParseColorMode parses a supported console color policy.
+func ParseColorMode(value string) (ColorMode, error) {
+	switch ColorMode(strings.ToLower(strings.TrimSpace(value))) {
+	case ColorAuto:
+		return ColorAuto, nil
+	case ColorAlways:
+		return ColorAlways, nil
+	case ColorNever:
+		return ColorNever, nil
+	default:
+		return "", fmt.Errorf("invalid log color %q (expected auto, always, or never)", value)
+	}
+}
+
+// New creates a logger from these settings plus any sink-specific options.
+func (s Settings) New(opts ...Option) *slog.Logger {
+	base := []Option{
+		WithLevel(s.Level),
+		WithFormat(s.Format),
+		WithColor(s.Color),
+	}
+	return New(append(base, opts...)...)
+}
+
+// WithDefaultFormat replaces auto with a sink-specific default format.
+func (s Settings) WithDefaultFormat(format Format) Settings {
+	if s.Format == FormatAuto {
+		s.Format = format
+	}
+	return s
+}
+
+type settingsContextKey struct{}
+
+// WithSettings stores resolved logging settings in a context.
+func WithSettings(ctx context.Context, settings Settings) context.Context {
+	return context.WithValue(ctx, settingsContextKey{}, settings)
+}
+
+// SettingsFromContext returns resolved settings or the package defaults.
+func SettingsFromContext(ctx context.Context) Settings {
+	if ctx != nil {
+		if settings, ok := ctx.Value(settingsContextKey{}).(Settings); ok {
+			return settings
+		}
+	}
+	return DefaultSettings()
+}
+
+// FromContext creates a logger using settings stored in ctx.
+func FromContext(ctx context.Context, opts ...Option) *slog.Logger {
+	return SettingsFromContext(ctx).New(opts...)
+}


### PR DESCRIPTION
# 👨🏼

Replaces charm's logger with the native Go's `log/slog` which with Go 1.26 is pretty mature. This keeps nice debug logging with the `tint` package when `--debug` is set.

<img width="1169" height="336" alt="Screenshot 2026-07-29 at 8 44 17 PM" src="https://github.com/user-attachments/assets/808ec2ca-7ac5-45c6-80bf-46a23c721ed1" />

Closes PCC-1051

# 🤖

- replace `github.com/charmbracelet/log` with native `log/slog` handlers
- add independent `--log-level`, `--log-format`, and `--log-color` controls, with config and `TAPES_LOGGING_*` environment support
- retain `--debug` as a deprecated shorthand for `--log-level=debug`
- use tint with `time.StampMilli` for terminal console output while automatically suppressing ANSI for files and pipes
- support `NO_COLOR`, explicit color policies, native text, and structured JSON output
- propagate resolved logging settings into services and the `tapes start` daemon
- add Ginkgo coverage for levels, formats, colors, precedence, configuration, and daemon propagation

## Validation

- `make format`
- `make build-local`
- `go test ./...`
