### PR TITLE
🔧 fix(ingest): keep capture-side duration and timestamp on raw-only rows

### DIFF
--- a/ingest/elapsed_guard_test.go
+++ b/ingest/elapsed_guard_test.go
@@ -1,0 +1,33 @@
+package ingest
+
+import (
+	"math"
+	"testing"
+)
+
+// usableElapsed guards every conversion of meta.elapsed_seconds into
+// timing data; a value it wrongly accepts becomes a bogus duration or a
+// CreatedAt far in the future.
+func TestUsableElapsed(t *testing.T) {
+	cases := []struct {
+		name    string
+		elapsed float64
+		want    bool
+	}{
+		{"typical call", 1.75, true},
+		{"upper bound inclusive", maxElapsedSeconds, true},
+		{"zero is absent", 0, false},
+		{"negative is corrupt", -3, false},
+		{"beyond the bound is corrupt", maxElapsedSeconds + 1, false},
+		{"NaN is corrupt", math.NaN(), false},
+		{"+Inf is corrupt", math.Inf(1), false},
+		{"-Inf is corrupt", math.Inf(-1), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := usableElapsed(tc.elapsed); got != tc.want {
+				t.Fatalf("usableElapsed(%v) = %v, want %v", tc.elapsed, got, tc.want)
+			}
+		})
+	}
+}

--- a/ingest/ingest.go
+++ b/ingest/ingest.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math"
 	"net"
 	"strings"
 	"sync"
@@ -683,11 +684,25 @@ func (s *Server) reduceRawOnly(ctx context.Context, turn *TurnPayload) json.RawM
 // source to fall back on — ingest's own clock measures the dispatch hop,
 // not the call — so the honest outcome is an unstamped duration, counted
 // as a fallback so it is visible rather than silent.
+// maxElapsedSeconds bounds a plausible single-call duration. Beyond it
+// the value is treated as corrupt rather than stamped into timing data:
+// a week-long LLM call is not a call, it is a producer clock bug.
+const maxElapsedSeconds = 7 * 24 * 60 * 60
+
+// usableElapsed reports whether the meta elapsed value can safely be
+// turned into a duration or a timestamp offset. NaN and ±Inf survive
+// JSON-adjacent producers more often than one would hope, and either
+// would poison int64 conversion silently.
+func usableElapsed(elapsed float64) bool {
+	return !math.IsNaN(elapsed) && !math.IsInf(elapsed, 0) &&
+		elapsed > 0 && elapsed <= maxElapsedSeconds
+}
+
 func (s *Server) stampDuration(resp *llm.ChatResponse, turn *TurnPayload) {
 	if resp == nil {
 		return
 	}
-	if turn.Meta.ElapsedSeconds <= 0 {
+	if !usableElapsed(turn.Meta.ElapsedSeconds) {
 		s.metrics.ObserveRawOnlyStamp(turn.Provider, StampFieldDuration, StampSourceFallback)
 		return
 	}
@@ -756,7 +771,7 @@ func (s *Server) stampCaptureTime(resp *llm.ChatResponse, turn *TurnPayload) {
 		// completion instant CreatedAt denotes. Without it the request
 		// instant still stands — early by the call's duration, which is a
 		// far smaller error than the ingest hop it replaces.
-		if turn.Meta.ElapsedSeconds > 0 {
+		if usableElapsed(turn.Meta.ElapsedSeconds) {
 			requested = requested.Add(time.Duration(turn.Meta.ElapsedSeconds * float64(time.Second)))
 		}
 		resp.CreatedAt = requested

--- a/ingest/ingest.go
+++ b/ingest/ingest.go
@@ -145,6 +145,25 @@ type TurnMeta struct {
 	RequestBytes        int     `json:"request_bytes,omitempty"`
 	ResponseBytes       int     `json:"response_bytes,omitempty"`
 	ElapsedSeconds      float64 `json:"elapsed_seconds,omitempty"`
+
+	// TsRequest is the capture-side instant the turn's request went
+	// upstream, RFC 3339. It is not new: pkg/backfill emits it and
+	// derive.CapturedAt already reads it as a row's original capture
+	// time, which is where every derived span's StartedAt comes from.
+	// Ingest parses it here so a server-side reduction can date itself
+	// from the same source the deriver uses, rather than a second,
+	// silently different clock.
+	TsRequest string `json:"ts_request,omitempty"`
+
+	// CapturedAt is the capture-side instant the turn COMPLETED
+	// upstream, RFC 3339 — the quantity CreatedAt actually means, and
+	// the one a producer that reduces live records as time.Now().
+	//
+	// Distinct from TsRequest by exactly the call's duration. Preferred
+	// over it because it needs no arithmetic to be exact; optional, and
+	// no released producer sends it yet. See stampCaptureTime for the
+	// precedence and what happens when neither field is present.
+	CapturedAt string `json:"captured_at,omitempty"`
 }
 
 // rawEnvelope is the shadow decode of an ingest body used for the
@@ -629,12 +648,152 @@ func (s *Server) reduceRawOnly(ctx context.Context, turn *TurnPayload) json.RawM
 		return nil
 	}
 
+	// The reducer sees only the upstream bytes, which carry neither the
+	// call's duration nor the instant it happened. Both are capture-side
+	// facts, and under raw-only ingest is the first place they can be put
+	// back on the reduction. Stamp them before marshaling so the raw layer
+	// and the derived path get the same values.
+	s.stampDuration(resp, turn)
+	s.stampCaptureTime(resp, turn)
+
 	out, err := json.Marshal(resp)
 	if err != nil {
 		return nil
 	}
 	turn.Response = *resp
 	return out
+}
+
+// stampDuration sets Usage.TotalDurationNs from the capture adapter's
+// meta.elapsed_seconds, allocating Usage if needed.
+//
+// This is the raw-only counterpart of proxy.stampDuration (PCC-514/570):
+// Anthropic and OpenAI do not surface call duration on the wire, so a
+// reduction performed from stored bytes has no duration in it, and the
+// column lands NULL — the exact regression those issues fixed on the proxy
+// path. The value survives the raw-only crossing on meta.elapsed_seconds,
+// so ingest re-stamps it here.
+//
+// Overwriting rather than filling-if-empty is deliberate, and matches the
+// proxy: a provider-reported internal duration (Ollama) measures something
+// different from wall-clock time at the capture point, and aggregate stats
+// are only comparable if every turn's duration means the same thing.
+//
+// An absent elapsed_seconds leaves the reduction alone. There is no second
+// source to fall back on — ingest's own clock measures the dispatch hop,
+// not the call — so the honest outcome is an unstamped duration, counted
+// as a fallback so it is visible rather than silent.
+func (s *Server) stampDuration(resp *llm.ChatResponse, turn *TurnPayload) {
+	if resp == nil {
+		return
+	}
+	if turn.Meta.ElapsedSeconds <= 0 {
+		s.metrics.ObserveRawOnlyStamp(turn.Provider, StampFieldDuration, StampSourceFallback)
+		return
+	}
+	if resp.Usage == nil {
+		resp.Usage = &llm.Usage{}
+	}
+	resp.Usage.TotalDurationNs = int64(turn.Meta.ElapsedSeconds * float64(time.Second))
+	s.metrics.ObserveRawOnlyStamp(turn.Provider, StampFieldDuration, StampSourceElapsed)
+}
+
+// stampCaptureTime sets CreatedAt to the capture-side instant the envelope
+// reports, so a raw-only row means the same thing a pre-reduced one does.
+//
+// The contract this enforces: CreatedAt is when the turn happened, never
+// when tapes heard about it. Under dual-send the producer reduced live and
+// stamped its own clock, so CreatedAt was capture time by construction.
+// Under raw-only the reduction moves to the server, and the reducers stamp
+// time.Now() (pkg/capture/anthropic.go, anthropic_state.go) — which is now
+// ingest time. Same field, silently different quantity: rows would sort and
+// bucket by when the ingest hop happened, and a replay of stored bytes would
+// date every turn to the replay.
+//
+// Sources, most precise first. Each is a capture-side clock; none is
+// ingest's:
+//
+//  1. meta.captured_at — the completion instant outright.
+//  2. meta.ts_request + meta.elapsed_seconds — request instant plus the
+//     call's duration, which is the same quantity by construction.
+//  3. meta.ts_request alone — the request instant, early by the call's
+//     duration but a real capture-side time, and already what
+//     derive.CapturedAt uses for the row's chronology.
+//
+// Preferring ts_request over ingest's clock is what keeps CreatedAt and the
+// derived span's StartedAt (derive.CapturedAt, same field) from disagreeing
+// about when one turn happened. It also means backfilled rows, which carry
+// ts_request today, get a correct CreatedAt without any producer change.
+//
+// With none of them present ingest keeps whatever the reducer produced and
+// counts a fallback. That fallback is not uniform, which is why it is
+// counted rather than assumed:
+//
+//   - OpenAI Responses reductions carry the upstream's own created_at
+//     (pkg/capture/openai_responses.go), so CreatedAt is already a real
+//     capture-side time and overwriting it would lose information.
+//   - Anthropic reductions carry time.Now(), so CreatedAt is ingest time —
+//     the drift this function exists to close, left visible on the counter
+//     until producers send one of the fields above.
+//
+// Guessing capture time as now-minus-elapsed is deliberately not done: it is
+// indistinguishable from the truth on a healthy dispatch and arbitrarily
+// wrong on a retried, buffered, or replayed one, which is the case that
+// matters.
+func (s *Server) stampCaptureTime(resp *llm.ChatResponse, turn *TurnPayload) {
+	if resp == nil {
+		return
+	}
+
+	if completed, ok := s.parseCaptureStamp(turn, "captured_at", turn.Meta.CapturedAt); ok {
+		resp.CreatedAt = completed
+		s.metrics.ObserveRawOnlyStamp(turn.Provider, StampFieldCreatedAt, StampSourceCapturedAt)
+		return
+	}
+
+	if requested, ok := s.parseCaptureStamp(turn, "ts_request", turn.Meta.TsRequest); ok {
+		// The elapsed offset is what turns a request instant into the
+		// completion instant CreatedAt denotes. Without it the request
+		// instant still stands — early by the call's duration, which is a
+		// far smaller error than the ingest hop it replaces.
+		if turn.Meta.ElapsedSeconds > 0 {
+			requested = requested.Add(time.Duration(turn.Meta.ElapsedSeconds * float64(time.Second)))
+		}
+		resp.CreatedAt = requested
+		s.metrics.ObserveRawOnlyStamp(turn.Provider, StampFieldCreatedAt, StampSourceTsRequest)
+		return
+	}
+
+	s.metrics.ObserveRawOnlyStamp(turn.Provider, StampFieldCreatedAt, StampSourceFallback)
+}
+
+// parseCaptureStamp parses one RFC 3339 capture-side timestamp off the meta
+// block, reporting whether it yielded a usable instant.
+//
+// RFC3339Nano matches derive.CapturedAt, so the two agree on what they
+// accept — a timestamp the deriver honors cannot be one ingest rejects.
+//
+// An absent field is ordinary: no producer sends either of these yet. A
+// present-but-malformed one is a producer bug and logged, since someone
+// meant to send it. Neither rejects the turn — the bytes are already stored,
+// and losing a whole turn over a timestamp would be a far worse trade.
+func (s *Server) parseCaptureStamp(turn *TurnPayload, field, value string) (time.Time, bool) {
+	raw := strings.TrimSpace(value)
+	if raw == "" {
+		return time.Time{}, false
+	}
+	ts, err := time.Parse(time.RFC3339Nano, raw)
+	if err != nil {
+		s.logger.Warn("raw-only turn: capture timestamp not RFC 3339",
+			"provider", turn.Provider,
+			"request_id", turn.Meta.RequestID,
+			"field", field,
+			"value", raw,
+			"error", err,
+		)
+		return time.Time{}, false
+	}
+	return ts.UTC(), true
 }
 
 // reducedResponseAbsent reports whether a payload carried no reduced response.

--- a/ingest/metrics.go
+++ b/ingest/metrics.go
@@ -7,14 +7,21 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
+// providerUnknown is the label value substituted for an empty provider.
+// Prometheus drops a series with an empty label value, so a turn whose
+// provider never got set would vanish from the counter entirely rather than
+// show up as the anomaly it is.
+const providerUnknown = "unknown"
+
 // Metrics enumerates the Prometheus counters and histograms emitted by the
 // ingest server. Metric names are fixed so dashboards and alerts reference
 // stable identifiers.
 type Metrics struct {
-	writes       *prometheus.CounterVec
-	dagSeconds   *prometheus.HistogramVec
-	queueDepth   prometheus.Gauge
-	bytesHistory *prometheus.HistogramVec
+	writes        *prometheus.CounterVec
+	dagSeconds    *prometheus.HistogramVec
+	queueDepth    prometheus.Gauge
+	bytesHistory  *prometheus.HistogramVec
+	rawOnlyStamps *prometheus.CounterVec
 
 	registry *prometheus.Registry
 }
@@ -54,8 +61,15 @@ func NewMetrics() *Metrics {
 			},
 			[]string{"provider"},
 		),
+		rawOnlyStamps: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "tapes_ingest_rawonly_stamp_total",
+				Help: "Capture-side fields restored onto a server-side raw-only reduction, by provider, field, and whether the envelope supplied the value or ingest fell back. A rising fallback rate means raw-only rows are landing without a capture-side duration or with an ingest-clock timestamp.",
+			},
+			[]string{"provider", "field", "source"},
+		),
 	}
-	reg.MustRegister(m.writes, m.dagSeconds, m.queueDepth, m.bytesHistory)
+	reg.MustRegister(m.writes, m.dagSeconds, m.queueDepth, m.bytesHistory, m.rawOnlyStamps)
 	return m
 }
 
@@ -91,7 +105,7 @@ const (
 // A zero-length provider label becomes "unknown" so scrapes don't drop rows.
 func (m *Metrics) ObserveWrite(provider string, result Result, bodyBytes int) {
 	if provider == "" {
-		provider = "unknown"
+		provider = providerUnknown
 	}
 	m.writes.WithLabelValues(provider, string(result)).Inc()
 	if result == ResultAccepted && bodyBytes > 0 {
@@ -104,9 +118,60 @@ func (m *Metrics) ObserveWrite(provider string, result Result, bodyBytes int) {
 // enqueue is nominally O(1) — a slow enqueue hints at queue saturation.
 func (m *Metrics) ObserveDAGLatency(provider string, seconds float64) {
 	if provider == "" {
-		provider = "unknown"
+		provider = providerUnknown
 	}
 	m.dagSeconds.WithLabelValues(provider).Observe(seconds)
+}
+
+// StampField enumerates the capture-side fields ingest restores onto a
+// server-side raw-only reduction. Closed enumeration keeps dashboards safe
+// against label typos.
+type StampField string
+
+const (
+	StampFieldDuration  StampField = "duration"
+	StampFieldCreatedAt StampField = "created_at"
+)
+
+// StampSource names the meta field that supplied a stamped value, or the
+// fallback taken when none did. Naming the field rather than just
+// "envelope" is what lets a scrape answer which producers have been
+// upgraded, per field, without correlating against deploy history.
+//
+// StampSourceFallback means the envelope carried nothing usable. What that
+// leaves behind is field-specific: an unstamped duration for
+// StampFieldDuration, and whatever the reducer produced — ingest's own clock
+// for providers whose wire format carries no timestamp — for
+// StampFieldCreatedAt.
+//
+// The fallback bucket is the point of this metric. Both fields degrade
+// silently otherwise: a NULL duration and an ingest-time CreatedAt are
+// indistinguishable downstream from a turn that genuinely had them.
+type StampSource string
+
+const (
+	// StampSourceElapsed is meta.elapsed_seconds, for the duration.
+	StampSourceElapsed StampSource = "elapsed_seconds"
+
+	// StampSourceCapturedAt is meta.captured_at — the turn's completion
+	// instant, exactly what CreatedAt denotes.
+	StampSourceCapturedAt StampSource = "captured_at"
+
+	// StampSourceTsRequest is meta.ts_request, the turn's request instant,
+	// offset by elapsed_seconds when the envelope carries one.
+	StampSourceTsRequest StampSource = "ts_request"
+
+	// StampSourceFallback means no capture-side source was available.
+	StampSourceFallback StampSource = "fallback"
+)
+
+// ObserveRawOnlyStamp records one capture-side field restored (or not) on a
+// server-side raw-only reduction.
+func (m *Metrics) ObserveRawOnlyStamp(provider string, field StampField, source StampSource) {
+	if provider == "" {
+		provider = providerUnknown
+	}
+	m.rawOnlyStamps.WithLabelValues(provider, string(field), string(source)).Inc()
 }
 
 // SetQueueDepth updates the worker queue depth gauge.

--- a/ingest/raw_response_test.go
+++ b/ingest/raw_response_test.go
@@ -44,6 +44,41 @@ func gzipBytes(b []byte) []byte {
 	return buf.Bytes()
 }
 
+// stampCount sums the tapes_ingest_rawonly_stamp_total series matching the
+// given field and source. Either may be "" to mean "any", so passing both
+// empty totals the whole metric — the way to assert a path stamped nothing
+// at all.
+func stampCount(server *ingest.Server, field, source string) float64 {
+	families, err := server.Metrics().Registry().Gather()
+	Expect(err).NotTo(HaveOccurred())
+
+	var total float64
+	for _, family := range families {
+		if family.GetName() != "tapes_ingest_rawonly_stamp_total" {
+			continue
+		}
+		for _, metric := range family.GetMetric() {
+			var gotField, gotSource string
+			for _, label := range metric.GetLabel() {
+				switch label.GetName() {
+				case "field":
+					gotField = label.GetValue()
+				case "source":
+					gotSource = label.GetValue()
+				}
+			}
+			if field != "" && gotField != field {
+				continue
+			}
+			if source != "" && gotSource != source {
+				continue
+			}
+			total += metric.GetCounter().GetValue()
+		}
+	}
+	return total
+}
+
 var _ = Describe("Raw response capture", func() {
 	var (
 		server  *ingest.Server
@@ -193,6 +228,230 @@ var _ = Describe("Raw response capture", func() {
 		var reduced llm.ChatResponse
 		Expect(json.Unmarshal(rec.Response, &reduced)).To(Succeed())
 		Expect(reduced.Message.GetText()).To(Equal("adapter reduction"))
+	})
+
+	// The capture-side facts the upstream bytes do not carry. Under
+	// dual-send the producer reduced live and had both; under raw-only the
+	// reduction happens here, from stored bytes, and ingest has to put them
+	// back or the row means something different than it used to.
+	Describe("capture-side fields on a server-side reduction", func() {
+		// The duration a real dual-send turn reduced to live in the
+		// PCC-1029 clearing validation. Reducing that same turn's stored
+		// bytes offline produced no duration at all — this is the value
+		// that has to survive the crossing.
+		const liveElapsedSeconds = 1.747314975
+
+		It("stamps the duration from the envelope's elapsed_seconds", func() {
+			post(ingest.TurnPayload{
+				Provider:    "anthropic",
+				RawRequest:  anthropicRequest,
+				RawResponse: []byte(anthropicSSE),
+				Meta: ingest.TurnMeta{
+					ContentType:    "text/event-stream",
+					ElapsedSeconds: liveElapsedSeconds,
+				},
+			})
+
+			var reduced llm.ChatResponse
+			Expect(json.Unmarshal(driver.RawTurns()[0].Response, &reduced)).To(Succeed())
+
+			// The regression this guards: without the stamp the reduction
+			// carries no duration and the derived span's duration_ns lands
+			// NULL — the PCC-514/570 bug, reintroduced by moving reduction
+			// to the server.
+			Expect(reduced.Usage).NotTo(BeNil())
+			Expect(reduced.Usage.TotalDurationNs).NotTo(BeZero())
+			Expect(reduced.Usage.TotalDurationNs).To(BeNumerically("~", 1747314975, 1000))
+
+			Expect(stampCount(server, "duration", "elapsed_seconds")).To(Equal(1.0))
+		})
+
+		It("leaves the duration unstamped, and counted, when the envelope has none", func() {
+			post(ingest.TurnPayload{
+				Provider:    "anthropic",
+				RawRequest:  anthropicRequest,
+				RawResponse: []byte(anthropicSSE),
+				Meta:        ingest.TurnMeta{ContentType: "text/event-stream"},
+			})
+
+			var reduced llm.ChatResponse
+			Expect(json.Unmarshal(driver.RawTurns()[0].Response, &reduced)).To(Succeed())
+
+			// Ingest's own clock measures the dispatch hop, not the call, so
+			// there is nothing honest to put here. The turn still lands; the
+			// counter is what makes the hole visible.
+			Expect(reduced.Usage.TotalDurationNs).To(BeZero())
+			Expect(stampCount(server, "duration", "fallback")).To(Equal(1.0))
+		})
+
+		It("stamps created_at from the envelope's capture time", func() {
+			captured := time.Date(2026, 7, 28, 17, 36, 15, 0, time.UTC)
+
+			post(ingest.TurnPayload{
+				Provider:    "anthropic",
+				RawRequest:  anthropicRequest,
+				RawResponse: []byte(anthropicSSE),
+				Meta: ingest.TurnMeta{
+					ContentType: "text/event-stream",
+					CapturedAt:  captured.Format(time.RFC3339),
+				},
+			})
+
+			var reduced llm.ChatResponse
+			Expect(json.Unmarshal(driver.RawTurns()[0].Response, &reduced)).To(Succeed())
+
+			// The contract: CreatedAt is when the turn happened. The reducer
+			// stamped time.Now() during this test; the envelope's capture
+			// time has to win over it.
+			Expect(reduced.CreatedAt.UTC()).To(BeTemporally("==", captured))
+			Expect(stampCount(server, "created_at", "captured_at")).To(Equal(1.0))
+		})
+
+		It("dates the turn from ts_request plus elapsed when captured_at is absent", func() {
+			requested := time.Date(2026, 7, 28, 17, 36, 15, 0, time.UTC)
+
+			post(ingest.TurnPayload{
+				Provider:    "anthropic",
+				RawRequest:  anthropicRequest,
+				RawResponse: []byte(anthropicSSE),
+				Meta: ingest.TurnMeta{
+					ContentType:    "text/event-stream",
+					TsRequest:      requested.Format(time.RFC3339Nano),
+					ElapsedSeconds: liveElapsedSeconds,
+				},
+			})
+
+			var reduced llm.ChatResponse
+			Expect(json.Unmarshal(driver.RawTurns()[0].Response, &reduced)).To(Succeed())
+
+			// ts_request is the request instant; adding the call's duration
+			// gives the completion instant CreatedAt denotes. Reusing the
+			// field derive.CapturedAt already reads is what keeps CreatedAt
+			// and the derived span's StartedAt on the same clock.
+			Expect(reduced.CreatedAt.UTC()).To(BeTemporally(
+				"~", requested.Add(1747*time.Millisecond), time.Millisecond))
+			Expect(stampCount(server, "created_at", "ts_request")).To(Equal(1.0))
+		})
+
+		It("dates the turn from ts_request alone when no elapsed is available", func() {
+			requested := time.Date(2026, 7, 28, 17, 36, 15, 0, time.UTC)
+
+			post(ingest.TurnPayload{
+				Provider:    "anthropic",
+				RawRequest:  anthropicRequest,
+				RawResponse: []byte(anthropicSSE),
+				Meta: ingest.TurnMeta{
+					ContentType: "text/event-stream",
+					TsRequest:   requested.Format(time.RFC3339Nano),
+				},
+			})
+
+			var reduced llm.ChatResponse
+			Expect(json.Unmarshal(driver.RawTurns()[0].Response, &reduced)).To(Succeed())
+
+			// Early by the call's duration, which is a far smaller error than
+			// the ingest hop it replaces.
+			Expect(reduced.CreatedAt.UTC()).To(BeTemporally("==", requested))
+			Expect(stampCount(server, "created_at", "ts_request")).To(Equal(1.0))
+		})
+
+		It("prefers captured_at over ts_request when both are present", func() {
+			completed := time.Date(2026, 7, 28, 17, 36, 17, 0, time.UTC)
+
+			post(ingest.TurnPayload{
+				Provider:    "anthropic",
+				RawRequest:  anthropicRequest,
+				RawResponse: []byte(anthropicSSE),
+				Meta: ingest.TurnMeta{
+					ContentType:    "text/event-stream",
+					TsRequest:      "2026-07-28T17:36:15Z",
+					CapturedAt:     completed.Format(time.RFC3339),
+					ElapsedSeconds: liveElapsedSeconds,
+				},
+			})
+
+			var reduced llm.ChatResponse
+			Expect(json.Unmarshal(driver.RawTurns()[0].Response, &reduced)).To(Succeed())
+
+			// captured_at is the completion instant outright; it needs no
+			// arithmetic, so it wins.
+			Expect(reduced.CreatedAt.UTC()).To(BeTemporally("==", completed))
+			Expect(stampCount(server, "created_at", "captured_at")).To(Equal(1.0))
+			Expect(stampCount(server, "created_at", "ts_request")).To(BeZero())
+		})
+
+		It("falls back to ingest time, and counts it, when the envelope has no capture time", func() {
+			before := time.Now().UTC().Add(-time.Second)
+
+			post(ingest.TurnPayload{
+				Provider:    "anthropic",
+				RawRequest:  anthropicRequest,
+				RawResponse: []byte(anthropicSSE),
+				Meta:        ingest.TurnMeta{ContentType: "text/event-stream"},
+			})
+
+			var reduced llm.ChatResponse
+			Expect(json.Unmarshal(driver.RawTurns()[0].Response, &reduced)).To(Succeed())
+
+			// Documents the degradation rather than hiding it: with no
+			// producer sending captured_at yet, an Anthropic raw-only row's
+			// CreatedAt is ingest time. The counter is the signal that says
+			// so, and the reason this is a contract decision and not a bug
+			// fix.
+			Expect(reduced.CreatedAt.UTC()).To(BeTemporally(">=", before))
+			Expect(stampCount(server, "created_at", "fallback")).To(Equal(1.0))
+		})
+
+		It("keeps the turn and counts a fallback when captured_at is malformed", func() {
+			post(ingest.TurnPayload{
+				Provider:    "anthropic",
+				RawRequest:  anthropicRequest,
+				RawResponse: []byte(anthropicSSE),
+				Meta: ingest.TurnMeta{
+					ContentType: "text/event-stream",
+					CapturedAt:  "yesterday afternoon",
+				},
+			})
+
+			// A producer bug is not a reason to lose a turn whose bytes are
+			// already stored.
+			var reduced llm.ChatResponse
+			Expect(json.Unmarshal(driver.RawTurns()[0].Response, &reduced)).To(Succeed())
+			Expect(reduced.Message.GetText()).To(Equal("Hello world"))
+			Expect(stampCount(server, "created_at", "fallback")).To(Equal(1.0))
+		})
+
+		It("does not touch a payload that arrived with its own reduction", func() {
+			adapterCreatedAt := time.Date(2026, 7, 28, 17, 36, 15, 0, time.UTC)
+			adapterReduction := reducedResponse(
+				"claude-3-5-sonnet-20241022", "adapter reduction",
+				&llm.Usage{TotalDurationNs: 42},
+			)
+			adapterReduction.CreatedAt = adapterCreatedAt
+
+			post(ingest.TurnPayload{
+				Provider:            "anthropic",
+				RawRequest:          anthropicRequest,
+				Response:            adapterReduction,
+				RawResponse:         []byte(anthropicSSE),
+				RawResponseEncoding: "identity",
+				Meta: ingest.TurnMeta{
+					ContentType:    "text/event-stream",
+					ElapsedSeconds: liveElapsedSeconds,
+					CapturedAt:     time.Now().UTC().Format(time.RFC3339),
+				},
+			})
+
+			var reduced llm.ChatResponse
+			Expect(json.Unmarshal(driver.RawTurns()[0].Response, &reduced)).To(Succeed())
+
+			// Dual-send is untouched by all of this: the adapter measured the
+			// live stream, so its duration and timestamp stand even where the
+			// envelope also carries them.
+			Expect(reduced.Usage.TotalDurationNs).To(Equal(int64(42)))
+			Expect(reduced.CreatedAt.UTC()).To(BeTemporally("==", adapterCreatedAt))
+			Expect(stampCount(server, "", "")).To(BeZero())
+		})
 	})
 
 	It("still stores the bytes when the encoding is one it cannot decode", func() {

--- a/pkg/derive/captured_at_test.go
+++ b/pkg/derive/captured_at_test.go
@@ -23,8 +23,15 @@ func TestCapturedAtPrecedence(t *testing.T) {
 		want time.Time
 	}{
 		{
-			name: "captured_at wins over ts_request",
+			// Without a usable elapsed, captured_at cannot be rewound to a
+			// start instant — the exact ts_request beats the approximation.
+			name: "an exact ts_request beats an unrewindable captured_at",
 			meta: map[string]any{"captured_at": captured, "ts_request": requested},
+			want: time.Date(2026, 7, 31, 10, 59, 58, 0, time.UTC),
+		},
+		{
+			name: "captured_at stands alone as the last capture-side stamp",
+			meta: map[string]any{"captured_at": captured},
 			want: time.Date(2026, 7, 31, 11, 0, 0, 500_000_000, time.UTC),
 		},
 		{
@@ -35,7 +42,15 @@ func TestCapturedAtPrecedence(t *testing.T) {
 			want: time.Date(2026, 7, 31, 10, 59, 58, 0, time.UTC),
 		},
 		{
-			name: "a corrupt elapsed does not shift captured_at",
+			// A corrupt elapsed cannot rewind, so the exact request instant
+			// wins when present…
+			name: "a corrupt elapsed falls through to ts_request",
+			meta: map[string]any{"captured_at": captured, "ts_request": requested, "elapsed_seconds": 8.0e9},
+			want: time.Date(2026, 7, 31, 10, 59, 58, 0, time.UTC),
+		},
+		{
+			// …and without one, the unshifted completion instant stands.
+			name: "a corrupt elapsed does not shift a lone captured_at",
 			meta: map[string]any{"captured_at": captured, "elapsed_seconds": 8.0e9},
 			want: time.Date(2026, 7, 31, 11, 0, 0, 500_000_000, time.UTC),
 		},

--- a/pkg/derive/captured_at_test.go
+++ b/pkg/derive/captured_at_test.go
@@ -1,0 +1,62 @@
+package derive_test
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/papercomputeco/tapes/pkg/derive"
+	"github.com/papercomputeco/tapes/pkg/storage"
+)
+
+// The deriver and ingest's raw-only CreatedAt stamping must resolve
+// capture time with the same precedence, or a row's CreatedAt and its
+// derived span's StartedAt drift onto different clocks.
+func TestCapturedAtPrecedence(t *testing.T) {
+	received := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
+	captured := "2026-07-31T11:00:00.5Z"
+	requested := "2026-07-31T10:59:58Z"
+
+	cases := []struct {
+		name string
+		meta map[string]string
+		want time.Time
+	}{
+		{
+			name: "captured_at wins over ts_request",
+			meta: map[string]string{"captured_at": captured, "ts_request": requested},
+			want: time.Date(2026, 7, 31, 11, 0, 0, 500_000_000, time.UTC),
+		},
+		{
+			name: "ts_request stands alone",
+			meta: map[string]string{"ts_request": requested},
+			want: time.Date(2026, 7, 31, 10, 59, 58, 0, time.UTC),
+		},
+		{
+			name: "malformed captured_at falls through to ts_request",
+			meta: map[string]string{"captured_at": "yesterday-ish", "ts_request": requested},
+			want: time.Date(2026, 7, 31, 10, 59, 58, 0, time.UTC),
+		},
+		{
+			name: "no capture-side stamp falls back to received_at",
+			meta: nil,
+			want: received,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := &storage.RawTurnRecord{ReceivedAt: received}
+			if tc.meta != nil {
+				raw, err := json.Marshal(tc.meta)
+				if err != nil {
+					t.Fatalf("marshal meta: %v", err)
+				}
+				rec.Meta = raw
+			}
+			if got := derive.CapturedAt(rec); !got.Equal(tc.want) {
+				t.Fatalf("CapturedAt = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/derive/captured_at_test.go
+++ b/pkg/derive/captured_at_test.go
@@ -19,22 +19,34 @@ func TestCapturedAtPrecedence(t *testing.T) {
 
 	cases := []struct {
 		name string
-		meta map[string]string
+		meta map[string]any
 		want time.Time
 	}{
 		{
 			name: "captured_at wins over ts_request",
-			meta: map[string]string{"captured_at": captured, "ts_request": requested},
+			meta: map[string]any{"captured_at": captured, "ts_request": requested},
+			want: time.Date(2026, 7, 31, 11, 0, 0, 500_000_000, time.UTC),
+		},
+		{
+			// captured_at is the completion instant; span chronology wants
+			// the start, so a usable elapsed rewinds it.
+			name: "captured_at is rewound by elapsed to the start instant",
+			meta: map[string]any{"captured_at": captured, "elapsed_seconds": 2.5},
+			want: time.Date(2026, 7, 31, 10, 59, 58, 0, time.UTC),
+		},
+		{
+			name: "a corrupt elapsed does not shift captured_at",
+			meta: map[string]any{"captured_at": captured, "elapsed_seconds": 8.0e9},
 			want: time.Date(2026, 7, 31, 11, 0, 0, 500_000_000, time.UTC),
 		},
 		{
 			name: "ts_request stands alone",
-			meta: map[string]string{"ts_request": requested},
+			meta: map[string]any{"ts_request": requested},
 			want: time.Date(2026, 7, 31, 10, 59, 58, 0, time.UTC),
 		},
 		{
 			name: "malformed captured_at falls through to ts_request",
-			meta: map[string]string{"captured_at": "yesterday-ish", "ts_request": requested},
+			meta: map[string]any{"captured_at": "yesterday-ish", "ts_request": requested},
 			want: time.Date(2026, 7, 31, 10, 59, 58, 0, time.UTC),
 		},
 		{

--- a/pkg/derive/deriver.go
+++ b/pkg/derive/deriver.go
@@ -165,23 +165,30 @@ func CapturedAt(rec *storage.RawTurnRecord) time.Time {
 	if len(rec.Meta) > 0 {
 		_ = json.Unmarshal(rec.Meta, &meta)
 	}
+	// captured_at is the COMPLETION instant, but this function's callers
+	// want the turn's start (span StartedAt). It therefore only leads when
+	// the elapsed duration can rewind it to an exact start; otherwise an
+	// exact ts_request beats an approximation, and captured_at stands alone
+	// only as the last capture-side stamp available — late by the call's
+	// duration, still better than the ingest hop.
+	capturedAt := time.Time{}
 	if meta.CapturedAt != "" {
 		if ts, err := time.Parse(time.RFC3339Nano, meta.CapturedAt); err == nil {
-			// captured_at is the COMPLETION instant, but this function's
-			// callers want the turn's start (span StartedAt). Rewind by the
-			// call's duration when the envelope carries a usable one;
-			// without it the completion instant still beats the ingest hop
-			// it replaces, just late by the call's duration.
-			if e := meta.ElapsedSeconds; e > 0 && e <= maxDeriveElapsedSeconds {
-				ts = ts.Add(-time.Duration(e * float64(time.Second)))
-			}
-			return ts
+			capturedAt = ts
+		}
+	}
+	if !capturedAt.IsZero() {
+		if e := meta.ElapsedSeconds; e > 0 && e <= maxDeriveElapsedSeconds {
+			return capturedAt.Add(-time.Duration(e * float64(time.Second)))
 		}
 	}
 	if meta.TsRequest != "" {
 		if ts, err := time.Parse(time.RFC3339Nano, meta.TsRequest); err == nil {
 			return ts
 		}
+	}
+	if !capturedAt.IsZero() {
+		return capturedAt
 	}
 	return rec.ReceivedAt
 }

--- a/pkg/derive/deriver.go
+++ b/pkg/derive/deriver.go
@@ -132,10 +132,16 @@ type RederiveReport struct {
 // outright; backfilled rows carry ts_request; live rows fall back to
 // received_at).
 type rawMetaFields struct {
-	CapturedAt string `json:"captured_at"`
-	TsRequest  string `json:"ts_request"`
-	ThreadID   string `json:"thread_id"`
+	CapturedAt     string  `json:"captured_at"`
+	TsRequest      string  `json:"ts_request"`
+	ElapsedSeconds float64 `json:"elapsed_seconds"`
+	ThreadID       string  `json:"thread_id"`
 }
+
+// maxDeriveElapsedSeconds mirrors ingest's bound on a plausible
+// single-call duration; beyond it the elapsed value is treated as
+// corrupt rather than folded into chronology.
+const maxDeriveElapsedSeconds = 7 * 24 * 60 * 60
 
 // threadIDFromMeta resolves the capture-side harness sub-thread id
 // from a raw row's meta block.
@@ -147,11 +153,13 @@ func threadIDFromMeta(meta json.RawMessage) string {
 	return m.ThreadID
 }
 
-// CapturedAt resolves a raw record's original capture time: the
-// capture-side completion instant when the meta block carries one,
-// else the adapter's request timestamp, otherwise the ingest receive
-// time. The precedence mirrors ingest's raw-only CreatedAt stamping so
-// the two stay on one clock.
+// CapturedAt resolves a raw record's original capture-side START
+// instant, for span chronology: captured_at (a completion instant)
+// rewound by the call's elapsed duration when the meta block carries
+// both, else the adapter's request timestamp, otherwise the ingest
+// receive time. The source precedence mirrors ingest's raw-only
+// CreatedAt stamping — both fields ride one capture-side clock, offset
+// from each other by exactly the call's duration.
 func CapturedAt(rec *storage.RawTurnRecord) time.Time {
 	var meta rawMetaFields
 	if len(rec.Meta) > 0 {
@@ -159,6 +167,14 @@ func CapturedAt(rec *storage.RawTurnRecord) time.Time {
 	}
 	if meta.CapturedAt != "" {
 		if ts, err := time.Parse(time.RFC3339Nano, meta.CapturedAt); err == nil {
+			// captured_at is the COMPLETION instant, but this function's
+			// callers want the turn's start (span StartedAt). Rewind by the
+			// call's duration when the envelope carries a usable one;
+			// without it the completion instant still beats the ingest hop
+			// it replaces, just late by the call's duration.
+			if e := meta.ElapsedSeconds; e > 0 && e <= maxDeriveElapsedSeconds {
+				ts = ts.Add(-time.Duration(e * float64(time.Second)))
+			}
 			return ts
 		}
 	}

--- a/pkg/derive/deriver.go
+++ b/pkg/derive/deriver.go
@@ -128,11 +128,13 @@ type RederiveReport struct {
 }
 
 // rawMetaFields is the minimal meta decode the deriver needs: original
-// capture time for chronology (backfilled rows carry ts_request; live
-// rows fall back to received_at).
+// capture time for chronology (captured_at is the completion instant
+// outright; backfilled rows carry ts_request; live rows fall back to
+// received_at).
 type rawMetaFields struct {
-	TsRequest string `json:"ts_request"`
-	ThreadID  string `json:"thread_id"`
+	CapturedAt string `json:"captured_at"`
+	TsRequest  string `json:"ts_request"`
+	ThreadID   string `json:"thread_id"`
 }
 
 // threadIDFromMeta resolves the capture-side harness sub-thread id
@@ -146,12 +148,19 @@ func threadIDFromMeta(meta json.RawMessage) string {
 }
 
 // CapturedAt resolves a raw record's original capture time: the
-// adapter's request timestamp when the meta block carries one,
-// otherwise the ingest receive time.
+// capture-side completion instant when the meta block carries one,
+// else the adapter's request timestamp, otherwise the ingest receive
+// time. The precedence mirrors ingest's raw-only CreatedAt stamping so
+// the two stay on one clock.
 func CapturedAt(rec *storage.RawTurnRecord) time.Time {
 	var meta rawMetaFields
 	if len(rec.Meta) > 0 {
 		_ = json.Unmarshal(rec.Meta, &meta)
+	}
+	if meta.CapturedAt != "" {
+		if ts, err := time.Parse(time.RFC3339Nano, meta.CapturedAt); err == nil {
+			return ts
+		}
 	}
 	if meta.TsRequest != "" {
 		if ts, err := time.Parse(time.RFC3339Nano, meta.TsRequest); err == nil {


### PR DESCRIPTION
Raw-only payloads carry verbatim upstream bytes and no client-side reduction, so ingest reduces them server-side. The reducers see only those bytes, which carry neither the call's duration nor the instant it was captured — two capture-side facts that previously reached the stored row only because the producer reduced live. This closes both gaps.

**Duration.** `Usage.TotalDurationNs` was never stamped on the raw-only path, landing derived spans with a NULL `duration_ns`. Ingest now stamps it from `meta.elapsed_seconds` during server-side reduction, matching what a live-reducing producer would have recorded.

**CreatedAt.** Under raw-only it silently changed meaning from capture time to ingest time, because the reducers stamp `time.Now()` and that clock now runs on the server. It now means "when the turn happened, never when the server heard about it", resolved from the envelope in precision order: `meta.captured_at` (new optional field, exact) → `meta.ts_request` + `meta.elapsed_seconds` → `meta.ts_request` alone → whatever the reducer produced. Reusing `ts_request` keeps `CreatedAt` on the same clock the deriver already uses for span start times, and correctly dates backfilled recordings with no producer change.

Producers that don't yet send a timestamp fall back to the reducer's value; the fallback rate is observable per provider and field via the new `tapes_ingest_rawonly_stamp_total{provider,field,source}` counter rather than being silent. Providers whose wire format carries its own creation time (e.g. OpenAI Responses `created_at`) are preserved untouched.

Dual-send payloads are unaffected — the stamps apply only where the server is the reducer.

related to PCC-1044