### PR TITLE
🔧 fix(api): validate and log cassette admission

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -66,6 +66,7 @@ func newServer(config Config, driver storage.Driver, log *slog.Logger, docs tape
 	contracts := resolveContractVersions(config.ContractVersions)
 	runner := cassetterunner.NewRunner(cassetterunner.Config{
 		Contracts: contracts,
+		Logger:    log,
 		Title:     "tapes",
 		// The aggregate document is versioned with the contract discovery
 		// advertises, so /openapi and /v1/cassettes cannot disagree about

--- a/api/cassetterunner/fetch.go
+++ b/api/cassetterunner/fetch.go
@@ -131,7 +131,7 @@ func sourceOrigin(source string) (string, error) {
 	parsed, err := url.Parse(source)
 	if err != nil ||
 		(parsed.Scheme != "http" && parsed.Scheme != "https") ||
-		parsed.Host == "" ||
+		parsed.Hostname() == "" ||
 		parsed.Fragment != "" ||
 		parsed.User != nil {
 		return "", fmt.Errorf(

--- a/api/cassetterunner/registry.go
+++ b/api/cassetterunner/registry.go
@@ -223,7 +223,7 @@ func validateURL(endpoint string) string {
 	if parsed.Scheme != "http" && parsed.Scheme != "https" {
 		return "must use the http or https scheme"
 	}
-	if parsed.Host == "" {
+	if parsed.Hostname() == "" {
 		return "must include a host"
 	}
 	if parsed.RawQuery != "" || parsed.Fragment != "" {

--- a/api/cassetterunner/registry_test.go
+++ b/api/cassetterunner/registry_test.go
@@ -96,6 +96,9 @@ var _ = Describe("Registry", func() {
 		one.URL = "http://127.0.0.1:9000?a=1"
 		Expect(reg.Put(one)).To(MatchError(ContainSubstring("must not carry a query or fragment")))
 
+		one.URL = "http://:9000"
+		Expect(reg.Put(one)).To(MatchError(ContainSubstring("must include a host")))
+
 		Expect(reg.Instances()).To(BeEmpty())
 	})
 

--- a/api/cassetterunner/runner.go
+++ b/api/cassetterunner/runner.go
@@ -15,12 +15,14 @@ package cassetterunner
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"sync"
 	"time"
 
 	"github.com/papercomputeco/tapes/pkg/cassette"
 	"github.com/papercomputeco/tapes/pkg/cassette/manifest"
+	"github.com/papercomputeco/tapes/pkg/logger"
 	"github.com/papercomputeco/tapes/pkg/tapesoapi"
 )
 
@@ -75,6 +77,10 @@ type Config struct {
 	// admitted from a document served by a different origin than the one core
 	// proxies traffic to.
 	Client *http.Client
+
+	// Logger records source admission and rejection. A nil logger discards
+	// records, which keeps standalone runner use safe.
+	Logger *slog.Logger
 }
 
 // sourceState is one configured OpenAPI URL and what resolving it produced.
@@ -94,6 +100,10 @@ type sourceState struct {
 
 	// resolved reports whether this source has ever been admitted.
 	resolved bool
+
+	// problem is the last rejection logged for this source. Keeping it with the
+	// source state prevents startup retries from repeating the same warning.
+	problem string
 }
 
 // Runner resolves configured cassette sources into a registry and keeps their
@@ -102,6 +112,7 @@ type Runner struct {
 	registry  *Registry
 	specs     *specCache
 	client    *http.Client
+	logger    *slog.Logger
 	contracts []cassette.ContractVersion
 	title     string
 	version   string
@@ -137,11 +148,16 @@ func NewRunner(config Config) *Runner {
 	if title == "" {
 		title = "tapes"
 	}
+	log := config.Logger
+	if log == nil {
+		log = logger.NewNoop()
+	}
 
 	return &Runner{
 		registry:  registry,
 		specs:     newSpecCache(),
 		client:    client,
+		logger:    log,
 		contracts: append([]cassette.ContractVersion(nil), config.Contracts...),
 		title:     title,
 		version:   config.Version,
@@ -204,8 +220,8 @@ func (runner *Runner) SetSources(sources []string) {
 // Refresh resolves every configured source once.
 //
 // Errors are returned per source rather than joined, because each one is a
-// separate operator-facing problem: the caller logs them individually and each
-// is already filed as a rejection against the source that produced it.
+// separate operator-facing problem. Each is logged and filed as a rejection
+// against the source that produced it.
 func (runner *Runner) Refresh(ctx context.Context) []error {
 	runner.refreshMutex.Lock()
 	defer runner.refreshMutex.Unlock()
@@ -372,14 +388,23 @@ func (runner *Runner) sourceIndex(source string) int {
 	return -1
 }
 
-// resolveSource pins a source to the cassette it produced.
+// resolveSource pins a source to the cassette it produced and reports its
+// first admission or recovery from a recorded problem.
 func (runner *Runner) resolveSource(index int, name cassette.Name, etag string) {
 	runner.mutex.Lock()
-	defer runner.mutex.Unlock()
-
+	state := runner.sources[index]
 	runner.sources[index].name = name
 	runner.sources[index].etag = etag
 	runner.sources[index].resolved = true
+	runner.sources[index].problem = ""
+	runner.mutex.Unlock()
+
+	if !state.resolved || state.problem != "" {
+		runner.logger.Info("admitted cassette OpenAPI source",
+			"source", safeSource(state.url),
+			"cassette", name,
+		)
+	}
 }
 
 // failSource records a source problem: against the cassette whose document it
@@ -391,6 +416,16 @@ func (runner *Runner) failSource(index int, err error) error {
 	}
 	runner.registry.SetRejection(safeSource(state.url), err)
 
+	if state.problem != err.Error() {
+		runner.mutex.Lock()
+		runner.sources[index].problem = err.Error()
+		runner.mutex.Unlock()
+		runner.logger.Warn("cassette OpenAPI source rejected",
+			"source", safeSource(state.url),
+			"error", err,
+		)
+	}
+
 	return err
 }
 
@@ -399,6 +434,16 @@ func (runner *Runner) markSourceFresh(index int) {
 	state := runner.source(index)
 	runner.specs.markFresh(state.name, state.url)
 	runner.registry.ClearRejection(safeSource(state.url))
+
+	if state.problem != "" {
+		runner.mutex.Lock()
+		runner.sources[index].problem = ""
+		runner.mutex.Unlock()
+		runner.logger.Info("refreshed cassette OpenAPI source",
+			"source", safeSource(state.url),
+			"cassette", state.name,
+		)
+	}
 }
 
 // Status reports how current the cached document for a cassette is.

--- a/api/cassetterunner/source_test.go
+++ b/api/cassetterunner/source_test.go
@@ -103,6 +103,15 @@ var _ = Describe("OpenAPI cassette sources", func() {
 		Expect(runtime.Status("summary")).To(Equal(tapesoapi.Fresh))
 	})
 
+	It("rejects a port-only source authority before fetching", func(ctx SpecContext) {
+		runtime := cassetterunner.NewRunner(cassetterunner.Config{Contracts: servedContracts()})
+		runtime.SetSources([]string{"http://:8080/openapi"})
+
+		errs := runtime.Refresh(ctx)
+		Expect(errs).To(HaveLen(1))
+		Expect(errs[0]).To(MatchError(ContainSubstring("must be a full http(s) URL")))
+	})
+
 	It("keeps unresolved sources retryable", func(ctx SpecContext) {
 		source := newMutableSource(`{"openapi":"3.1.0","paths":{}}`)
 		defer source.Close()

--- a/api/cassetterunner/source_test.go
+++ b/api/cassetterunner/source_test.go
@@ -1,10 +1,12 @@
 package cassetterunner_test
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -12,6 +14,7 @@ import (
 
 	"github.com/papercomputeco/tapes/api/cassetterunner"
 	"github.com/papercomputeco/tapes/pkg/cassette"
+	"github.com/papercomputeco/tapes/pkg/logger"
 	"github.com/papercomputeco/tapes/pkg/tapesoapi"
 )
 
@@ -117,6 +120,47 @@ var _ = Describe("OpenAPI cassette sources", func() {
 		Expect(runtime.Refresh(ctx)).To(BeEmpty())
 		Expect(registry.Instances()).To(HaveLen(1))
 		Expect(registry.Rejections()).To(BeEmpty())
+	})
+
+	It("logs a warning when an OpenAPI source problem is recorded", func(ctx SpecContext) {
+		source := newMutableSource(`{"openapi":"3.1.0","paths":{}}`)
+		defer source.Close()
+
+		var logs bytes.Buffer
+		runtime := cassetterunner.NewRunner(cassetterunner.Config{
+			Contracts: servedContracts(),
+			Logger: logger.New(
+				logger.WithWriter(&logs),
+				logger.WithFormat(logger.FormatJSON),
+				logger.WithColor(logger.ColorNever),
+			),
+		})
+		runtime.SetSources([]string{source.URL + "/openapi"})
+
+		Expect(runtime.Refresh(ctx)).To(HaveLen(1))
+		Expect(runtime.Refresh(ctx)).To(HaveLen(1))
+		Expect(logs.String()).To(And(
+			ContainSubstring(`"level":"WARN"`),
+			ContainSubstring(`"msg":"cassette OpenAPI source rejected"`),
+			ContainSubstring(`"source":"`+source.URL+`/openapi"`),
+			ContainSubstring("missing root extension"),
+		))
+		Expect(strings.Count(logs.String(), "cassette OpenAPI source rejected")).To(Equal(1),
+			"startup retries should not repeat an unchanged problem")
+
+		malformed := `{`
+		source.document.Store(&malformed)
+		Expect(runtime.Refresh(ctx)).To(HaveLen(1))
+		Expect(strings.Count(logs.String(), "cassette OpenAPI source rejected")).To(Equal(2),
+			"a changed problem should be reported")
+
+		valid := sourceDocument("summary")
+		source.document.Store(&valid)
+		Expect(runtime.Refresh(ctx)).To(BeEmpty())
+		source.document.Store(&malformed)
+		Expect(runtime.Refresh(ctx)).To(HaveLen(1))
+		Expect(strings.Count(logs.String(), "cassette OpenAPI source rejected")).To(Equal(3),
+			"a problem after recovery should be reported")
 	})
 
 	It("keeps the configured-order winner while preserving valid peers", func(ctx SpecContext) {
@@ -281,14 +325,24 @@ var _ = Describe("OpenAPI cassette sources", func() {
 
 	DescribeTable("never publishes credentials from a rejected source URL",
 		func(ctx SpecContext, source string) {
+			var logs bytes.Buffer
 			registry := cassetterunner.NewRegistry()
-			runtime := cassetterunner.NewRunner(cassetterunner.Config{Registry: registry, Contracts: servedContracts()})
+			runtime := cassetterunner.NewRunner(cassetterunner.Config{
+				Registry:  registry,
+				Contracts: servedContracts(),
+				Logger: logger.New(
+					logger.WithWriter(&logs),
+					logger.WithFormat(logger.FormatJSON),
+					logger.WithColor(logger.ColorNever),
+				),
+			})
 			runtime.SetSources([]string{source})
 			errs := runtime.Refresh(ctx)
 			Expect(errs).To(HaveLen(1))
 			Expect(errs[0].Error()).NotTo(ContainSubstring("secret"))
 			Expect(registry.Rejections()).To(HaveLen(1))
 			Expect(registry.Rejections()[0].Subject).NotTo(ContainSubstring("secret"))
+			Expect(logs.String()).NotTo(ContainSubstring("secret"))
 		},
 		Entry("parseable userinfo", "http://user:secret@example.invalid/openapi"),
 		Entry("malformed userinfo", "http://user:secret%zz@example.invalid/openapi"),

--- a/api/cassettes.go
+++ b/api/cassettes.go
@@ -93,9 +93,6 @@ func (s *Server) runCassetteSpecRefresh(ctx context.Context, interval time.Durat
 		case <-time.After(startupRetry):
 		}
 	}
-	for _, err := range errs {
-		s.logger.Warn("could not refresh cassette OpenAPI document", "error", err)
-	}
 	if interval <= 0 {
 		return
 	}
@@ -107,9 +104,7 @@ func (s *Server) runCassetteSpecRefresh(ctx context.Context, interval time.Durat
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			for _, err := range s.RefreshCassetteSpecs(ctx) {
-				s.logger.Warn("could not refresh cassette OpenAPI document", "error", err)
-			}
+			s.RefreshCassetteSpecs(ctx)
 		}
 	}
 }

--- a/cmd/tapes/serve/api/api.go
+++ b/cmd/tapes/serve/api/api.go
@@ -99,6 +99,9 @@ func newAPICmd(cmder *apiCommander) *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("loading cassette sources: %w", err)
 			}
+			if err := config.ValidateCassetteSources(cmder.cassetteSources); err != nil {
+				return err
+			}
 
 			cmder.listen = v.GetString("api.listen")
 			cmder.webUI = v.GetBool("api.web_ui")
@@ -151,6 +154,11 @@ func newAPICmd(cmder *apiCommander) *cobra.Command {
 
 func (c *apiCommander) run(ctx context.Context) error {
 	c.logger = logger.FromContext(ctx)
+	if len(c.cassetteSources) > 0 {
+		c.logger.Info("configured cassette OpenAPI sources",
+			"count", len(c.cassetteSources),
+		)
+	}
 
 	driver, err := postgres.NewDriver(ctx, c.postgresDSN)
 	if err != nil {

--- a/cmd/tapes/serve/api/api_test.go
+++ b/cmd/tapes/serve/api/api_test.go
@@ -38,4 +38,22 @@ var _ = Describe("standalone API cassette configuration", func() {
 		Expect(command.PreRunE(command, nil)).To(Succeed())
 		Expect(commander.cassetteSources).To(Equal([]string{"http://flag/one", "http://flag/two"}))
 	})
+
+	DescribeTable("rejects invalid effective sources before server startup",
+		func(source, problem string) {
+			commander := &apiCommander{flags: apiFlags}
+			command := newAPICmd(commander)
+			command.Flags().String("config-dir", GinkgoT().TempDir(), "")
+			Expect(command.Flags().Set("cassettes", source)).To(Succeed())
+
+			Expect(command.PreRunE(command, nil)).To(MatchError(And(
+				ContainSubstring("cassettes[0]"),
+				ContainSubstring(problem),
+			)))
+		},
+		Entry("without a scheme", "cassette.internal/openapi", "must use the http or https scheme"),
+		Entry("with a non-HTTP scheme", "ftp://cassette.internal/openapi", "must use the http or https scheme"),
+		Entry("without a host", "http:///openapi", "must include a host"),
+		Entry("when malformed", "http://cassette.internal/%zz", "must be a valid URL"),
+	)
 })

--- a/cmd/tapes/serve/api/api_test.go
+++ b/cmd/tapes/serve/api/api_test.go
@@ -53,7 +53,8 @@ var _ = Describe("standalone API cassette configuration", func() {
 		},
 		Entry("without a scheme", "cassette.internal/openapi", "must use the http or https scheme"),
 		Entry("with a non-HTTP scheme", "ftp://cassette.internal/openapi", "must use the http or https scheme"),
-		Entry("without a host", "http:///openapi", "must include a host"),
+		Entry("without an authority", "http:///openapi", "must include a host"),
+		Entry("with only a port", "http://:8080/openapi", "must include a host"),
 		Entry("when malformed", "http://cassette.internal/%zz", "must be a valid URL"),
 	)
 })

--- a/cmd/tapes/serve/cassettes.go
+++ b/cmd/tapes/serve/cassettes.go
@@ -2,19 +2,18 @@ package servecmder
 
 import (
 	"context"
-	"fmt"
-
-	"github.com/spf13/cobra"
 
 	"github.com/papercomputeco/tapes/api"
 )
 
-func (commander *ServeCommander) configureCassettes(cmd *cobra.Command) {
+func (commander *ServeCommander) configureCassettes() {
 	if len(commander.stack.CassetteSources) == 0 {
 		return
 	}
 
-	fmt.Fprintf(cmd.OutOrStdout(), "configured %d cassette OpenAPI source(s)\n", len(commander.stack.CassetteSources))
+	commander.stack.Logger.Info("configured cassette OpenAPI sources",
+		"count", len(commander.stack.CassetteSources),
+	)
 	commander.stack.Started = func(ctx context.Context, server *api.Server) {
 		server.StartCassetteSpecRefresh(ctx, commander.refresh)
 	}

--- a/cmd/tapes/serve/cassettes_test.go
+++ b/cmd/tapes/serve/cassettes_test.go
@@ -1,6 +1,7 @@
 package servecmder
 
 import (
+	"bytes"
 	"context"
 	"os"
 	"path/filepath"
@@ -8,6 +9,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/spf13/cobra"
+
+	"github.com/papercomputeco/tapes/pkg/logger"
 )
 
 var _ = Describe("combined cassette configuration", func() {
@@ -45,5 +48,35 @@ var _ = Describe("combined cassette configuration", func() {
 		stack, cmd := newStack(directory)
 		Expect(stack.Resolve(cmd, ServeFlags)).To(Succeed())
 		Expect(stack.CassetteSources).To(Equal([]string{"http://one/openapi", "http://two/openapi"}))
+	})
+
+	It("rejects invalid effective sources before starting the stack", func() {
+		stack, cmd := newStack(GinkgoT().TempDir(), "--cassettes=cassette.internal/openapi")
+
+		Expect(stack.Resolve(cmd, ServeFlags)).To(MatchError(ContainSubstring(
+			"cassettes[0]: must use the http or https scheme",
+		)))
+	})
+
+	It("logs configured sources instead of writing command output", func() {
+		var logs bytes.Buffer
+		stack, cmd := newStack(GinkgoT().TempDir())
+		stack.CassetteSources = []string{"http://one/openapi"}
+		stack.Logger = logger.New(
+			logger.WithWriter(&logs),
+			logger.WithFormat(logger.FormatJSON),
+			logger.WithColor(logger.ColorNever),
+		)
+		var stdout bytes.Buffer
+		cmd.SetOut(&stdout)
+
+		commander := &ServeCommander{stack: *stack}
+		commander.configureCassettes()
+
+		Expect(stdout.String()).To(BeEmpty())
+		Expect(logs.String()).To(And(
+			ContainSubstring(`"msg":"configured cassette OpenAPI sources"`),
+			ContainSubstring(`"count":1`),
+		))
 	})
 })

--- a/cmd/tapes/serve/serve.go
+++ b/cmd/tapes/serve/serve.go
@@ -98,7 +98,7 @@ func NewServeCmd() *cobra.Command {
 
 func (c *ServeCommander) run(cmd *cobra.Command) error {
 	c.stack.Logger = logger.FromContext(cmd.Context())
-	c.configureCassettes(cmd)
+	c.configureCassettes()
 
 	// Signal-aware context: a SIGINT/SIGTERM cancels it, which stops the
 	// in-process workers' run loops (the HTTP servers are torn down via their

--- a/cmd/tapes/serve/stack.go
+++ b/cmd/tapes/serve/stack.go
@@ -132,6 +132,9 @@ func (stack *Stack) Resolve(cmd *cobra.Command, flags config.FlagSet) error {
 	if err != nil {
 		return fmt.Errorf("loading cassette sources: %w", err)
 	}
+	if err := config.ValidateCassetteSources(stack.CassetteSources); err != nil {
+		return err
+	}
 
 	// Default pgvector to the primary Postgres DSN.
 	if v.GetString("vector_store.target") == "" && v.GetString("storage.postgres_dsn") != "" {

--- a/pkg/cassette/v1alpha1/cassette_test.go
+++ b/pkg/cassette/v1alpha1/cassette_test.go
@@ -99,6 +99,16 @@ var _ = Describe("versioned cassette metadata", func() {
 		}))
 	})
 
+	It("rejects a homepage with only a port in its authority", func() {
+		manifest, err := v1alpha1.Parse([]byte(validMetadata))
+		Expect(err).NotTo(HaveOccurred())
+		manifest.Cassette.Homepage = "http://:8080"
+
+		Expect(manifest.Validate([]cassette.ContractVersion{"v1"})).To(MatchError(ContainSubstring(
+			"cassette.homepage: must be an absolute http or https URL",
+		)))
+	})
+
 	It("rejects float integers that would wrap and attributes bounds correctly", func() {
 		manifest := &v1alpha1.Manifest{
 			Kind: v1alpha1.Kind, Cassette: v1alpha1.Identity{Name: "summary", Version: "1"},

--- a/pkg/cassette/v1alpha1/validate.go
+++ b/pkg/cassette/v1alpha1/validate.go
@@ -45,7 +45,7 @@ func (m *Manifest) Validate(supported []cassette.ContractVersion) error {
 	}
 	if m.Cassette.Homepage != "" {
 		parsed, err := url.Parse(m.Cassette.Homepage)
-		if err != nil || parsed.Host == "" || (parsed.Scheme != "http" && parsed.Scheme != "https") {
+		if err != nil || parsed.Hostname() == "" || (parsed.Scheme != "http" && parsed.Scheme != "https") {
 			add("cassette.homepage", "must be an absolute http or https URL")
 		}
 	}

--- a/pkg/config/cassettes.go
+++ b/pkg/config/cassettes.go
@@ -46,7 +46,7 @@ func validateCassetteURL(source string) string {
 	if parsed.Scheme != "http" && parsed.Scheme != "https" {
 		return "must use the http or https scheme"
 	}
-	if parsed.Host == "" {
+	if parsed.Hostname() == "" {
 		return "must include a host"
 	}
 	if parsed.User != nil {

--- a/pkg/config/cassettes.go
+++ b/pkg/config/cassettes.go
@@ -7,12 +7,18 @@ import (
 	"github.com/papercomputeco/tapes/pkg/cassette"
 )
 
-// ValidateCassettes checks configured full OpenAPI source URLs. Resolution and
-// metadata admission are runtime concerns so unreachable sources remain retryable.
+// ValidateCassettes checks this config's cassette OpenAPI source URLs.
 func (config *Config) ValidateCassettes() error {
+	return ValidateCassetteSources(config.Cassettes)
+}
+
+// ValidateCassetteSources checks configured full OpenAPI source URLs. Resolution
+// and metadata admission are runtime concerns so unreachable sources remain
+// retryable.
+func ValidateCassetteSources(sources []string) error {
 	problems := make([]cassette.Problem, 0)
-	seen := make(map[string]int, len(config.Cassettes))
-	for index, source := range config.Cassettes {
+	seen := make(map[string]int, len(sources))
+	for index, source := range sources {
 		field := fmt.Sprintf("cassettes[%d]", index)
 		if message := validateCassetteURL(source); message != "" {
 			problems = append(problems, cassette.Problem{Field: field, Message: message})

--- a/pkg/config/cassettes_file_test.go
+++ b/pkg/config/cassettes_file_test.go
@@ -31,11 +31,12 @@ enabled = true
 	})
 
 	It("validates full HTTP URLs while allowing an exact query", func() {
-		_, err := config.ParseConfigTOML([]byte(`cassettes = ["tcp://host/spec", "http://host/spec#fragment", "http://user:secret@host/spec"]`))
+		_, err := config.ParseConfigTOML([]byte(`cassettes = ["tcp://host/spec", "http://host/spec#fragment", "http://user:secret@host/spec", "http://:8080/openapi"]`))
 		Expect(err).To(MatchError(And(
 			ContainSubstring("http or https"),
 			ContainSubstring("fragment"),
 			ContainSubstring("must not include URL userinfo"),
+			ContainSubstring("must include a host"),
 		)))
 	})
 


### PR DESCRIPTION
# 👨🏼

Addresses some logging / validation bits I noticed in tapes cassette admission functionality - now should 1) outright reject incorrectly configured `--cassette` entries and 2) properly log warnings and problems that occur

Closes PCC-1057

# 🤖

- validate the effective cassette OpenAPI source list before either API server mode starts
- reject malformed, non-HTTP(S), hostless, credential-bearing, fragmented, or duplicate source URLs at startup
- route cassette configuration, admission, recovery, and rejection events through the structured logger
- warn immediately when OpenAPI loading or manifest validation records a problem, while deduplicating unchanged retry warnings
- preserve URL credential redaction in operator logs

## Testing

- `make format`
- `make test`
- `git diff --check`
