### PR TITLE
📚 docs(cassettes): add builder guide (PCC-1090)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,10 @@
   changing it changes everything for the internal merkle/dedup layer.
 - Always use `make` operations for development: use `make help` to understand
   the various operations available.
+- Every PR that adds or changes user-visible features or functionality **MUST**
+  add or update the corresponding documentation in `docs/src/` in the same PR,
+  add any new pages to `docs/src/SUMMARY.md`, and run `make docs-build` before
+  review. Do not defer required documentation to a follow-up PR.
 - Run tests with `make test`; the Dagger workflow provisions the Postgres
   service and passes its DSN to DB-backed suites.
 - Run `make format` to format and organize imports using `goimports` and `golangci-lint`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,9 +3,9 @@
 ## Quick start (recommended)
 
 The Nix flake dev shell is the recommended way to develop tapes. It pins the
-toolchain (Go 1.26, Dagger, `sqlc`, `hurl`) and exports the environment
-the build and tests need — `GOEXPERIMENT=jsonv2` and `TEST_POSTGRES_DSN` — so
-you don't have to set either by hand.
+toolchain (Go 1.26, Dagger, `sqlc`, `hurl`) and exports
+`GOEXPERIMENT=jsonv2`. `make test` provisions the test PostgreSQL service and
+passes its DSN to DB-backed suites.
 
 ```bash
 nix develop          # enter the dev shell

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -11,6 +11,7 @@
 # Concepts and workflows
 
 - [Architecture](./architecture.md)
+- [Cassettes](./cassettes.md)
 - [Search](./search.md)
 - [Skills](./skills.md)
 - [Inspecting and exporting data](./data.md)

--- a/docs/src/apis.md
+++ b/docs/src/apis.md
@@ -8,16 +8,16 @@ The default read API listens on `:8081`. It serves health, derived data, search,
 
 | Area | Routes |
 | --- | --- |
-| Health and contract | `GET /ping`, `/swagger`, `/swagger/openapi.yaml` |
+| Health and contract | `GET /ping`, `GET /openapi`, `/swagger` |
 | Sessions | `/v1/sessions`, `/v1/sessions/{id}`, `/v1/sessions/{id}/traces`, `/v1/sessions/{id}/raw_turns`, `/v1/sessions/{id}/export` |
 | Traces and spans | `/v1/traces`, `/v1/traces/{trace_id}`, `/v1/traces/{trace_id}/spans/{span_id}` |
 | Search and aggregates | `GET /v1/search/spans`, `GET /v1/stats` |
 | Skills | `/v1/skills` and session skill routes |
 | MCP | `/v1/mcp` |
 | Operator actions | `/v1/admin/derive/run`, `/v1/admin/seed/demo` |
-| Cassettes | `GET /v1/cassettes` |
+| Cassettes | `GET /v1/cassettes`, `GET /v1/cassettes/{name}/openapi.json`, `/v1/cassettes/{name}`, `/v1/cassettes/{name}/*` |
 
-The authoritative parameters, schemas, and methods are in `api/openapi.yaml` and the running `/swagger/openapi.yaml`. Notable current behavior:
+The authoritative parameters, schemas, and methods are compiled from route registrations and served by the running API at `GET /openapi`; no generated contract is checked in. The aggregate includes admitted cassette operations. See [Cassettes](./cassettes.md) for their manifest and proxy contract. Notable current behavior:
 
 - session listing is cursor-paginated;
 - session and trace/span paths use UUID IDs;
@@ -29,7 +29,7 @@ There is no `/v1/search`, `/v1/sessions/summary`, or hash-based session route.
 
 ## Private ingest API
 
-The private ingest API defaults to `:8082` and publishes a separate contract in `ingest/openapi.yaml`. The all-in-one `tapes serve` stack starts it alongside the proxy and read API; `tapes serve ingest` runs it as a standalone sidecar. Its write routes are:
+The private ingest API defaults to `:8082` and serves its separate contract at `GET /openapi`. The all-in-one `tapes serve` stack starts it alongside the proxy and read API; `tapes serve ingest` runs it as a standalone sidecar. Its write routes are:
 
 - `POST /v1/ingest` — append one completed conversation turn;
 - `POST /v1/ingest/transcript` — append transcript capture data;

--- a/docs/src/cassettes.md
+++ b/docs/src/cassettes.md
@@ -1,0 +1,425 @@
+# Cassettes
+
+> **Alpha/POC:** the current cassette contract is `cassette/v1alpha1`. It is
+> suitable for experiments and integrations, but its manifest and runtime
+> behavior are not yet a stable compatibility promise.
+
+A cassette is an independently deployed HTTP service that extends the Tapes read
+API. Tapes fetches the service's OpenAPI document, admits the manifest embedded
+in that document, rewrites the cassette's paths into the Tapes namespace, and
+reverse-proxies client requests to the cassette.
+
+A cassette is not a plugin loaded into the Tapes process. It can use any
+language or HTTP framework and does not have to import Tapes. The deployment,
+not Tapes, starts it and supplies its credentials and configuration.
+
+The complete runnable example is in
+[`pkg/cassette/examples/hello-world`](https://github.com/papercomputeco/tapes/tree/main/pkg/cassette/examples/hello-world).
+It includes an HTTP service, OpenAPI generation, `cassette.toml`, a container,
+PostgreSQL provisioning, and a Compose deployment.
+
+## What a cassette must provide
+
+A cassette has three kinds of endpoint on its own listener:
+
+1. a health anchor, `/ping` by default;
+2. an OpenAPI anchor, `/openapi` by default; and
+3. its API below a declared local prefix.
+
+For a cassette named `summary` with the default `prefix_path = "api"`, its own
+listener might serve:
+
+```text
+GET /ping
+GET /openapi
+GET /api/summary/reports
+```
+
+Tapes republishes only the cassette API:
+
+```text
+GET /v1/cassettes/summary/reports
+```
+
+The health and OpenAPI anchors describe the process itself. Do **not** include
+those root paths as operations in the cassette OpenAPI document. Every path in
+the document must be below the cassette's local API prefix, or Tapes refuses the
+whole document.
+
+The OpenAPI document must carry an `x-tapes-cassette` root extension containing
+the manifest. Tapes uses the configured document URL to both fetch the contract
+and determine the origin to which API requests are proxied.
+
+## Minimum manifest
+
+The current manifest kind is `cassette/v1alpha1`. The authored TOML form can be
+as small as:
+
+```toml
+kind = "cassette/v1alpha1"
+
+[cassette]
+name = "summary"
+version = "0.1.0"
+
+[depends]
+core = "v1"
+```
+
+Omitted API anchors default to:
+
+```toml
+[api]
+health = "/ping"
+openapi = "/openapi"
+prefix_path = "api"
+```
+
+The same logical manifest is required in the OpenAPI document as JSON:
+
+```json
+{
+  "openapi": "3.1.0",
+  "info": {"title": "Summary cassette", "version": "0.1.0"},
+  "x-tapes-cassette": {
+    "kind": "cassette/v1alpha1",
+    "cassette": {"name": "summary", "version": "0.1.0"},
+    "depends": {"core": "v1"},
+    "api": {
+      "health": "/ping",
+      "openapi": "/openapi",
+      "prefix_path": "api"
+    }
+  },
+  "paths": {
+    "/api/summary/reports": {
+      "get": {
+        "operationId": "listReports",
+        "responses": {"200": {"description": "Reports"}}
+      }
+    }
+  }
+}
+```
+
+Use any OpenAPI library that can add a root extension. The hello-world example
+uses `pkg/tapesoapi`, but that package is a convenience rather than part of the
+wire protocol.
+
+## The two published forms
+
+A cassette normally publishes the same declaration in two places:
+
+- **`cassette.toml`** is read before the process starts by a registry,
+  installer, or orchestrator. It describes the image, port, database access,
+  and configuration that deployment tooling may need. Tapes does not read this
+  file.
+- **`x-tapes-cassette` in OpenAPI** is read from the running service by Tapes.
+  This copy is required for admission.
+
+They are two encodings of one schema, not independent manifests. For the same
+installation identity, keep them in sync and test that they produce the same
+canonical manifest digest. Defaults are applied before canonicalization, and
+set-like fields are sorted, so an explicit default and an omitted default have
+the same identity.
+
+The Go parser is strict: duplicate keys, unknown fields, trailing JSON values,
+and an unsupported `kind` are errors. Parsing applies defaults but does not run
+semantic validation; callers of the package must also call `Validate`:
+
+```go
+package main
+
+import (
+    "fmt"
+    "os"
+
+    "github.com/papercomputeco/tapes/pkg/cassette"
+    "github.com/papercomputeco/tapes/pkg/cassette/manifest"
+)
+
+func main() {
+    declared, err := manifest.Load("cassette.toml")
+    if err != nil {
+        panic(err)
+    }
+    if err := declared.Validate([]cassette.ContractVersion{"v1"}); err != nil {
+        panic(err)
+    }
+    digest, err := declared.Digest()
+    if err != nil {
+        panic(err)
+    }
+    fmt.Fprintln(os.Stdout, digest)
+}
+```
+
+There is not yet a dedicated `tapes cassette validate` command.
+
+## `cassette/v1alpha1` field reference
+
+### Identity
+
+| Field | Required | Rules and purpose |
+| --- | --- | --- |
+| `kind` | yes | Must be exactly `cassette/v1alpha1`. |
+| `cassette.name` | yes | Two to 32 lowercase letters, digits, or interior dashes; must start with a letter and end with a letter or digit. `public`, `tapes`, and names beginning `pg_` are reserved. |
+| `cassette.version` | yes | Non-empty release identifier. The alpha schema does not require semantic version syntax. |
+| `cassette.display_name` | no | Human-readable name. |
+| `cassette.description` | no | Human-readable summary. |
+| `cassette.license` | no | License identifier or prose. |
+| `cassette.homepage` | no | Absolute `http` or `https` URL. |
+| `cassette.image` | no | Image reference for deployment tooling, without leading or trailing whitespace. If set, `port` is required. Tapes does not pull or run it. |
+| `cassette.port` | no | Listener port from 1 through 65535. If set, `image` is required. |
+| `x-source-digest` | no | Optional source provenance in `sha256:<64 lowercase hex characters>` form. Tapes checks the shape but does not fetch or verify a source artifact. |
+
+The name is shared across several namespaces:
+
+```text
+public route     /v1/cassettes/<name>
+Postgres schema  <name>
+Postgres role    cassette_<name>
+```
+
+A valid name may contain a dash, so quote derived PostgreSQL identifiers rather
+than interpolating them as bare SQL identifiers.
+
+### Tapes dependency
+
+```toml
+[depends]
+core = "v1"
+views = ["sessions", "spans"]
+```
+
+`depends.core` names a major Tapes contract (`v1`, `v2`, and so on), not a Tapes
+binary release. A running core admits the cassette only if it serves that
+contract. The current default contract is `v1`.
+
+Each `depends.views` entry must be a unique lowercase PostgreSQL identifier of
+at most 63 bytes. `raw_turns` is explicitly forbidden: it is an internal capture
+log, not a cassette contract view. The manifest derives requested grants as
+`tapes_<core>.<view>`, for example `tapes_v1.spans`.
+
+This is a declaration only. Tapes does not check that a named view exists, apply
+grants, create roles, or give the cassette a database credential. Deployment
+tooling owns those actions.
+
+### API anchors and path mapping
+
+```toml
+[api]
+health = "/ping"
+openapi = "/openapi"
+prefix_path = "api"
+```
+
+`health` and `openapi` must be absolute paths without a host, query, fragment,
+or `.`/`..` segment. The current POC records both anchors, but Tapes fetches the
+exact OpenAPI URL configured by the operator and does not currently probe the
+health anchor.
+
+`prefix_path` is the path before the cassette name on the cassette's own
+listener. Each slash-separated segment must begin with a lowercase letter or
+digit; the rest may contain only lowercase letters, digits, dashes, or
+underscores. Prefer slash-free outer edges, such as `api` or `extensions/v2`.
+Tapes normalizes surrounding slashes. Set it to `/` to mount directly below the
+name:
+
+| `prefix_path` | Cassette-local path | Public path |
+| --- | --- | --- |
+| omitted or `api` | `/api/summary/reports` | `/v1/cassettes/summary/reports` |
+| `extensions/v2` | `/extensions/v2/summary/reports` | `/v1/cassettes/summary/reports` |
+| `/` | `/summary/reports` | `/v1/cassettes/summary/reports` |
+
+Every documented OpenAPI path must be contained by the local path in the middle
+column. Tapes rewrites that prefix in both the cached per-cassette document and
+the aggregate document.
+
+### Owned tables
+
+Declare tables the cassette owns in its own schema:
+
+```toml
+[[tables]]
+name = "daily_summary"
+```
+
+Names must be unique lowercase PostgreSQL identifiers of at most 63 bytes.
+Discovery publishes the qualified name, such as `summary.daily_summary`.
+
+Again, this is desired deployment state. The cassette owns its migrations;
+Tapes does not create the schema or tables.
+
+### Configuration schema
+
+A manifest can describe values that the deployment supplies to the cassette:
+
+```toml
+[[config]]
+key = "llm.model"
+type = "string"
+required = true
+enum = ["claude", "other"]
+description = "Model used to create summaries."
+
+[[config]]
+key = "batch_size"
+type = "int"
+default = 50
+min = 1
+max = 500
+
+[[config]]
+key = "llm.api_key"
+type = "string"
+required = true
+secret = true
+```
+
+Keys consist of dotted lowercase snake-case segments. They must be unique both
+as keys and after conversion to the conventional environment name:
+
+```text
+llm.model   -> CASSETTE_LLM_MODEL
+batch_size  -> CASSETTE_BATCH_SIZE
+```
+
+Supported types are:
+
+| Type | Default value rules | Extra constraints |
+| --- | --- | --- |
+| `string` | TOML/JSON string | `enum` is allowed only here, and its values must be unique. |
+| `int` | Integer | Optional inclusive `min` and `max`; `min` must not exceed `max`. |
+| `bool` | Boolean | — |
+| `duration` | String accepted by Go's duration parser, such as `30s` or `5m` | — |
+| `json` | A string whose contents are valid JSON | The manifest value is a string, not an inline TOML object. |
+
+A secret setting cannot have a default. Tapes publishes this schema, never
+runtime values, and does not inject environment variables. The `CASSETTE_...`
+name is a convention for the deployment and cassette to implement.
+
+The current discovery response projects each setting's key, type, required and
+secret flags, default, and description. Constraints such as `enum`, `min`, and
+`max` remain in the manifest but are not projected into discovery, so deployment
+tooling that needs the full configuration schema should read the manifest.
+
+## OpenAPI admission rules
+
+Before publishing a cassette, Tapes:
+
+1. fetches the configured URL with `GET`, a ten-second default timeout, and an
+   8 MiB response limit; an initial or changed document must return HTTP 200,
+   while a conditional refresh may return 304;
+2. refuses redirects by default;
+3. parses the OpenAPI document and its required root manifest extension;
+4. validates the manifest against the contracts this core serves;
+5. verifies that every path is below the declared local prefix;
+6. rewrites paths to `/v1/cassettes/<name>`; and
+7. compiles the rewritten document to ensure it can be published.
+
+Every operation must declare at least one response. If an operation supplies an
+`operationId`, it must be unique within that cassette; Tapes synthesizes an ID
+for anonymous operations in the aggregate. Component names and operation IDs
+are namespaced by cassette name in the aggregate `/openapi` document, so
+independently authored cassettes can use the same local names. A cassette's own
+cached document remains available at
+`/v1/cassettes/<name>/openapi.json`.
+
+The configured source must be a full `http` or `https` URL with a host and no
+userinfo or fragment. Tapes uses only its origin (scheme, host, and port) as the
+reverse-proxy target, so the service API must be reachable on the same origin as
+the OpenAPI document. Do not change the manifest name served by an already
+resolved source URL; the source is pinned to its first admitted identity.
+
+Cassette requests receive `X-Tapes-Cassette: <name>` and standard forwarded
+headers. The current proxy buffers complete requests and responses. Treat the
+POC surface as JSON request/response APIs; streaming is not currently supported.
+
+## Run and register a cassette
+
+Tapes does not start cassette processes. Start the cassette through your normal
+process manager, then give the Tapes API server the exact URL of its OpenAPI
+document:
+
+```toml
+# .tapes/config.toml
+cassettes = ["http://127.0.0.1:9999/openapi"]
+```
+
+Equivalent CLI configuration is:
+
+```bash
+tapes serve --cassettes=http://127.0.0.1:9999/openapi
+# or: tapes serve api --cassettes=http://127.0.0.1:9999/openapi
+# or: TAPES_CASSETTES=http://127.0.0.1:9999/openapi tapes serve
+```
+
+Tapes retries unresolved sources during startup and refreshes documents every
+30 seconds by default. Change that interval with `--cassette-refresh`. A
+cassette being unavailable does not prevent Tapes from starting.
+
+Inspect the installed surface with:
+
+```bash
+curl http://localhost:8081/v1/cassettes
+curl http://localhost:8081/v1/cassettes/summary/openapi.json
+curl http://localhost:8081/openapi
+curl http://localhost:8081/v1/cassettes/summary/reports
+```
+
+Discovery reports admitted cassettes, their manifest digests, OpenAPI status,
+and rejected source problems. After a successful admission, a later refresh
+failure marks the cached document stale rather than deleting it. Removing the
+source from configuration withdraws the cassette.
+
+The `manifest_digest` in discovery identifies canonical manifest metadata. The
+`ETag` on a cached cassette OpenAPI response identifies the complete republished
+OpenAPI document; these digests answer different questions and need not match.
+
+## Database and deployment responsibilities
+
+For a manifest named `summary`, depending on `v1` views `sessions` and `spans`,
+and declaring table `daily_summary`, the derived grant plan is:
+
+```text
+role        cassette_summary
+own schema  summary
+SELECT      tapes_v1.sessions
+SELECT      tapes_v1.spans
+owned table summary.daily_summary
+```
+
+The deployment should:
+
+- create and manage the cassette role and credentials;
+- grant only the declared contract views;
+- allow or create the cassette's schema as appropriate;
+- supply database and manifest-declared configuration values directly to the
+  process; and
+- let the cassette run its own schema migrations.
+
+Tapes publishes the declaration but deliberately performs none of those steps.
+It also does not pull `cassette.image`, expose `cassette.port`, or manage the
+cassette lifecycle.
+
+## Builder checklist
+
+Before handing a cassette to an operator:
+
+- serve a 200 health response at the declared health anchor;
+- serve one valid OpenAPI JSON document with HTTP 200 at the declared OpenAPI
+  anchor;
+- embed the exact `cassette/v1alpha1` manifest at `x-tapes-cassette`;
+- keep every OpenAPI operation under `/<prefix_path>/<name>` (or `/<name>` when
+  `prefix_path = "/"`);
+- make any supplied operation IDs unique and declare responses for every
+  operation;
+- validate both TOML and embedded copies, and compare their manifest digests
+  for the same installation identity;
+- keep deployment metadata, listener port, runtime name, and documented paths
+  consistent;
+- provision database access outside Tapes and run cassette-owned migrations;
+- test direct health/OpenAPI access, discovery, the cached spec, the aggregate
+  spec, and at least one proxied request; and
+- avoid streaming endpoints until the proxy gains streaming support.

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -60,7 +60,7 @@ Useful supported keys include:
 | `telemetry.disabled` | Disable CLI usage telemetry | `false` |
 | `update.disabled` | Disable update checks | `false` |
 
-`cassettes = ["https://host/openapi"]` is a top-level array for operator-managed cassette OpenAPI URLs; it is not a dotted `config set` field.
+`cassettes = ["https://host/openapi"]` is a top-level array for operator-managed cassette OpenAPI URLs; it is not a dotted `config set` field. See [Cassettes](./cassettes.md) for the manifest, deployment responsibilities, and runtime behavior.
 
 ## Example
 

--- a/docs/src/data.md
+++ b/docs/src/data.md
@@ -63,4 +63,4 @@ curl http://localhost:8081/v1/stats
 
 Session IDs and trace/span IDs are UUIDs, not content hashes. `GET /v1/sessions/{id}` returns session metadata; conversation content is on the trace/span endpoints. Raw-turn retrieval preserves the original capture separately from the derived model.
 
-Browse the live contract at `http://localhost:8081/swagger`, or fetch it from `http://localhost:8081/swagger/openapi.yaml`. See [HTTP APIs](./apis.md) for the surface and trust boundary.
+Browse the live contract at `http://localhost:8081/swagger`, or fetch it from `http://localhost:8081/openapi`. See [HTTP APIs](./apis.md) for the surface and trust boundary.

--- a/docs/src/development.md
+++ b/docs/src/development.md
@@ -10,7 +10,7 @@ The repository's supported workflow is Make-based. Run `make help` before invoki
 - PostgreSQL with pgvector and pg_duckdb for runtime and DB-backed tests;
 - Ollama when exercising default local embeddings.
 
-The Nix development shell supplies Go, Dagger, sqlc, swag, hurl, mdBook, `GOEXPERIMENT=jsonv2`, and the test PostgreSQL DSN:
+The Nix development shell supplies Go, Dagger, sqlc, hurl, mdBook, and `GOEXPERIMENT=jsonv2`:
 
 ```bash
 git clone https://github.com/papercomputeco/tapes.git
@@ -37,15 +37,7 @@ make install
 
 ## Tests and checks
 
-DB-backed suites must use the pinned PostgreSQL image, which carries pgvector and pg_duckdb:
-
-```bash
-make test-db-up
-make test-local
-make test-db-down
-```
-
-Scope a local run with `PKG=./pkg/... make test-local`. CI-style operations run through Dagger:
+Run the test suite through Dagger so DB-backed suites receive the pinned PostgreSQL service with pgvector and pg_duckdb:
 
 ```bash
 make test
@@ -64,6 +56,6 @@ make docs-serve
 
 The mdBook source is `docs/src/`, configuration is `docs/book.toml`, and generated HTML is `docs/book/` (ignored by Git). `docs-serve` rebuilds and serves the book locally.
 
-## Generated contracts
+## OpenAPI contracts
 
-`make openapi` regenerates both read and ingest contracts and their Swagger intermediates. Do not hand-edit generated files. Documentation changes should validate routes against `api/openapi.yaml`, `ingest/openapi.yaml`, and current command `--help` output.
+Read and ingest routes register their OpenAPI descriptions through the `oasfiber` wrapper and each running server compiles its contract at `GET /openapi`. There is no generated contract to update or check in. From a checkout, `tapes dev openapi [api|ingest]` emits a contract with field prose when a consumer needs bytes on disk.

--- a/pkg/cassette/examples/hello-world/README.md
+++ b/pkg/cassette/examples/hello-world/README.md
@@ -1,8 +1,9 @@
 # Hello world cassette
 
-The minimum viable tapes cassette. It is its own Go module and imports nothing
-from tapes: a cassette talks to core over HTTP and to Postgres when its
-deployment supplies a DSN.
+The minimum viable tapes cassette. It is its own Go module, and its runtime
+contract with core is only HTTP (plus Postgres when its deployment supplies a
+DSN). This example imports `pkg/tapesoapi` to generate OpenAPI, but cassette
+builders may use any OpenAPI implementation.
 
 ## Run it
 
@@ -71,19 +72,22 @@ in the spec so that core has one artifact to fetch and one thing to configure.
 Core reads only this one.
 
 They are not two schemas. `cassette/manifest.ParseTOML` transcodes TOML into
-JSON and runs the same strict parser and validator core runs, so a field that
-does not exist is refused identically in both.
+JSON and runs the same strict parser core uses, so a field that does not exist
+is refused identically in both. Parsing applies defaults; deployment tooling
+must then call `Validate` with the contract versions its target core serves.
 
-Nor are they two documents. Both canonicalize to the same bytes, so both hash to
-the same digest — the one core publishes for the copy it fetched over HTTP:
+With the example's default `hello-world` installation identity, both copies
+canonicalize to the same bytes and hash to the same digest — the one core
+publishes for the copy it fetched over HTTP:
 
 ```sh
 curl -s localhost:8081/v1/cassettes | jq -r '.cassettes[0].manifest_digest'
 # sha256:8171d476...  the digest of cassette.toml
 ```
 
-If those ever disagree, the running cassette is not the one the manifest
-describes.
+If those disagree for the same installation identity, the running cassette is
+not the one the publishable manifest describes. Core does not fetch
+`cassette.toml` or perform this comparison for the deployment.
 
 ## Contract
 

--- a/pkg/cassette/examples/hello-world/cassette.toml
+++ b/pkg/cassette/examples/hello-world/cassette.toml
@@ -12,9 +12,11 @@
 # must exist, and tapes has no hardcoded opinion of what this file should say.
 #
 # This is not a second schema. `cassette/manifest.ParseTOML` transcodes TOML to
-# JSON and hands it to the same strict parser and the same validator core uses
-# on the embedded copy, so the field names below are the JSON field names, and a
-# key that does not exist is refused here exactly as it would be there.
+# JSON and hands it to the same strict parser core uses on the embedded copy, so
+# the field names below are the JSON field names, and a key that does not exist
+# is refused here exactly as it would be there. Parsing applies defaults;
+# deployment tooling must then call `Validate` with the contract versions its
+# target core serves.
 # `pkg/cassette/manifest/toml_test.go` parses this very file and asserts that
 # what it derives is what the rest of this directory does — the role and schema
 # compose provisions, the prefix main.go serves, the port the Dockerfile


### PR DESCRIPTION
# 👨🏼

Closes PCC-1090 - documents cassettes in `docs/src/` and cleans up some other docs throughout

# 🤖

- add a comprehensive `cassette/v1alpha1` builder guide covering manifests, OpenAPI admission, routing, configuration, database grants, deployment, and POC limitations
- add cassette documentation to mdBook navigation and cross-link it from API and configuration references
- correct stale OpenAPI, Dagger/Postgres, and hello-world cassette guidance discovered during the review
- require same-PR documentation for user-visible feature and functionality changes in `AGENTS.md`

## Validation

- `make docs-build`
- `git diff --check`
- `make test` and `make format` were attempted but Dagger could not initialize because the local SSH agent returned EOF

Tracking: PCC-1090
