### PR TITLE
✨ feat(ingest): decode zstd raw bodies and record producer-withheld bytes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/golang-migrate/migrate/v4 v4.19.1
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.8.0
+	github.com/klauspost/compress v1.18.4
 	github.com/lmittmann/tint v1.2.0
 	github.com/modelcontextprotocol/go-sdk v1.2.0
 	github.com/onsi/ginkgo/v2 v2.27.4
@@ -64,7 +65,6 @@ require (
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
-	github.com/klauspost/compress v1.18.4 // indirect
 	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect

--- a/ingest/ingest.go
+++ b/ingest/ingest.go
@@ -99,6 +99,30 @@ type TurnPayload struct {
 	// what the upstream sent.
 	RawResponseEncoding string `json:"raw_response_encoding,omitempty"`
 
+	// RawResponseWithheld says the producer captured verbatim bytes and
+	// deliberately did not send them — almost always because including them
+	// would have pushed the envelope past MaxIngestBodyBytes, so the choice
+	// was between a turn without its bytes and no turn at all.
+	//
+	// Without it that turn is indistinguishable from one produced by an
+	// adapter that never captured raw bytes in the first place: both arrive
+	// with raw_response absent. Those are opposite facts. The first is a
+	// limit that bit and wants tuning; the second is a deployment fact about
+	// which producers are running. A fidelity report that cannot separate
+	// them reports the wrong one — silently, and in the reassuring
+	// direction, since "this producer doesn't send raw" reads as expected
+	// where "we lost bytes we had" does not.
+	//
+	// Deliberately NOT named to match the raw_response_dropped column it
+	// feeds. The column is the union of two causes — the producer withheld,
+	// or ingest capped — and this field is only one of them. A shared name
+	// would imply the producer sets the column, when it contributes to it.
+	//
+	// Absent means "no claim", which is exactly the pre-existing behavior:
+	// every producer shipped before this field omits it and keeps reading as
+	// it always did.
+	RawResponseWithheld bool `json:"raw_response_withheld,omitempty"`
+
 	// Meta is the capture adapter's metadata block. Parsed for the
 	// fields ingest promotes (request_id for raw-turn dedup); the
 	// verbatim JSON is persisted alongside the raw turn so fields
@@ -873,6 +897,27 @@ func (s *Server) persistRawTurn(ctx context.Context, turn *TurnPayload, raw rawE
 			"cap", MaxRawResponseBytes,
 		)
 		rawResponse, dropped = nil, true
+	}
+
+	// A producer that withheld its bytes lands the same marker as a turn
+	// whose bytes ingest dropped, because the marker answers "did verbatim
+	// bytes exist for this turn?" and for both the answer is yes-and-gone.
+	// Which limit bit is an operational question, not a fidelity one, and it
+	// is answered by these two log lines rather than by a second column: a
+	// tier nobody can act on differently is a tier that only splits the
+	// dashboards.
+	//
+	// Honored only when no bytes arrived, so that a marked row never also
+	// carries a raw_response. A producer claiming both sent the bytes, and
+	// the bytes are the stronger evidence — keeping them and ignoring the
+	// claim degrades to the truth, while trusting the claim would discard
+	// verbatim capture on the strength of a contradicted flag.
+	if turn.RawResponseWithheld && len(rawResponse) == 0 {
+		s.logger.Warn("raw response withheld by producer",
+			"provider", turn.Provider,
+			"request_id", turn.Meta.RequestID,
+		)
+		dropped = true
 	}
 
 	rec := storage.RawTurnRecord{

--- a/ingest/ingest.go
+++ b/ingest/ingest.go
@@ -2,14 +2,12 @@ package ingest
 
 import (
 	"bytes"
-	"compress/gzip"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"log/slog"
 	"math"
 	"net"
@@ -623,7 +621,7 @@ func (s *Server) reduceRawOnly(ctx context.Context, turn *TurnPayload) json.RawM
 		return nil
 	}
 
-	body, err := decodeContentEncoding(turn.RawResponse, turn.RawResponseEncoding)
+	body, stats, err := capture.DecodeContentEncoding(turn.RawResponse, turn.RawResponseEncoding)
 	if err != nil {
 		s.logger.Warn("raw-only turn not reduced: decode failed",
 			"provider", turn.Provider,
@@ -632,6 +630,17 @@ func (s *Server) reduceRawOnly(ctx context.Context, turn *TurnPayload) json.RawM
 			"error", err,
 		)
 		return nil
+	}
+	if stats.Truncated {
+		// The reduction goes ahead: a turn recovered from a stream that
+		// ended early is worth more than no turn. Logged rather than
+		// dropped, because the reduction may be missing its tail and
+		// nothing downstream can tell that from the row alone.
+		s.logger.Info("raw-only turn reduced from a truncated body",
+			"provider", turn.Provider,
+			"request_id", turn.Meta.RequestID,
+			"encoding", turn.RawResponseEncoding,
+		)
 	}
 
 	resp, err := reducer.Reduce(ctx,
@@ -829,33 +838,6 @@ func reducedResponseAbsent(r llm.ChatResponse) bool {
 		!r.Done &&
 		r.StopReason == "" &&
 		r.Usage == nil
-}
-
-// decodeContentEncoding returns body decoded per encoding, for handing to a
-// reducer. The stored column keeps the ENCODED bytes; only the reduction sees
-// the decoded form.
-//
-// An unrecognized encoding is an error rather than a pass-through: handing
-// compressed bytes to a reducer that expects text yields a confusing parse
-// failure well away from the actual cause.
-func decodeContentEncoding(body []byte, encoding string) ([]byte, error) {
-	switch strings.ToLower(strings.TrimSpace(encoding)) {
-	case "", "identity":
-		return body, nil
-	case "gzip", "x-gzip":
-		zr, err := gzip.NewReader(bytes.NewReader(body))
-		if err != nil {
-			return nil, fmt.Errorf("gzip reader: %w", err)
-		}
-		defer zr.Close()
-		out, err := io.ReadAll(zr)
-		if err != nil {
-			return nil, fmt.Errorf("gzip decode: %w", err)
-		}
-		return out, nil
-	default:
-		return nil, fmt.Errorf("unsupported content-encoding %q", encoding)
-	}
 }
 
 // MaxRawResponseBytes caps the verbatim response bytes ingest will store on a

--- a/ingest/raw_response_test.go
+++ b/ingest/raw_response_test.go
@@ -180,6 +180,44 @@ var _ = Describe("Raw response capture", func() {
 		Expect(rec.Response).NotTo(BeEmpty())
 	})
 
+	It("marks a turn whose producer withheld the bytes", func() {
+		// The row looks identical on the wire to one from a producer that
+		// never captured raw bytes — same absent raw_response. The marker
+		// is the only thing separating "a limit took them" from "there
+		// were none", which are opposite operational facts.
+		post(ingest.TurnPayload{
+			Provider:            "anthropic",
+			RawRequest:          anthropicRequest,
+			Response:            reducedResponse("claude-3-5-sonnet-20241022", "Hello world", nil),
+			RawResponseWithheld: true,
+		})
+
+		rec := driver.RawTurns()[0]
+		Expect(rec.RawResponse).To(BeEmpty())
+		Expect(rec.RawResponseDropped).To(BeTrue())
+		// The turn is otherwise whole; only its verbatim bytes are gone.
+		Expect(rec.Response).NotTo(BeEmpty())
+	})
+
+	It("keeps the bytes when a producer both sends and claims to withhold them", func() {
+		// A contradicted claim loses to the evidence. Trusting it would
+		// discard verbatim capture on the strength of a flag the payload
+		// itself refutes, and would leave a marked row still carrying a
+		// raw_response — the one shape the marker must never produce.
+		post(ingest.TurnPayload{
+			Provider:            "anthropic",
+			RawRequest:          anthropicRequest,
+			RawResponse:         []byte(anthropicSSE),
+			RawResponseEncoding: "identity",
+			RawResponseWithheld: true,
+			Meta:                ingest.TurnMeta{ContentType: "text/event-stream"},
+		})
+
+		rec := driver.RawTurns()[0]
+		Expect(string(rec.RawResponse)).To(Equal(anthropicSSE))
+		Expect(rec.RawResponseDropped).To(BeFalse())
+	})
+
 	It("reduces a raw-only payload server-side", func() {
 		post(ingest.TurnPayload{
 			Provider:    "anthropic",

--- a/ingest/raw_response_test.go
+++ b/ingest/raw_response_test.go
@@ -11,10 +11,9 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/klauspost/compress/zstd"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
-	"github.com/klauspost/compress/zstd"
 
 	"github.com/papercomputeco/tapes/ingest"
 	"github.com/papercomputeco/tapes/pkg/llm"

--- a/ingest/raw_response_test.go
+++ b/ingest/raw_response_test.go
@@ -14,6 +14,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/klauspost/compress/zstd"
+
 	"github.com/papercomputeco/tapes/ingest"
 	"github.com/papercomputeco/tapes/pkg/llm"
 )
@@ -39,6 +41,16 @@ func gzipBytes(b []byte) []byte {
 	var buf bytes.Buffer
 	zw := gzip.NewWriter(&buf)
 	_, err := zw.Write(b)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(zw.Close()).To(Succeed())
+	return buf.Bytes()
+}
+
+func zstdBytes(b []byte) []byte {
+	var buf bytes.Buffer
+	zw, err := zstd.NewWriter(&buf)
+	Expect(err).NotTo(HaveOccurred())
+	_, err = zw.Write(b)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(zw.Close()).To(Succeed())
 	return buf.Bytes()
@@ -454,6 +466,51 @@ var _ = Describe("Raw response capture", func() {
 		})
 	})
 
+	It("reduces a zstd-encoded raw-only payload while storing the compressed bytes", func() {
+		// This is the case the raw-only lane existed for and could not
+		// serve: Codex traffic is zstd, so until ingest could decode it
+		// every zstd turn fell back to dual-send permanently. The bytes
+		// were already being stored — what was missing was the ability to
+		// get anything back out of them.
+		compressed := zstdBytes([]byte(anthropicSSE))
+
+		post(ingest.TurnPayload{
+			Provider:            "anthropic",
+			RawRequest:          anthropicRequest,
+			RawResponse:         compressed,
+			RawResponseEncoding: "zstd",
+			Meta:                ingest.TurnMeta{ContentType: "text/event-stream"},
+		})
+
+		rec := driver.RawTurns()[0]
+		Expect(rec.RawResponse).To(Equal(compressed))
+		Expect(rec.RawResponseEncoding).To(Equal("zstd"))
+		Expect(rec.RawResponseDropped).To(BeFalse())
+
+		var reduced llm.ChatResponse
+		Expect(json.Unmarshal(rec.Response, &reduced)).To(Succeed())
+		Expect(reduced.Message.GetText()).To(Equal("Hello world"))
+	})
+
+	It("reduces a raw-only payload whose stream was cut short", func() {
+		// The producer forwards the truncated compressed bytes as they
+		// arrived, so these are exactly what ingest is handed. Refusing
+		// them would discard a turn that is all there bar its trailer.
+		full := gzipBytes([]byte(anthropicSSE))
+
+		post(ingest.TurnPayload{
+			Provider:            "anthropic",
+			RawRequest:          anthropicRequest,
+			RawResponse:         full[:len(full)-8],
+			RawResponseEncoding: "gzip",
+			Meta:                ingest.TurnMeta{ContentType: "text/event-stream"},
+		})
+
+		var reduced llm.ChatResponse
+		Expect(json.Unmarshal(driver.RawTurns()[0].Response, &reduced)).To(Succeed())
+		Expect(reduced.Message.GetText()).To(Equal("Hello world"))
+	})
+
 	It("still stores the bytes when the encoding is one it cannot decode", func() {
 		post(ingest.TurnPayload{
 			Provider:            "anthropic",
@@ -464,9 +521,10 @@ var _ = Describe("Raw response capture", func() {
 		})
 
 		rec := driver.RawTurns()[0]
-		// A reduction ingest cannot perform is not a reason to lose the bytes:
-		// they are exactly what a later build with a zstd decoder re-derives
-		// from.
+		// zstd is decodable now, but these bytes are not valid zstd. A
+		// reduction ingest cannot perform is still not a reason to lose
+		// the bytes — the recovery path re-reads this column, so a fix to
+		// the decoder or the reducer can still reach this row.
 		Expect(rec.RawResponse).NotTo(BeEmpty())
 		Expect(rec.RawResponseEncoding).To(Equal("zstd"))
 		Expect(rec.RawResponseDropped).To(BeFalse())

--- a/pkg/capture/contentencoding.go
+++ b/pkg/capture/contentencoding.go
@@ -1,0 +1,178 @@
+package capture
+
+// Decoding a captured body's Content-Encoding.
+//
+// This is the ingest-side half of a contract whose other half lives in the
+// extproc capture adapter (telemetry/tapes-extproc, decodeBodyWithStats). The
+// two must agree, and for a long time they did not: extproc decoded zstd,
+// stacked encodings and truncated-but-salvageable streams, while ingest
+// handled a single identity-or-gzip layer. The asymmetry was not a latent
+// bug — it was load-bearing. extproc interlocks its raw-only lane against
+// what it believes ingest can decode, so every encoding ingest could not read
+// permanently fell back to dual-send. Codex traffic is zstd, so raw-only was
+// unreachable for it by construction.
+//
+// Closing that gap is what this file is for. The rules below are extproc's
+// rules, deliberately mirrored rather than reinvented, because the failure
+// mode of a capture contract implemented twice is that the two copies drift
+// while both stay green — the same divergence the envelope fixture corpus
+// exists to kill for headers.
+//
+// It lives in pkg/capture rather than in ingest because content-encoding is a
+// capture concern, not a projection one, and because two callers need it:
+// ingest's raw-only reduction and the storage layer's read-time reduction
+// recovery. Those were separate copies of a single-layer gzip decoder, which
+// is how this class of drift starts.
+
+import (
+	"bytes"
+	"compress/gzip"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/klauspost/compress/zstd"
+)
+
+// MaxDecompressedBytes caps one decompressed body, per layer. It bounds a
+// decompression bomb: the compressed bytes are already capped on the way in,
+// but a few KiB of zstd expands to gigabytes if nothing stops it.
+//
+// 32 MiB matches extproc's cap exactly. It has to: a body extproc accepted and
+// forwarded must not then be rejected here, or the raw lane would drop bytes
+// the producer believed were safe to send.
+const MaxDecompressedBytes = 32 << 20
+
+// DecodeStats reports what had to be tolerated to produce the decoded bytes.
+type DecodeStats struct {
+	// Truncated marks a body recovered from a stream that ended early —
+	// the decode succeeded only because partial output was accepted. The
+	// caller decides what that is worth; it is surfaced rather than
+	// swallowed so a salvaged reduction is never silently indistinguishable
+	// from a clean one.
+	Truncated bool
+}
+
+// DecodeContentEncoding returns body decoded per encoding, for handing to a
+// reducer. Callers store the ENCODED bytes and decode only for reduction:
+// re-compression is not byte-identical, so a column that promises "verbatim"
+// has to keep what arrived.
+//
+// An unrecognized encoding is an error rather than a pass-through. Handing
+// compressed bytes to a reducer that expects text yields a parse failure well
+// away from the actual cause, and the bytes are still stored either way — so
+// erroring here loses nothing and names the real problem.
+//
+// Truncated streams are salvaged rather than refused when they yielded any
+// output at all, and the salvage is reported in DecodeStats. A capture that
+// lost its tail is still most of a turn; refusing it would discard everything
+// the stream did deliver in exchange for nothing. This mirrors extproc's
+// response-side behavior — and it must, because extproc forwards the truncated
+// compressed bytes as they arrived, so these are exactly the bytes ingest is
+// handed.
+func DecodeContentEncoding(body []byte, encoding string) ([]byte, DecodeStats, error) {
+	ce := strings.TrimSpace(strings.ToLower(encoding))
+	if ce == "" || ce == "identity" {
+		return body, DecodeStats{}, nil
+	}
+
+	// Layers are peeled right-to-left: RFC 9110 §8.4 lists encodings in the
+	// order they were applied, so the last one listed is the outermost and
+	// comes off first.
+	layers := splitContentEncoding(ce)
+	current := body
+	var stats DecodeStats
+	for i := len(layers) - 1; i >= 0; i-- {
+		decoded, layerStats, err := decodeOneLayer(current, layers[i])
+		if err != nil {
+			// Name the full header as well as the failing token: with
+			// stacked encodings the token alone does not say which
+			// header produced it.
+			return nil, DecodeStats{}, fmt.Errorf("content-encoding %q: %w", encoding, err)
+		}
+		stats.Truncated = stats.Truncated || layerStats.Truncated
+		current = decoded
+	}
+	return current, stats, nil
+}
+
+// splitContentEncoding parses a Content-Encoding value into the layers to
+// undo, dropping whitespace and identity tokens.
+//
+// identity is dropped rather than handled as a layer because it means "no
+// transformation was applied": "gzip, identity" is one layer of gzip, and
+// "identity, identity" is zero layers, not an error.
+func splitContentEncoding(ce string) []string {
+	parts := strings.Split(ce, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" || p == "identity" {
+			continue
+		}
+		out = append(out, p)
+	}
+	return out
+}
+
+// decodeOneLayer undoes a single content-coding. The caller has already
+// lower-cased and trimmed the token.
+func decodeOneLayer(body []byte, encoding string) ([]byte, DecodeStats, error) {
+	switch encoding {
+	case "gzip", "x-gzip":
+		zr, err := gzip.NewReader(bytes.NewReader(body))
+		if err != nil {
+			return nil, DecodeStats{}, fmt.Errorf("gzip reader init: %w", err)
+		}
+		defer zr.Close()
+		return readCapped(zr, "gzip")
+
+	case "zstd":
+		// Bound the decoder itself as well as its output. The window and
+		// memory limits let a hostile frame be refused before it is
+		// expanded, rather than after MaxDecompressedBytes of it exists.
+		zr, err := zstd.NewReader(
+			bytes.NewReader(body),
+			zstd.WithDecoderMaxMemory(MaxDecompressedBytes),
+			zstd.WithDecoderMaxWindow(MaxDecompressedBytes),
+		)
+		if err != nil {
+			return nil, DecodeStats{}, fmt.Errorf("zstd reader init: %w", err)
+		}
+		defer zr.Close()
+		return readCapped(zr, "zstd")
+
+	default:
+		// deflate and br land here deliberately: no capture path emits
+		// them, and a decoder for an encoding nothing produces is
+		// untested code that only exists to be wrong later.
+		return nil, DecodeStats{}, fmt.Errorf("unsupported encoding %q", encoding)
+	}
+}
+
+// readCapped drains r under the size cap, applying the salvage rule.
+//
+// The cap is checked before the error is, so an oversize stream that also
+// ended early is refused rather than salvaged — otherwise the bomb guard would
+// be bypassable by truncating the bomb.
+func readCapped(r io.Reader, kind string) ([]byte, DecodeStats, error) {
+	// Read one byte past the cap so that a body of exactly
+	// MaxDecompressedBytes is accepted and one byte more is unambiguously
+	// over, without a second read to disambiguate.
+	decoded, err := io.ReadAll(io.LimitReader(r, MaxDecompressedBytes+1))
+	if len(decoded) > MaxDecompressedBytes {
+		return nil, DecodeStats{}, fmt.Errorf("%s decoded body exceeds %d bytes", kind, MaxDecompressedBytes)
+	}
+	if err != nil {
+		// Salvage on exactly two conjuncts: the stream ended early, and
+		// it produced something first. A corrupt header, a bad checksum,
+		// or an early end that yielded nothing are all hard failures —
+		// there is no partial turn in them to keep.
+		if errors.Is(err, io.ErrUnexpectedEOF) && len(decoded) > 0 {
+			return decoded, DecodeStats{Truncated: true}, nil
+		}
+		return nil, DecodeStats{}, fmt.Errorf("%s read: %w", kind, err)
+	}
+	return decoded, DecodeStats{}, nil
+}

--- a/pkg/capture/contentencoding_test.go
+++ b/pkg/capture/contentencoding_test.go
@@ -10,10 +10,9 @@ import (
 	"compress/gzip"
 	"math/rand"
 
+	"github.com/klauspost/compress/zstd"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
-	"github.com/klauspost/compress/zstd"
 
 	"github.com/papercomputeco/tapes/pkg/capture"
 )

--- a/pkg/capture/contentencoding_test.go
+++ b/pkg/capture/contentencoding_test.go
@@ -1,0 +1,160 @@
+package capture_test
+
+// These cases mirror the extproc decoder's own suite (tapes-extproc
+// decode_test.go) case for case. That is the point of them: the two decoders
+// are one contract implemented twice, and a contract implemented twice drifts
+// unless both copies are pinned to the same table.
+
+import (
+	"bytes"
+	"compress/gzip"
+	"math/rand"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/klauspost/compress/zstd"
+
+	"github.com/papercomputeco/tapes/pkg/capture"
+)
+
+func gzipped(b []byte) []byte {
+	var buf bytes.Buffer
+	w := gzip.NewWriter(&buf)
+	_, err := w.Write(b)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(w.Close()).To(Succeed())
+	return buf.Bytes()
+}
+
+func zstdCompressed(b []byte) []byte {
+	var buf bytes.Buffer
+	w, err := zstd.NewWriter(&buf)
+	Expect(err).NotTo(HaveOccurred())
+	_, err = w.Write(b)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(w.Close()).To(Succeed())
+	return buf.Bytes()
+}
+
+var _ = Describe("DecodeContentEncoding", func() {
+	const plain = "event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n"
+
+	decode := func(body []byte, enc string) ([]byte, capture.DecodeStats) {
+		out, stats, err := capture.DecodeContentEncoding(body, enc)
+		Expect(err).NotTo(HaveOccurred())
+		return out, stats
+	}
+
+	It("passes an empty or identity encoding through untouched", func() {
+		for _, enc := range []string{"", "identity", "  Identity  "} {
+			out, stats := decode([]byte(plain), enc)
+			Expect(string(out)).To(Equal(plain), "encoding %q", enc)
+			Expect(stats.Truncated).To(BeFalse())
+		}
+	})
+
+	It("does not copy on the identity path", func() {
+		// Pinned because the identity path is the common one: a capture
+		// that pays a full copy per turn to do nothing is a cost with no
+		// corresponding behavior.
+		body := []byte(plain)
+		out, _ := decode(body, "")
+		Expect(&out[0]).To(Equal(&body[0]))
+	})
+
+	It("decodes gzip under every spelling", func() {
+		for _, enc := range []string{"gzip", "x-gzip", "GZIP", " gzip "} {
+			out, stats := decode(gzipped([]byte(plain)), enc)
+			Expect(string(out)).To(Equal(plain), "encoding %q", enc)
+			Expect(stats.Truncated).To(BeFalse())
+		}
+	})
+
+	It("decodes zstd", func() {
+		out, stats := decode(zstdCompressed([]byte(plain)), "zstd")
+		Expect(string(out)).To(Equal(plain))
+		Expect(stats.Truncated).To(BeFalse())
+	})
+
+	It("treats identity as no layer at all within a list", func() {
+		// "gzip, identity" is one layer of gzip, not gzip plus a second
+		// encoding — identity names the absence of a transformation.
+		out, _ := decode(gzipped([]byte(plain)), "gzip, identity")
+		Expect(string(out)).To(Equal(plain))
+
+		out, _ = decode([]byte(plain), "identity, identity")
+		Expect(string(out)).To(Equal(plain))
+	})
+
+	It("unwraps stacked encodings outermost first", func() {
+		// RFC 9110 §8.4 lists encodings in the order they were applied,
+		// so "gzip, zstd" is zstd(gzip(body)) and zstd comes off first.
+		// Decoding left-to-right would fail on the very first layer,
+		// which is the only reason this asymmetry is testable at all.
+		stacked := zstdCompressed(gzipped([]byte(plain)))
+		out, stats := decode(stacked, "gzip, zstd")
+		Expect(string(out)).To(Equal(plain))
+		Expect(stats.Truncated).To(BeFalse())
+	})
+
+	It("salvages a truncated gzip body and reports it", func() {
+		// Losing the 8-byte trailer (CRC32 + ISIZE) is what a capture cut
+		// off mid-flight looks like: every payload byte arrived and only
+		// the integrity footer is missing.
+		full := gzipped([]byte(plain))
+		out, stats := decode(full[:len(full)-8], "gzip")
+		Expect(string(out)).To(Equal(plain))
+		Expect(stats.Truncated).To(BeTrue())
+	})
+
+	It("salvages a truncated zstd body and reports it", func() {
+		body := make([]byte, 256<<10)
+		rng := rand.New(rand.NewSource(1))
+		for i := range body {
+			body[i] = byte(rng.Intn(26) + 'a')
+		}
+		full := zstdCompressed(body)
+		out, stats := decode(full[:len(full)-1], "zstd")
+		Expect(len(out)).To(BeNumerically(">", 0))
+		Expect(stats.Truncated).To(BeTrue())
+	})
+
+	It("refuses a corrupt body rather than salvaging nothing", func() {
+		// Salvage needs output to salvage. A body that decoded to zero
+		// bytes is a failure, not a partial success, or every corrupt
+		// capture would land as a silently empty turn.
+		for _, tc := range []struct{ body, enc string }{
+			{"\x28\xb5\x2f\xfd\xff", "zstd"},
+			{"\x1f\x8b\x08\xff\xff\xff", "gzip"},
+		} {
+			_, _, err := capture.DecodeContentEncoding([]byte(tc.body), tc.enc)
+			Expect(err).To(HaveOccurred(), "encoding %q", tc.enc)
+		}
+	})
+
+	It("names both the header and the offending token on an unknown encoding", func() {
+		_, _, err := capture.DecodeContentEncoding([]byte(plain), "gzip, brotli-experimental")
+		Expect(err).To(HaveOccurred())
+		// With a stacked header the token alone does not say which
+		// header produced it, and the header alone does not say which
+		// layer failed.
+		Expect(err.Error()).To(ContainSubstring("brotli-experimental"))
+		Expect(err.Error()).To(ContainSubstring("gzip, brotli-experimental"))
+	})
+
+	It("rejects a decompression bomb", func() {
+		_, _, err := capture.DecodeContentEncoding(
+			gzipped(make([]byte, capture.MaxDecompressedBytes+1)), "gzip")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("exceeds"))
+	})
+
+	It("accepts a body of exactly the cap", func() {
+		// The cap is inclusive; the reader takes one byte past it purely
+		// so that "at the limit" and "over it" are distinguishable
+		// without a second read.
+		out, _ := decode(gzipped(make([]byte, capture.MaxDecompressedBytes)), "gzip")
+		Expect(out).To(HaveLen(capture.MaxDecompressedBytes))
+	})
+})

--- a/pkg/storage/postgres/change_feed.go
+++ b/pkg/storage/postgres/change_feed.go
@@ -43,10 +43,20 @@ const (
 	// reduction. Re-derivation is bounded by what that adapter chose to keep.
 	FidelityReduced = "reduced"
 
-	// FidelityDegraded marks a row whose verbatim bytes arrived and were
-	// dropped for exceeding the ingest cap. Distinct from reduced: this is a
-	// capture path that sent the bytes and a limit that refused them, which is
-	// a tuning signal rather than a deployment fact.
+	// FidelityDegraded marks a row whose verbatim bytes existed and are gone:
+	// either they arrived and exceeded the ingest cap, or the producer
+	// captured them and withheld them to keep the envelope under the
+	// transport limit. Distinct from reduced: this is a capture path that
+	// HAD the bytes and a limit that took them, which is a tuning signal
+	// rather than a deployment fact.
+	//
+	// Both causes share this tier on purpose. Fidelity answers what can be
+	// re-derived from a row, and neither can — the reason a limit bit does
+	// not change the answer. Which limit bit is an operations question,
+	// answered by the ingest logs that record each cause separately; giving
+	// it a tier would put a distinction nobody re-derives differently into
+	// every rollup, and rollups take the worst tier, so the split would be
+	// lost at the trace level anyway.
 	FidelityDegraded = "degraded"
 )
 

--- a/pkg/storage/postgres/recover_reduction.go
+++ b/pkg/storage/postgres/recover_reduction.go
@@ -30,13 +30,9 @@ package postgres
 
 import (
 	"bytes"
-	"compress/gzip"
 	"context"
 	"encoding/json"
-	"fmt"
-	"io"
 	"log/slog"
-	"strings"
 
 	"github.com/papercomputeco/tapes/pkg/capture"
 	"github.com/papercomputeco/tapes/pkg/llm"
@@ -145,24 +141,14 @@ func reducedResponseUnusable(raw json.RawMessage) bool {
 // handing to a reducer. The column keeps the ENCODED bytes — re-compression is
 // not byte-identical, so "verbatim" has to mean verbatim — and only the
 // reduction sees the decoded form.
+//
+// It delegates to pkg/capture so recovery decodes exactly what ingest decodes.
+// A narrower decoder here would be the worst possible place for the gap: these
+// are precisely the rows whose reduction already failed once, so an encoding
+// recovery cannot read is an encoding no build ever recovers.
 func decodeStoredEncoding(body []byte, encoding string) ([]byte, error) {
-	switch strings.ToLower(strings.TrimSpace(encoding)) {
-	case "", "identity":
-		return body, nil
-	case "gzip", "x-gzip":
-		zr, err := gzip.NewReader(bytes.NewReader(body))
-		if err != nil {
-			return nil, fmt.Errorf("gzip reader: %w", err)
-		}
-		defer zr.Close()
-		out, err := io.ReadAll(zr)
-		if err != nil {
-			return nil, fmt.Errorf("gzip decode: %w", err)
-		}
-		return out, nil
-	default:
-		return nil, fmt.Errorf("unsupported content-encoding %q", encoding)
-	}
+	out, _, err := capture.DecodeContentEncoding(body, encoding)
+	return out, err
 }
 
 // contentTypeFromMeta pulls the capture adapter's recorded content type out of

--- a/pkg/storage/raw_turn.go
+++ b/pkg/storage/raw_turn.go
@@ -75,10 +75,16 @@ type RawTurnRecord struct {
 	// mean verbatim for the column to be worth having.
 	RawResponseEncoding string
 
-	// RawResponseDropped marks a turn whose raw response arrived but was
-	// too large to store. It is the difference between "this turn never had
-	// verbatim bytes" and "it did, and we chose not to keep them" — without
-	// it a fidelity gap is indistinguishable from an absence.
+	// RawResponseDropped marks a turn whose raw response existed and was not
+	// kept — because it arrived too large to store, or because the producer
+	// captured it and withheld it to fit the ingest transport limit. It is
+	// the difference between "this turn never had verbatim bytes" and "it
+	// did, and we chose not to keep them" — without it a fidelity gap is
+	// indistinguishable from an absence.
+	//
+	// True implies RawResponse is empty: the two say opposite things about
+	// the same bytes, so a row asserting both would be unreadable. Ingest
+	// enforces it on both paths.
 	RawResponseDropped bool
 
 	// Meta is the capture adapter's metadata block (model, stream,


### PR DESCRIPTION
related to PCC-1044

Items 3 and 4 of the ingest prerequisites for raw-only capture (items 1–2 shipped in #280 / v0.31.0).

**Item 3 — encoding parity with extproc.** Ingest's raw-only reduction handled a single identity-or-gzip layer while extproc (the producer) decodes zstd, stacked encodings, and salvages truncated gzip — an asymmetry extproc interlocks against, which made raw-only permanently unreachable for zstd traffic (all of Codex). A new shared decoder in `pkg/capture` mirrors extproc's rules exactly: right-to-left layer peeling per RFC 9110 §8.4, gzip/x-gzip/zstd, hard error on unknown encodings, 32 MiB per-layer cap, salvage on truncated streams that yielded output. Both ingest's raw-only lane and the storage layer's read-time reduction recovery (which carried a second, independently narrow copy of the gzip decoder) now call it. zstd via `klauspost/compress` — already an indirect dep and the same implementation extproc uses.

**Item 4 — producer-withheld marker.** A turn whose producer captured verbatim bytes but withheld them at the transport limit arrived indistinguishable from a producer that never captured raw at all. `TurnPayload` gains `raw_response_withheld`; ingest folds it into the existing `raw_response_dropped` column (the union of "producer withheld" and "ingest capped"), honored only when no bytes arrived so a marked row never also carries a `raw_response`. Absent means no claim — pre-existing producers are unaffected.

**Deployment ordering:** ingest must deploy before extproc starts relying on either half. The extproc-side follow-ups (widening `ingestCanDecodeEncoding`, relaxing the salvage interlock, setting the marker at its two withholding sites) are enumerated on PCC-1044 and intentionally not part of this PR — extproc's interlocks exist precisely to avoid sending bytes a live ingest cannot read.

Gates: full Dagger suite (54 packages, real Postgres), envelope-corpus parity gate, build/vet — all green. The corpus needed no update: it pins the header contract, and `TurnPayload` self-publishes through the compiled OpenAPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
