### PR TITLE
🔧 fix(proxy): resolve Codex sub-thread ids on the gateway and backfill paths

### DIFF
--- a/pkg/backfill/wiretrace.go
+++ b/pkg/backfill/wiretrace.go
@@ -306,10 +306,7 @@ func buildWireTraceEnvelope(ctx context.Context, dir, turnDir string, reducer ca
 		return ""
 	}
 
-	// Mirror extproc's harness thread-id mapping (headers.ThreadID in
-	// tapes-extproc) so backfilled rows attribute threads exactly like
-	// live capture.
-	threadID := headers("x-claude-code-agent-id")
+	threadID := threadIDFromHeaders(headers)
 
 	envelope := &wireTraceEnvelope{
 		Provider:  provider,
@@ -340,6 +337,58 @@ func buildWireTraceEnvelope(ctx context.Context, dir, turnDir string, reducer ca
 	}
 	return envelope, "", nil
 }
+
+// threadIDFromHeaders resolves the harness-native sub-thread id for a
+// captured turn, or "" for a main-thread call (or a harness with no known
+// mapping). It mirrors extproc's harness thread-id mapping (headers.ThreadID
+// in tapes-extproc) so backfilled rows attribute threads exactly like live
+// capture; any change here belongs in extproc's ThreadID too.
+//
+// Claude Code is resolved from a header list (first present wins): it stamps
+// x-claude-code-agent-id only on calls made from a subagent context, so
+// presence alone is the signal.
+//
+// Codex is a header *pair*, not a list member. Codex stamps thread-id on
+// EVERY call — root turns carry thread-id == session-id, and only spawned
+// sub-thread (child) turns carry a distinct thread-id. So a sub-thread id is
+// resolved only when both headers are present AND they diverge. Both must be
+// present: a lone thread-id without its session-id counterpart isn't a
+// recognized Codex shape, and treating it as a sub-thread would risk
+// misrouting root spines.
+//
+// The root guard is not cosmetic: a non-empty thread_id on a root turn
+// misroutes the root spine into tapes derive's threadCall path and silently
+// degrades the session's derived status (terminalMainSpan requires
+// ThreadID=="").
+func threadIDFromHeaders(header func(string) string) string {
+	for _, name := range claudeThreadIDHeaders {
+		if v := header(name); v != "" {
+			return v
+		}
+	}
+	if tid := header(codexThreadIDHeader); tid != "" {
+		if sid := header(codexSessionIDHeader); sid != "" && tid != sid {
+			return tid
+		}
+	}
+	return ""
+}
+
+// claudeThreadIDHeaders is ordered; first present header wins.
+var claudeThreadIDHeaders = []string{
+	"x-claude-code-agent-id",
+}
+
+const (
+	// codexSessionIDHeader is the Codex harness's root session id, present
+	// on every Codex call.
+	codexSessionIDHeader = "session-id"
+
+	// codexThreadIDHeader is the Codex harness's thread id for this call:
+	// equal to session-id on root turns, a distinct id on sub-thread
+	// (spawned agent) turns.
+	codexThreadIDHeader = "thread-id"
+)
 
 // sessionEnvelopeFromHeaders rebuilds the session block from the
 // captured X-Tapes-* request headers, mirroring tapes-extproc's

--- a/pkg/backfill/wiretrace_threadid_test.go
+++ b/pkg/backfill/wiretrace_threadid_test.go
@@ -1,0 +1,64 @@
+package backfill
+
+// Unit coverage for threadIDFromHeaders, the backfill-side mirror of
+// extproc's headers.ThreadID. The cases here are the ones that separate
+// the two harness shapes: Claude Code signals a subagent by the mere
+// presence of its agent-id header, while Codex stamps thread-id on every
+// call and only signals a sub-thread when thread-id and session-id
+// diverge.
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("threadIDFromHeaders", func() {
+	It("resolves Claude Code's agent-id header", func() {
+		Expect(threadIDFromHeaders(headersFrom(map[string]string{
+			"x-claude-code-agent-id": "agent-7",
+		}))).To(Equal("agent-7"))
+	})
+
+	It("prefers the Claude list over the Codex pair", func() {
+		Expect(threadIDFromHeaders(headersFrom(map[string]string{
+			"x-claude-code-agent-id": "agent-7",
+			"thread-id":              "thr-2",
+			"session-id":             "sess-1",
+		}))).To(Equal("agent-7"))
+	})
+
+	It("resolves a Codex sub-thread when the pair diverges", func() {
+		Expect(threadIDFromHeaders(headersFrom(map[string]string{
+			"thread-id":  "thr-2",
+			"session-id": "sess-1",
+		}))).To(Equal("thr-2"))
+	})
+
+	// The root guard: a non-empty thread_id on a root turn would misroute
+	// the root spine into derive's threadCall path, degrading the derived
+	// status (terminalMainSpan requires ThreadID=="").
+	It("resolves a Codex root turn to empty when the pair matches", func() {
+		Expect(threadIDFromHeaders(headersFrom(map[string]string{
+			"thread-id":  "sess-1",
+			"session-id": "sess-1",
+		}))).To(BeEmpty())
+	})
+
+	It("ignores a lone thread-id with no session-id counterpart", func() {
+		Expect(threadIDFromHeaders(headersFrom(map[string]string{
+			"thread-id": "thr-2",
+		}))).To(BeEmpty())
+	})
+
+	It("ignores a lone session-id with no thread-id", func() {
+		Expect(threadIDFromHeaders(headersFrom(map[string]string{
+			"session-id": "sess-1",
+		}))).To(BeEmpty())
+	})
+
+	It("resolves to empty when no thread headers are present", func() {
+		Expect(threadIDFromHeaders(headersFrom(map[string]string{
+			"x-tapes-harness-id": "codex",
+		}))).To(BeEmpty())
+	})
+})

--- a/proxy/header/header.go
+++ b/proxy/header/header.go
@@ -36,7 +36,9 @@ const AgentNameHeader = "X-Tapes-Agent-Name"
 //
 // The list is ordered; first present header wins. Add other harnesses'
 // equivalents here as they are identified — the rest of the pipeline is
-// harness-neutral and only sees the resolved thread id.
+// harness-neutral and only sees the resolved thread id. Codex is NOT a member
+// of this list: its sub-thread signal is a header *pair* (see the Codex
+// constants below), resolved separately in ThreadID.
 //
 // This must stay in step with tapes-extproc's harnessThreadIDHeaders: the two
 // are independent capture paths for the same traffic, and a header one records
@@ -49,6 +51,25 @@ var ThreadIDHeaders = []string{
 	"x-claude-code-agent-id",
 }
 
+// Codex's native identity headers. Unlike Claude Code, Codex stamps thread-id
+// on EVERY call — root turns carry thread-id == session-id, and only spawned
+// sub-thread (child) turns carry a distinct thread-id. So presence alone
+// doesn't mean "subagent"; the root guard in ThreadID compares the pair and
+// resolves root turns to "". Getting this wrong is not cosmetic: a non-empty
+// thread_id on a root turn misroutes the root spine into tapes derive's
+// threadCall path and silently degrades the session's derived status
+// (terminalMainSpan requires ThreadID=="").
+const (
+	// CodexSessionID is the Codex harness's root session id, present on
+	// every Codex call.
+	CodexSessionID = "session-id"
+
+	// CodexThreadID is the Codex harness's thread id for this call: equal to
+	// session-id on root turns, a distinct id on sub-thread (spawned agent)
+	// turns.
+	CodexThreadID = "thread-id"
+)
+
 // ThreadID resolves the harness-native sub-thread id for this request, or ""
 // for a main-thread call (or a harness with no known mapping). Fiber's Get is
 // case-insensitive, so the constants are written in the lowercase HTTP/2 form
@@ -57,6 +78,16 @@ func ThreadID(c *fiber.Ctx) string {
 	for _, name := range ThreadIDHeaders {
 		if v := strings.TrimSpace(c.Get(name)); v != "" {
 			return v
+		}
+	}
+	// Codex: sub-thread iff the thread-id / session-id pair diverges. Both
+	// must be present — a lone thread-id without its session-id counterpart
+	// isn't a recognized Codex shape, and treating it as a sub-thread would
+	// risk misrouting root spines (see the root-guard comment on the Codex
+	// constants above).
+	if tid := strings.TrimSpace(c.Get(CodexThreadID)); tid != "" {
+		if sid := strings.TrimSpace(c.Get(CodexSessionID)); sid != "" && tid != sid {
+			return tid
 		}
 	}
 	return ""

--- a/proxy/header/header_test.go
+++ b/proxy/header/header_test.go
@@ -253,3 +253,84 @@ var _ = Describe("SetClientResponseHeaders", func() {
 		Expect(resp.Header.Get("X-Multi")).To(Equal("value1, value2"))
 	})
 })
+
+var _ = Describe("ThreadID", func() {
+	var app *fiber.App
+
+	BeforeEach(func() {
+		app = fiber.New()
+	})
+
+	AfterEach(func() {
+		app.Shutdown()
+	})
+
+	// resolve runs ThreadID against a request carrying the given headers.
+	resolve := func(hdrs map[string]string) string {
+		var got string
+
+		app.Post("/test", func(c *fiber.Ctx) error {
+			got = ThreadID(c)
+			return c.SendStatus(fiber.StatusOK)
+		})
+
+		req := httptest.NewRequest(http.MethodPost, "/test", nil)
+		for k, v := range hdrs {
+			req.Header.Set(k, v)
+		}
+
+		resp, err := app.Test(req)
+		Expect(err).NotTo(HaveOccurred())
+		resp.Body.Close()
+
+		return got
+	}
+
+	It("resolves Claude Code's agent-id header", func() {
+		Expect(resolve(map[string]string{
+			"x-claude-code-agent-id": "agent-7",
+		})).To(Equal("agent-7"))
+	})
+
+	It("prefers the Claude list over the Codex pair", func() {
+		Expect(resolve(map[string]string{
+			"x-claude-code-agent-id": "agent-7",
+			"thread-id":              "thr-2",
+			"session-id":             "sess-1",
+		})).To(Equal("agent-7"))
+	})
+
+	It("resolves a Codex sub-thread when the pair diverges", func() {
+		Expect(resolve(map[string]string{
+			"thread-id":  "thr-2",
+			"session-id": "sess-1",
+		})).To(Equal("thr-2"))
+	})
+
+	// The root guard: a non-empty thread_id on a root turn would misroute
+	// the root spine into derive's threadCall path.
+	It("resolves a Codex root turn to empty when the pair matches", func() {
+		Expect(resolve(map[string]string{
+			"thread-id":  "sess-1",
+			"session-id": "sess-1",
+		})).To(BeEmpty())
+	})
+
+	It("ignores a lone thread-id with no session-id counterpart", func() {
+		Expect(resolve(map[string]string{
+			"thread-id": "thr-2",
+		})).To(BeEmpty())
+	})
+
+	It("ignores a lone session-id with no thread-id", func() {
+		Expect(resolve(map[string]string{
+			"session-id": "sess-1",
+		})).To(BeEmpty())
+	})
+
+	It("resolves to empty when no thread headers are present", func() {
+		Expect(resolve(map[string]string{
+			"content-type": "application/json",
+		})).To(BeEmpty())
+	})
+})


### PR DESCRIPTION
fixes PCC-1064

The harness-side pipeline (tapes-harnesses#4) and extproc's capture path (tapes-extproc#29) both resolve Codex sub-thread ids from the thread-id/session-id header pair, but the two sibling capture paths in this repo — the gateway proxy (`proxy/header`) and the wire-trace backfill (`pkg/backfill`) — still read only `x-claude-code-agent-id`. Codex subagent turns arriving through them resolve `thread_id = ""`, starving the deriver's Codex subagent reconciliation (PCC-1021) of the same evidence one layer down.

Both sites now mirror extproc's semantics exactly: the Claude header list first, then the Codex pair, resolving a sub-thread id only when both headers are present and differ. The root guard matters — Codex stamps thread-id on every call with thread-id == session-id on root turns, and a non-empty thread_id on a root turn misroutes the root spine into derive's threadCall path and silently degrades derived status.

14 new specs across the two sites (root-pair equality, lone-header shapes, Claude-over-Codex precedence); the root guard was mutation-tested. A repo-wide sweep for the Claude header found no other code sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
