### PR TITLE
🔧 fix(envelope): decode cwd at the reader, and refuse control bytes

### DIFF
--- a/fixtures/envelope/README.md
+++ b/fixtures/envelope/README.md
@@ -62,8 +62,8 @@ Each `cases/*.json` file is one object:
 | `x-tapes-harness-id`                   | `harness_id`                | verbatim; missing/empty → `"unknown"` |
 | `x-tapes-harness-session-id`           | `harness_session_id`        | verbatim |
 | `x-tapes-harness-version`              | `harness_version`           | verbatim |
-| `x-tapes-cwd`                          | `cwd`                       | producer percent-encodes UTF-8; **reader stores it verbatim (does NOT decode)** |
-| `x-tapes-session-name`                 | `name`                      | producer percent-encodes UTF-8 (capped 256 raw bytes); **reader percent-decodes** |
+| `x-tapes-cwd`                          | `cwd`                       | producer percent-encodes UTF-8; **reader percent-decodes**, then applies the control-byte guard |
+| `x-tapes-session-name`                 | `name`                      | producer percent-encodes UTF-8 (capped 256 raw bytes); **reader percent-decodes**, then applies the control-byte guard |
 | `x-tapes-parent-harness-session-id`    | `parent_harness_session_id` | verbatim; **an empty header is dropped by the reader** (omit it) |
 | `x-tapes-harness-metadata`             | `harness_metadata`          | **base64url(no-pad) of a JSON value**, raw ≤ 4 KiB; reader retains any valid JSON, validation requires an **object** |
 | `x-paper-auth-org-id`                  | `org_id`                    | server-trusted (set from a validated JWT claim); UUID or empty |
@@ -89,14 +89,24 @@ The header values are byte-exact and auditable — reproduce them from these rul
 ## Reader behavior the cases pin
 
 The `envelope` in each case is exactly what the reader produces from `headers` — not an
-idealized inverse of the producer. Two spots are deliberately asymmetric and easy to get
-wrong:
+idealized inverse of the producer. Every parser of this corpus must agree on all of it;
+these are the spots that are easy to get wrong:
 
-- **`cwd` is stored verbatim** (still percent-encoded), while **`name` is percent-decoded**.
-  So the non-ASCII / control-byte `cwd` cases are `direction: encode` with a lossy
-  round-trip: `encode_from` holds the logical path, but decoding the header yields the
-  encoded string. (That the reader decodes `name` but not `cwd` is a standing asymmetry
-  worth revisiting in the reader, not in these fixtures.)
+- **Both `cwd` and `name` are percent-decoded**, with the same RFC 3986 path-segment
+  rules (`PathUnescape`, not `QueryUnescape` — the latter would mistranslate a literal
+  `+` into a space). The stored value is the *logical* value; percent-encoding is
+  transport framing that dies at the parser, so `/Users/松本/code` is stored and
+  displayed as itself. A malformed encoding is non-fatal: the raw header value is kept
+  so the row still records something recognisable.
+- **A decoded value carrying control bytes is refused, not stored.** After decoding, if
+  `cwd` or `name` contains any C0 control (`< 0x20`) or DEL (`0x7F`), the parser logs
+  and stores the **empty** string — it never persists the raw bytes. That is why
+  `cwd-control-bytes-escaped` is `direction: encode`: the producer can encode such a
+  path, but no reader will store it, so the case stays lossy and keeps its
+  `encode_from`. Escaping stops a control byte from forging a header *on the wire*; the
+  guard stops it from reaching *storage*. The injection defense therefore lives in
+  validation rather than in representation, which is what lets the stored field stay a
+  logical path instead of an encoded one that every consumer would have to decode.
 - **Non-object metadata is retained, then rejected.** The reader accepts any valid-JSON
   metadata (arrays included); object-ness is enforced by envelope validation, so
   `error-metadata-not-object` is `reject-400`, not a silent drop. Metadata that isn't

--- a/fixtures/envelope/cases/cwd-control-bytes-escaped.json
+++ b/fixtures/envelope/cases/cwd-control-bytes-escaped.json
@@ -2,7 +2,7 @@
   "name": "cwd-control-bytes-escaped",
   "category": "percent-encoding",
   "harness": "claude",
-  "description": "Header-injection defense: the producer percent-encodes control bytes in cwd (newline -> %0A) so no second header can be smuggled. The reader stores x-tapes-cwd verbatim, so the encoded, injection-safe form is what is persisted.",
+  "description": "Header-injection defense: the producer percent-encodes control bytes in cwd (newline -> %0A) so no second header can be smuggled. The reader decodes, sees a control byte, and refuses the value — cwd lands empty rather than carrying a raw newline.",
   "direction": "encode",
   "headers": {
     "x-tapes-harness-id": "claude",
@@ -15,10 +15,9 @@
     "org_id": "00000000-0000-4000-8000-000000000001",
     "auth_subject": "user_synthetic_fixture_subject",
     "harness_id": "claude",
-    "harness_session_id": "11111111-1111-4111-8111-111111111111",
-    "cwd": "/Users/matt%0Awith-injection:%20yes"
+    "harness_session_id": "11111111-1111-4111-8111-111111111111"
   },
-  "grounding": "Producer escapes control bytes when encoding cwd; the reader keeps the escaped value verbatim, so no raw CR/LF ever reaches the envelope.",
+  "grounding": "Escaping keeps the control byte from forging a header on the wire; the control-byte guard keeps it out of storage. A decoded cwd or session-name containing any C0 control (< 0x20) or DEL (0x7F) is refused: the parser logs and stores empty, never the raw bytes.",
   "encode_from": {
     "org_id": "00000000-0000-4000-8000-000000000001",
     "auth_subject": "user_synthetic_fixture_subject",
@@ -26,5 +25,5 @@
     "harness_session_id": "11111111-1111-4111-8111-111111111111",
     "cwd": "/Users/matt\nwith-injection: yes"
   },
-  "notes": "The percent-encoding happens on the producer side; the reader does not decode cwd, so the stored value stays escaped (this is what makes the injection defense hold end to end)."
+  "notes": "Lossy on purpose, which is why it keeps encode_from: the producer can encode this path, but no reader will store it. The injection defense lives in validation (refuse control bytes after decoding) rather than in representation (store the escaped form), so the stored value stays a logical path and no consumer needs its own decoder."
 }

--- a/fixtures/envelope/cases/cwd-unicode.json
+++ b/fixtures/envelope/cases/cwd-unicode.json
@@ -2,8 +2,8 @@
   "name": "cwd-unicode",
   "category": "percent-encoding",
   "harness": "claude",
-  "description": "Non-ASCII working directory. The producer percent-encodes each UTF-8 byte; the reader stores x-tapes-cwd VERBATIM, so the decoded path is not recovered.",
-  "direction": "encode",
+  "description": "Non-ASCII working directory. The producer percent-encodes each UTF-8 byte to survive the header hop; every reader decodes, so the logical path is recovered exactly.",
+  "direction": "roundtrip",
   "headers": {
     "x-tapes-harness-id": "claude",
     "x-paper-auth-org-id": "00000000-0000-4000-8000-000000000001",
@@ -16,15 +16,8 @@
     "auth_subject": "user_synthetic_fixture_subject",
     "harness_id": "claude",
     "harness_session_id": "11111111-1111-4111-8111-111111111111",
-    "cwd": "/Users/%E6%9D%BE%E6%9C%AC/code"
-  },
-  "grounding": "cwd is copied verbatim from x-tapes-cwd (the reader does not percent-decode it, unlike session-name).",
-  "encode_from": {
-    "org_id": "00000000-0000-4000-8000-000000000001",
-    "auth_subject": "user_synthetic_fixture_subject",
-    "harness_id": "claude",
-    "harness_session_id": "11111111-1111-4111-8111-111111111111",
     "cwd": "/Users/松本/code"
   },
-  "notes": "Reader asymmetry: session-name is percent-decoded but cwd is stored as-is. The round-trip is therefore lossy for non-ASCII cwd. Encode side is authoritative; decode yields the encoded string."
+  "grounding": "cwd is percent-decoded (RFC 3986 path-segment rules), exactly like session-name: the stored value is the logical path, and percent-encoding is transport framing that dies at the parser.",
+  "notes": "This case round-trips — encode(envelope) == headers and decode(headers) == envelope — so it carries no encode_from. It is the display-fidelity half of the cwd contract; cwd-control-bytes-escaped is the safety half."
 }

--- a/pkg/backfill/wiretrace.go
+++ b/pkg/backfill/wiretrace.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"os"
@@ -344,6 +345,12 @@ func buildWireTraceEnvelope(ctx context.Context, dir, turnDir string, reducer ca
 // captured X-Tapes-* request headers, mirroring tapes-extproc's
 // header→envelope mapping. Returns nil when no envelope headers were
 // present (matching extproc's omission semantics).
+//
+// cwd and session-name are both percent-decoded through
+// decodeEnvelopeHeaderValue, which is the same transform extproc
+// applies. The two parsers are meant to be interchangeable — the
+// shared fixture corpus (fixtures/envelope/cases) is what proves it —
+// so any change here belongs in extproc's ParseSessionEnvelope too.
 func sessionEnvelopeFromHeaders(header func(string) string) *sessions.IngestEnvelope {
 	harnessSessionID := header("x-tapes-harness-session-id")
 	harnessID := header("x-tapes-harness-id")
@@ -354,14 +361,12 @@ func sessionEnvelopeFromHeaders(header func(string) string) *sessions.IngestEnve
 		HarnessID:        harnessID,
 		HarnessSessionID: harnessSessionID,
 		HarnessVersion:   header("x-tapes-harness-version"),
-		Cwd:              header("x-tapes-cwd"),
+	}
+	if cwd := header("x-tapes-cwd"); cwd != "" {
+		env.Cwd = decodeEnvelopeHeaderValue("cwd", cwd)
 	}
 	if name := header("x-tapes-session-name"); name != "" {
-		if decoded, err := url.QueryUnescape(name); err == nil {
-			env.Name = decoded
-		} else {
-			env.Name = name
-		}
+		env.Name = decodeEnvelopeHeaderValue("session-name", name)
 	}
 	if parent := header("x-tapes-parent-harness-session-id"); parent != "" {
 		env.ParentHarnessSessionID = &parent
@@ -372,6 +377,69 @@ func sessionEnvelopeFromHeaders(header func(string) string) *sessions.IngestEnve
 		}
 	}
 	return env
+}
+
+// decodeEnvelopeHeaderValue turns one percent-encoded session-envelope
+// header value into the logical value that gets stored.
+//
+// The contract: the stored envelope value is the *logical* value.
+// Percent-encoding is transport framing that dies at the parser, so
+// every reader decodes and a non-ASCII path lands as itself rather
+// than as the escaped form the header hop demanded. Storing the
+// escaped form instead would leak wire encoding into the data model
+// and force a decoder into every consumer — the many-parsers
+// divergence this contract exists to kill.
+//
+// PathUnescape, not QueryUnescape: the encoding is RFC 3986
+// path-segment escaping, which leaves a literal `+` intact.
+// QueryUnescape would silently mistranslate `+` into a space, so a
+// session named "go+rust" would land as "go rust".
+//
+// The producer escapes control bytes so that no second header can be
+// smuggled across the header hop. Decoding hands that byte back, so
+// the injection defense moves from representation to validation: a
+// decoded value carrying any C0 control (< 0x20) or DEL (0x7F) is
+// refused outright — logged and stored empty — rather than persisted
+// raw. Refusing beats sanitizing because a path that needed a control
+// byte to be expressed is not a path any operator meant to record.
+//
+// A malformed encoding is non-fatal: the raw header value is used so
+// the row still records something recognisable. It passes the same
+// control-byte gate, so no path through this function can return a
+// control byte.
+func decodeEnvelopeHeaderValue(field, raw string) string {
+	value := raw
+	if decoded, err := url.PathUnescape(raw); err == nil {
+		value = decoded
+	} else {
+		slog.Warn("backfill: envelope header percent-decode failed; using raw value",
+			"field", field,
+			"error", err,
+			"raw_len", len(raw),
+		)
+	}
+	if hasControlRune(value) {
+		// Log the length, never the value: the whole point is to keep
+		// raw control bytes out of anything downstream, and a log sink
+		// is downstream.
+		slog.Warn("backfill: envelope header contains control bytes after decoding; dropping the value",
+			"field", field,
+			"decoded_len", len(value),
+		)
+		return ""
+	}
+	return value
+}
+
+// hasControlRune reports whether s contains a C0 control character
+// (< 0x20) or DEL (0x7F). These are the bytes that let a decoded value
+// forge header structure if it were ever re-emitted into a
+// header-shaped context, and the bytes an operator never intends to
+// have in a working directory or a session name.
+func hasControlRune(s string) bool {
+	return strings.ContainsFunc(s, func(r rune) bool {
+		return r < 0x20 || r == 0x7F
+	})
 }
 
 // providerFromPath extracts the provider segment from a gateway path

--- a/pkg/backfill/wiretrace_envelope_test.go
+++ b/pkg/backfill/wiretrace_envelope_test.go
@@ -1,0 +1,121 @@
+package backfill
+
+// Unit coverage for the header→envelope decode contract that
+// sessionEnvelopeFromHeaders implements.
+//
+// The shared fixture corpus (envelope_fixtures_test.go) pins the cases
+// that every consumer of the contract must agree on. This file pins the
+// decode rules themselves at a finer grain — the `+` case in particular
+// has no fixture, because a literal `+` needs no escaping and so cannot
+// be told apart from its encoded form by looking at the header alone.
+// It is exactly the case that separates PathUnescape from QueryUnescape.
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// headersFrom builds the lookup closure sessionEnvelopeFromHeaders
+// expects from a plain map.
+func headersFrom(m map[string]string) func(string) string {
+	return func(name string) string { return m[name] }
+}
+
+var _ = Describe("sessionEnvelopeFromHeaders decode contract", func() {
+	// A harness-session-id is present in every case so the parser does
+	// not short-circuit to a nil envelope.
+	const sessionID = "11111111-1111-4111-8111-111111111111"
+
+	base := func(extra map[string]string) func(string) string {
+		m := map[string]string{
+			"x-tapes-harness-id":         "claude",
+			"x-tapes-harness-session-id": sessionID,
+		}
+		for k, v := range extra {
+			m[k] = v
+		}
+		return headersFrom(m)
+	}
+
+	DescribeTable("cwd decodes to the logical path",
+		func(header, expected string) {
+			env := sessionEnvelopeFromHeaders(base(map[string]string{"x-tapes-cwd": header}))
+			Expect(env).NotTo(BeNil())
+			Expect(env.Cwd).To(Equal(expected))
+		},
+		Entry("cwd-unicode: non-ASCII path is recovered, not left escaped",
+			"/Users/%E6%9D%BE%E6%9C%AC/code", "/Users/松本/code"),
+		Entry("cwd-control-bytes-escaped: a decoded newline is refused outright",
+			"/Users/matt%0Awith-injection:%20yes", ""),
+		Entry("plain ASCII path passes through unchanged",
+			"/Users/matt/code", "/Users/matt/code"),
+		Entry("escaped space decodes to a space",
+			"/Users/matt/my%20code", "/Users/matt/my code"),
+		Entry("a literal + in a path stays a +, not a space",
+			"/Users/matt/go+rust", "/Users/matt/go+rust"),
+		Entry("a decoded DEL (0x7F) is refused",
+			"/Users/matt%7Fcode", ""),
+		Entry("a decoded NUL is refused",
+			"/Users/matt%00code", ""),
+		Entry("malformed percent-encoding falls back to the raw value",
+			"/Users/matt/100%discount", "/Users/matt/100%discount"),
+	)
+
+	DescribeTable("session-name decodes on the same rules as cwd",
+		func(header, expected string) {
+			env := sessionEnvelopeFromHeaders(base(map[string]string{"x-tapes-session-name": header}))
+			Expect(env).NotTo(BeNil())
+			Expect(env.Name).To(Equal(expected))
+		},
+		// The regression this pins: the reader used QueryUnescape, which
+		// turns a literal `+` into a space. PathUnescape leaves it alone,
+		// which is what the producer's RFC 3986 escaping means.
+		Entry("a literal + survives decoding (QueryUnescape would eat it)",
+			"go+rust", "go+rust"),
+		Entry("a + mixed with escapes still survives",
+			"go+rust%20notes", "go+rust notes"),
+		Entry("non-ASCII name is recovered",
+			"caf%C3%A9", "café"),
+		Entry("special chars decode as the corpus declares",
+			"name%20with%20space%20%22quotes%22%20caf%C3%A9", `name with space "quotes" café`),
+		Entry("a decoded newline is refused, same guard as cwd",
+			"friendly%0Ax-injected: yes", ""),
+		Entry("malformed percent-encoding falls back to the raw value",
+			"50%off", "50%off"),
+	)
+
+	It("refuses control bytes independently per field", func() {
+		env := sessionEnvelopeFromHeaders(base(map[string]string{
+			"x-tapes-cwd":          "/Users/matt%0Aevil",
+			"x-tapes-session-name": "perfectly-fine",
+		}))
+		Expect(env).NotTo(BeNil())
+		// A poisoned cwd must not take an innocent session name with it.
+		Expect(env.Cwd).To(BeEmpty())
+		Expect(env.Name).To(Equal("perfectly-fine"))
+	})
+
+	It("leaves absent headers empty rather than decoding an empty string", func() {
+		env := sessionEnvelopeFromHeaders(base(nil))
+		Expect(env).NotTo(BeNil())
+		Expect(env.Cwd).To(BeEmpty())
+		Expect(env.Name).To(BeEmpty())
+	})
+
+	DescribeTable("hasControlRune identifies exactly the refused runes",
+		func(s string, expected bool) {
+			Expect(hasControlRune(s)).To(Equal(expected))
+		},
+		Entry("empty string", "", false),
+		Entry("plain ASCII", "/Users/matt/code", false),
+		Entry("multi-byte UTF-8 is not a control rune", "/Users/松本/code", false),
+		Entry("space (0x20) is the first allowed byte", "a b", false),
+		Entry("tilde (0x7E) is allowed", "a~b", false),
+		Entry("NUL (0x00)", "a\x00b", true),
+		Entry("newline (0x0A)", "a\nb", true),
+		Entry("carriage return (0x0D)", "a\rb", true),
+		Entry("tab (0x09)", "a\tb", true),
+		Entry("unit separator (0x1F) is the last control", "a\x1fb", true),
+		Entry("DEL (0x7F)", "a\x7fb", true),
+	)
+})

--- a/pkg/backfill/wiretrace_envelope_test.go
+++ b/pkg/backfill/wiretrace_envelope_test.go
@@ -11,6 +11,8 @@ package backfill
 // It is exactly the case that separates PathUnescape from QueryUnescape.
 
 import (
+	"maps"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -31,9 +33,7 @@ var _ = Describe("sessionEnvelopeFromHeaders decode contract", func() {
 			"x-tapes-harness-id":         "claude",
 			"x-tapes-harness-session-id": sessionID,
 		}
-		for k, v := range extra {
-			m[k] = v
-		}
+		maps.Copy(m, extra)
 		return headersFrom(m)
 	}
 


### PR DESCRIPTION
The two envelope parsers disagreed on `cwd`. The gateway parser percent-decodes it; this reader stored it verbatim — while it *did* decode `session-name`. The same request therefore yielded a different stored `cwd` depending on which ingest path it took, and a non-ASCII home directory landed as `/Users/%E6%9D%BE%E6%9C%AC/code`.

Settle it in favour of decoding at every reader. The stored value is the logical value; percent-encoding is transport framing that exists only to survive the header hop, and it dies at the parser. Storing the escaped form would leak wire encoding into the data model and force a decoder into every consumer — the many-parsers divergence the shared fixture corpus exists to kill.

Escaping was also what made the header-injection defense hold end to end, so decoding has to replace it rather than remove it. The defense moves from representation to validation: after decoding, a `cwd` or `session-name` carrying any C0 control (< 0x20) or DEL (0x7F) is refused outright — logged and stored empty, never persisted raw. The log records the field and the decoded length, never the value. Refusing beats sanitizing: a path that needs a control byte to be expressed is not a path anyone meant to record.

Both fields now decode with `PathUnescape`. `session-name` previously used `QueryUnescape`, which silently turns a literal `+` into a space, so a session named `go+rust` was stored as `go rust`. No fixture can catch that one — a literal `+` needs no escaping, so it is indistinguishable from its encoded form in the header alone — hence the unit table.

The fixture corpus is updated to match: `cwd-unicode` becomes a `roundtrip` case, and `cwd-control-bytes-escaped` declares no `cwd` at all, because no reader will store it.

Existing rows keep their escaped values. Re-decoding them would corrupt a legitimate `%` in a real path, and there is no way to tell the two apart after the fact.

fixes PCC-1027