### PR TITLE
🔧 fix(extproc): derive the raw-lane interlock from the shared decoder

### DIFF
--- a/extproc/decode_test.go
+++ b/extproc/decode_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 
 	"github.com/klauspost/compress/zstd"
+
+	"github.com/papercomputeco/tapes/pkg/capture"
 )
 
 func gzipped(t *testing.T, body string) []byte {
@@ -155,7 +157,7 @@ func TestDecodeResponseBodySalvagesTruncatedGzip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("decode with stats: %v", err)
 	}
-	if !stats.truncated {
+	if !stats.Truncated {
 		t.Fatal("expected truncated decode stats")
 	}
 	if !strings.Contains(string(got), "message_stop") {
@@ -175,7 +177,7 @@ func TestDecodeZstdTruncationIsSalvagedOnlyForResponses(t *testing.T) {
 	if err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	if !stats.truncated {
+	if !stats.Truncated {
 		t.Fatal("expected truncated decode stats")
 	}
 	if !bytes.Equal(got, plain) {
@@ -203,12 +205,12 @@ func TestDecodeResponseBodyPreservesUnderlyingBytesOnPassthrough(t *testing.T) {
 
 func TestDecodeRejectsOversizedGzip(t *testing.T) {
 	// A decompression bomb: a tiny gzip payload that would expand past
-	// maxDecompressedBytes. Compressing maxDecompressedBytes+1 zero
+	// capture.MaxDecompressedBytes. Compressing capture.MaxDecompressedBytes+1 zero
 	// bytes produces ~32 KB of gzip, decoding to >32 MiB — the size cap
 	// must reject this with an error rather than letting ReadAll allocate.
 	var buf bytes.Buffer
 	w := gzip.NewWriter(&buf)
-	if _, err := w.Write(make([]byte, maxDecompressedBytes+1)); err != nil {
+	if _, err := w.Write(make([]byte, capture.MaxDecompressedBytes+1)); err != nil {
 		t.Fatalf("gzip write: %v", err)
 	}
 	if err := w.Close(); err != nil {
@@ -225,7 +227,7 @@ func TestDecodeRejectsOversizedGzip(t *testing.T) {
 }
 
 func TestDecodeRejectsOversizedZstd(t *testing.T) {
-	compressed := zstdCompressed(t, make([]byte, maxDecompressedBytes+1))
+	compressed := zstdCompressed(t, make([]byte, capture.MaxDecompressedBytes+1))
 
 	_, err := decodeRequestBody(compressed, "zstd")
 	if err == nil {

--- a/extproc/dispatcher.go
+++ b/extproc/dispatcher.go
@@ -201,6 +201,31 @@ type TurnEnvelope struct {
 	// without it the bytes are unreducible archive.
 	RawResponseEncoding string `json:"raw_response_encoding,omitempty"`
 
+	// RawResponseWithheld says this adapter captured verbatim bytes for the
+	// turn and chose not to send them — always because including them would
+	// have pushed the envelope past ingest's body limit, and a turn without
+	// its bytes beats no turn at all.
+	//
+	// Only the producer can know this. An envelope with no raw_response is
+	// otherwise the same envelope whether the bytes never existed or were
+	// dropped on the way out, and those are opposite operational facts: the
+	// first says which adapters are deployed, the second says a limit bit and
+	// wants tuning. Ingest folds this into raw_response_dropped; the field is
+	// spelled differently on purpose, because that column is the union of "the
+	// producer withheld" and "ingest capped" and this is only the first.
+	//
+	// It is set at exactly the two places bytes are withheld after being
+	// captured — the pre-dispatch transport-budget decision, and
+	// enforceBodyLimit's post-marshal strip — and nowhere else. In particular
+	// it is NOT set when the mode never asked for bytes: mode=off captured
+	// nothing to withhold, and marking those turns would report the whole
+	// fleet as losing bytes it never had.
+	//
+	// Invariant, relied on by ingest, which honors the marker only when no
+	// bytes arrived: withheld implies raw_response absent. Both writers below
+	// clear the bytes in the same breath as setting this.
+	RawResponseWithheld bool `json:"raw_response_withheld,omitempty"`
+
 	// No omitempty: it has no effect on a non-pointer struct, and meta is
 	// always sent.
 	Meta TurnMeta `json:"meta"`
@@ -214,7 +239,9 @@ type TurnEnvelope struct {
 	// There is deliberately no raw_response_dropped field. Ingest computes
 	// that marker itself from the bytes it actually received, and does not
 	// read one off the payload — a producer-supplied value would be
-	// unverifiable and could contradict what was stored.
+	// unverifiable and could contradict what was stored. RawResponseWithheld
+	// above is not a counterexample: it reports a decision made here, which
+	// ingest cannot observe, rather than an outcome ingest can see for itself.
 
 	// reducedFallback holds the adapter's reduction on a raw-only envelope
 	// so the transport backstop in Dispatch can restore it if the bytes
@@ -520,6 +547,10 @@ func (d *Dispatcher) enforceBodyLimit(env TurnEnvelope, payload []byte) ([]byte,
 	stripped := env
 	stripped.RawResponse = nil
 	stripped.RawResponseEncoding = ""
+	// Bytes existed and this process decided not to send them. Set in the
+	// same breath as clearing them so the two can never disagree — ingest
+	// honors the marker only on an envelope carrying no bytes.
+	stripped.RawResponseWithheld = true
 	if stripped.Response == nil {
 		// Raw-only: without the bytes there is no response at all, so the
 		// reduction has to come back or ingest rejects an empty turn.

--- a/extproc/processor.go
+++ b/extproc/processor.go
@@ -2,7 +2,6 @@ package extproc
 
 import (
 	"bytes"
-	"compress/gzip"
 	"context"
 	"crypto/rand"
 	"encoding/hex"
@@ -19,7 +18,6 @@ import (
 
 	processingmodev3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_proc/v3"
 	extprocv3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
-	"github.com/klauspost/compress/zstd"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -498,7 +496,7 @@ func (p *Processor) dispatchTurn(ctx context.Context, st *streamState) {
 			p.metrics.ObserveSSEChunks(st.provider, countSSEDataFrames(decodedResp))
 		}
 	}
-	if decodeStats.truncated {
+	if decodeStats.Truncated {
 		messageStopSeen := bytes.Contains(decodedResp, []byte("event: message_stop")) ||
 			bytes.Contains(decodedResp, []byte(`"type":"message_stop"`))
 		if p.metrics != nil {
@@ -593,7 +591,20 @@ func (p *Processor) dispatchTurn(ctx context.Context, st *streamState) {
 	// decodedResp — is what the raw lane carries: the column is meant to be
 	// byte-faithful to what the upstream actually sent, and st.contentEncoding
 	// is what lets ingest undo the compression on its own terms.
-	rawLane := decideRawLane(p.rawResponseMode, len(respBytes), len(reqBytes), st.contentEncoding, decodeStats.truncated)
+	//
+	// decodeErr is the raw-only interlock, and it is nil by the time control
+	// reaches here — a body this build could not decode dropped the turn
+	// above. That early return is what makes raw-only safe rather than
+	// hopeful: the decode that already succeeded on this exact
+	// (respBytes, st.contentEncoding) pair ran capture.DecodeContentEncoding,
+	// which is the function ingest will run on the same pair. The interlock is
+	// therefore a fact carried forward, not a guess about the receiver.
+	//
+	// It is passed rather than hardcoded true so the guard survives
+	// refactoring: a future path that attaches bytes it did not decode
+	// inherits the fallback instead of silently shipping unreducible bytes
+	// with no reduction beside them.
+	rawLane := decideRawLane(p.rawResponseMode, len(respBytes), len(reqBytes), decodeErr == nil)
 	p.recordRawLane(st, rawLane)
 
 	envelope := TurnEnvelope{
@@ -624,6 +635,16 @@ func (p *Processor) dispatchTurn(ctx context.Context, st *streamState) {
 	if rawLane.attachRaw {
 		envelope.RawResponse = respBytes
 		envelope.RawResponseEncoding = st.contentEncoding
+	}
+	if rawLane.skipReason != "" {
+		// We captured bytes for this turn and are not sending them. Say so:
+		// without the marker this envelope is indistinguishable from one
+		// produced by an adapter that never captured raw bytes at all, and
+		// ingest would read a lost capture as an absent feature.
+		//
+		// Keyed off skipReason rather than off mode, so the modes that never
+		// wanted bytes stay unmarked — they withheld nothing.
+		envelope.RawResponseWithheld = true
 	}
 	if rawLane.omitReduction {
 		// Raw-only: ingest reduces server-side with the shared reducers.
@@ -729,134 +750,61 @@ func buildSessionEnvelope(st *streamState) *DispatchedSessionEnvelope {
 	}
 }
 
+// Decoding a captured body's Content-Encoding is capture.DecodeContentEncoding
+// — the same function the receiving ingest runs on the bytes this adapter
+// ships. It used to be a second implementation here, byte-identical by
+// discipline rather than by construction, from the era when extproc built
+// against a published tapes module and could not name it.
+//
+// That mattered for more than tidiness. The raw-only lane interlocks on
+// whether ingest can decode what we send (see rawlane.go); with two decoders
+// the interlock could only ever be an assertion about a copy. With one, a turn
+// that decoded here has been decoded by ingest's decoder, on the exact bytes
+// and encoding the envelope carries.
+//
+// The request and response halves still differ, and that difference is the
+// reason these two wrappers exist rather than raw calls at each site: a
+// truncated response is salvaged, a truncated request is refused.
+
 // decodeRequestBody returns canonical request JSON for metadata parsing,
 // reducer input, and the ingest envelope. Pi 0.80.4+ compresses Codex
 // request bodies with zstd, so treating the wire bytes as json.RawMessage
 // causes the entire turn to fail during envelope marshaling.
+//
+// A salvaged request is refused where a salvaged response is kept: the
+// response is prose, and most of it still reads, while the request is JSON
+// the reducer and metadata parser both have to parse. A truncated one is not
+// partially useful, it is a syntax error.
 func decodeRequestBody(body []byte, contentEncoding string) ([]byte, error) {
-	decoded, stats, err := decodeBodyWithStats(body, contentEncoding)
+	decoded, stats, err := capture.DecodeContentEncoding(body, contentEncoding)
 	if err != nil {
 		return nil, err
 	}
-	if stats.truncated {
+	if stats.Truncated {
 		return nil, errors.New("truncated compressed request body")
 	}
 	return decoded, nil
 }
 
-// decodeResponseBody returns the bytes the reducer should parse, given
-// the captured Content-Encoding header. Identity, empty, or unset
-// encoding is a pass-through (zero-copy: the returned slice IS body).
-// gzip and zstd are decompressed from the fully buffered wire body before
-// reduction. The same bounded decoder is shared with compressed requests.
+// decodeResponseBody returns the bytes the reducer should parse, given the
+// captured Content-Encoding header. What is and is not decodable, how stacked
+// layers are peeled, and where the size cap sits are all
+// capture.DecodeContentEncoding's to state — restating them here is how the
+// two copies started drifting the first time.
 //
-// Unknown encodings return an error rather than passing through bytes
-// the reducer would mis-parse. The dispatchTurn caller turns that into
-// a DropResponseDecode so the operator sees a distinct reason rather
-// than a laundered "reducer_error".
-//
-// Multiple comma-separated encodings (e.g., "gzip, br") are accepted
-// only if every layer is one we know; the layers are peeled in reverse
-// order. This is rare in practice (an LLM upstream is unlikely to
-// stack encodings) but the right shape if it ever happens.
+// What is local: an error here becomes a DropResponseDecode in dispatchTurn,
+// so an encoding this build cannot read shows up in dashboards under its own
+// reason rather than laundered into "reducer_error".
 func decodeResponseBody(body []byte, contentEncoding string) ([]byte, error) {
-	decoded, _, err := decodeResponseBodyWithStats(body, contentEncoding)
+	decoded, _, err := capture.DecodeContentEncoding(body, contentEncoding)
 	return decoded, err
 }
 
-type decodeStats struct {
-	truncated bool
-}
-
-func decodeResponseBodyWithStats(body []byte, contentEncoding string) ([]byte, decodeStats, error) {
-	return decodeBodyWithStats(body, contentEncoding)
-}
-
-func decodeBodyWithStats(body []byte, contentEncoding string) ([]byte, decodeStats, error) {
-	ce := strings.TrimSpace(strings.ToLower(contentEncoding))
-	if ce == "" || ce == "identity" {
-		return body, decodeStats{}, nil
-	}
-	// Apply layers right-to-left per RFC 9110 §8.4.
-	layers := splitContentEncoding(ce)
-	current := body
-	var stats decodeStats
-	for i := len(layers) - 1; i >= 0; i-- {
-		decoded, layerStats, err := decodeOneLayer(current, layers[i])
-		if err != nil {
-			return nil, decodeStats{}, fmt.Errorf("content-encoding %q: %w", contentEncoding, err)
-		}
-		stats.truncated = stats.truncated || layerStats.truncated
-		current = decoded
-	}
-	return current, stats, nil
-}
-
-// splitContentEncoding parses a Content-Encoding header value into
-// individual encodings, dropping empty tokens and trimming whitespace.
-func splitContentEncoding(ce string) []string {
-	parts := strings.Split(ce, ",")
-	out := make([]string, 0, len(parts))
-	for _, p := range parts {
-		p = strings.TrimSpace(p)
-		if p == "" || p == "identity" {
-			continue
-		}
-		out = append(out, p)
-	}
-	return out
-}
-
-// maxDecompressedBytes caps one decompressed request or response body.
-// It bounds decompression bombs regardless of which Envoy route delivered
-// the body and sits well above the request/response sizes normally captured.
-const maxDecompressedBytes = 32 << 20 // 32 MiB
-
-func decodeOneLayer(body []byte, encoding string) ([]byte, decodeStats, error) {
-	switch encoding {
-	case "gzip", "x-gzip":
-		gz, err := gzip.NewReader(bytes.NewReader(body))
-		if err != nil {
-			return nil, decodeStats{}, fmt.Errorf("gzip reader init: %w", err)
-		}
-		defer gz.Close()
-		// Read one byte past the cap so we can detect overflow without
-		// ambiguity when the decoded body is exactly maxDecompressedBytes.
-		decoded, err := io.ReadAll(io.LimitReader(gz, maxDecompressedBytes+1))
-		if len(decoded) > maxDecompressedBytes {
-			return nil, decodeStats{}, fmt.Errorf("gzip decoded body exceeds %d bytes", maxDecompressedBytes)
-		}
-		if err != nil {
-			if errors.Is(err, io.ErrUnexpectedEOF) && len(decoded) > 0 {
-				return decoded, decodeStats{truncated: true}, nil
-			}
-			return nil, decodeStats{}, fmt.Errorf("gzip read: %w", err)
-		}
-		return decoded, decodeStats{}, nil
-	case "zstd":
-		zr, err := zstd.NewReader(
-			bytes.NewReader(body),
-			zstd.WithDecoderMaxMemory(maxDecompressedBytes),
-			zstd.WithDecoderMaxWindow(maxDecompressedBytes),
-		)
-		if err != nil {
-			return nil, decodeStats{}, fmt.Errorf("zstd reader init: %w", err)
-		}
-		defer zr.Close()
-		decoded, err := io.ReadAll(io.LimitReader(zr, maxDecompressedBytes+1))
-		if len(decoded) > maxDecompressedBytes {
-			return nil, decodeStats{}, fmt.Errorf("zstd decoded body exceeds %d bytes", maxDecompressedBytes)
-		}
-		if err != nil {
-			if errors.Is(err, io.ErrUnexpectedEOF) && len(decoded) > 0 {
-				return decoded, decodeStats{truncated: true}, nil
-			}
-			return nil, decodeStats{}, fmt.Errorf("zstd read: %w", err)
-		}
-		return decoded, decodeStats{}, nil
-	default:
-		return nil, decodeStats{}, fmt.Errorf("unsupported encoding %q", encoding)
-	}
+// decodeResponseBodyWithStats is decodeResponseBody plus the salvage report.
+// Callers that care whether the stream ended early — the truncation metric,
+// and nothing else — take this form.
+func decodeResponseBodyWithStats(body []byte, contentEncoding string) ([]byte, capture.DecodeStats, error) {
+	return capture.DecodeContentEncoding(body, contentEncoding)
 }
 
 // reducerEmptyReason classifies a reducer output that ingest's

--- a/extproc/rawlane.go
+++ b/extproc/rawlane.go
@@ -110,30 +110,33 @@ func rawResponseFits(rawLen, reqLen int) bool {
 	return base64Len(rawLen) <= budget
 }
 
-// ingestCanDecodeEncoding reports the encodings the raw-only interlock is
-// willing to ship without a reduction attached: empty, identity, gzip, x-gzip
-// — one layer only. Shipping bytes the server cannot decode with no reduction
-// attached would store the bytes and lose the turn's content, which is worse
-// than either half alone.
+// The raw-only interlock used to be a list of encoding names — empty,
+// identity, gzip, x-gzip, one layer — maintained here as extproc's belief
+// about what the far side could decode. A list is the wrong shape for that
+// question. It was accurate when written, went stale the moment ingest moved
+// onto capture.DecodeContentEncoding (zstd, stacked layers, salvage), and
+// nothing failed when it did: a stale list in this direction only over-sends,
+// so it could drift indefinitely while every test stayed green.
 //
-// This is deliberately narrower than what ingest can now decode. It described
-// ingest exactly when ingest handled a single identity-or-gzip layer; ingest
-// has since moved onto capture.DecodeContentEncoding, which handles zstd and
-// peels comma-stacked layers — extproc's own rules, adopted server-side.
+// What replaced it is not a better list, it is the absence of one. extproc and
+// ingest are one module and decode with one function, so the honest way to ask
+// "can the receiver decode these bytes?" is to notice that the receiver's
+// decoder has already decoded them: processor.dispatchTurn runs
+// capture.DecodeContentEncoding over the same (bytes, encoding) pair the
+// envelope carries, and drops the turn if it fails. decideRawLane is handed
+// that outcome. Two encodings cannot disagree when there is one decoder and
+// one execution of it.
 //
-// Widening the interlock to match is a behaviour change to what goes on the
-// wire for zstd traffic, so it is not made here. Until it is, this predicate
-// is a conservative floor: everything it admits, ingest can certainly decode.
-// The cost of being wrong in this direction is a needless dual-send, not a
-// lost turn.
-func ingestCanDecodeEncoding(contentEncoding string) bool {
-	switch strings.ToLower(strings.TrimSpace(contentEncoding)) {
-	case "", "identity", "gzip", "x-gzip":
-		return true
-	default:
-		return false
-	}
-}
+// DEPLOYMENT ORDERING. Widening this means raw-only now ships zstd and stacked
+// bodies, which the receiving ingest must be able to decode. Both binaries
+// build from this repo and land in the same release, but their pods roll
+// independently, so for a window a widened extproc can sit in front of an
+// older ingest. Under mode=dual that is harmless in either order — the
+// reduction always ships, so the bytes are a bonus. Under mode=raw it is not:
+// raw-only bytes a pre-zstd ingest cannot reduce store as unreducible archive.
+// mode=raw is enabled in no environment today and gates on the equivalence
+// proof, so this needs no machinery, only a rule: never switch an environment
+// to raw while its tapes image predates this change.
 
 // rawLaneDecision is the resolved shape of one envelope's response half.
 type rawLaneDecision struct {
@@ -157,7 +160,6 @@ const (
 	// allowed for.
 	rawSkipOversizeStripped = "oversize_stripped"
 	rawFallbackEncoding     = "encoding_not_decodable"
-	rawFallbackSalvaged     = "decode_salvaged"
 )
 
 // rawShapeDual and rawShapeRawOnly label the attached-bytes metric.
@@ -168,14 +170,25 @@ const (
 
 // decideRawLane resolves mode plus per-turn facts into the envelope shape.
 //
-// The interlocks all answer one question: would dropping our reduction leave
-// ingest unable to produce one? If yes, the turn degrades to dual rather than
-// raw-only — bytes are still captured, and the content still lands.
+// Both remaining interlocks answer one question: would dropping our reduction
+// leave ingest unable to produce one? If yes, the turn degrades to dual rather
+// than raw-only — bytes are still captured, and the content still lands.
 //
-//   - salvaged: extproc recovered content from a truncated gzip body that
-//     ingest's plain gzip.Reader + io.ReadAll would reject outright.
-//   - encoding: ingest cannot undo zstd or stacked encodings.
-func decideRawLane(mode RawResponseMode, rawLen, reqLen int, contentEncoding string, salvaged bool) rawLaneDecision {
+// ingestCanDecode is that question for the bytes themselves, and the caller
+// answers it by having already decoded them with ingest's decoder rather than
+// by inspecting the encoding name. On today's only call path it is therefore
+// always true, because a body that failed to decode never reaches dispatch.
+// The branch stays because "the caller decoded first" is a property of that
+// path, not of this function, and a future caller that attaches bytes it did
+// not decode should degrade to dual rather than ship unreducible archive.
+//
+// Salvage is deliberately NOT an interlock any more. It was one while ingest
+// decoded with a plain gzip.Reader that refused a stream ending early; ingest
+// now salvages on exactly extproc's rule — partial output plus
+// io.ErrUnexpectedEOF — and reduces the result rather than discarding it. A
+// truncated capture reduces to most of a turn on either side, so forcing dual
+// bought nothing and cost the bytes their raw-only path.
+func decideRawLane(mode RawResponseMode, rawLen, reqLen int, ingestCanDecode bool) rawLaneDecision {
 	if !mode.sendsRawBytes() {
 		return rawLaneDecision{}
 	}
@@ -188,13 +201,10 @@ func decideRawLane(mode RawResponseMode, rawLen, reqLen int, contentEncoding str
 	if mode != RawResponseRaw {
 		return d
 	}
-	switch {
-	case !ingestCanDecodeEncoding(contentEncoding):
+	if !ingestCanDecode {
 		d.fallbackReason = rawFallbackEncoding
-	case salvaged:
-		d.fallbackReason = rawFallbackSalvaged
-	default:
-		d.omitReduction = true
+		return d
 	}
+	d.omitReduction = true
 	return d
 }

--- a/extproc/rawlane_equivalence_test.go
+++ b/extproc/rawlane_equivalence_test.go
@@ -2,7 +2,6 @@ package extproc
 
 import (
 	"bytes"
-	"compress/gzip"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -10,7 +9,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -38,37 +36,18 @@ import (
 // state machine driven over the committed wire recordings, so the bytes under
 // test are the bytes the deployed path would actually send.
 
-// ingestDecodeContentEncoding decodes the way a server may assume it can for
-// bytes the raw-only interlock actually admits: identity and gzip, one layer,
-// no zstd and no stacked encodings.
+// There used to be a hand-written decoder here, narrower than both extproc's
+// and ingest's, standing in for "what the receiver can do with these bytes".
+// It was a reasonable stand-in while extproc shipped as its own module and the
+// interlock was a name list — reproducing the receiver mattered more than
+// reusing our own code, and using extproc's decoder would have hidden the very
+// asymmetry the interlock existed to handle.
 //
-// It is intentionally narrower than extproc's own decoder, because the point
-// is to reproduce what the receiver does with the bytes, not what we can.
-// Using extproc's decoder here would hide exactly the asymmetry the interlock
-// exists to handle. It is also narrower than ingest's decoder now is —
-// capture.DecodeContentEncoding handles zstd and stacked layers — but it
-// matches ingestCanDecodeEncoding, and that is the set these recordings ship
-// under. Calling the shared decoder here would prove equivalence over inputs
-// the interlock never lets through.
-func ingestDecodeContentEncoding(body []byte, encoding string) ([]byte, error) {
-	switch strings.ToLower(strings.TrimSpace(encoding)) {
-	case "", "identity":
-		return body, nil
-	case "gzip", "x-gzip":
-		zr, err := gzip.NewReader(bytes.NewReader(body))
-		if err != nil {
-			return nil, fmt.Errorf("gzip reader: %w", err)
-		}
-		defer zr.Close()
-		out, err := io.ReadAll(zr)
-		if err != nil {
-			return nil, fmt.Errorf("gzip decode: %w", err)
-		}
-		return out, nil
-	default:
-		return nil, fmt.Errorf("unsupported content-encoding %q", encoding)
-	}
-}
+// Neither premise survives. extproc and ingest are one module, and both decode
+// with capture.DecodeContentEncoding, so the receiver's decoder is nameable
+// here — and a third copy of the rules in a test proving equivalence is the
+// least defensible copy of all: it can pass while disagreeing with both sides
+// it claims to relate.
 
 // dualSendEnvelope is the parsed view of one dispatched envelope. Fields are
 // typed loosely so a missing key is visible rather than defaulted.
@@ -194,8 +173,8 @@ func TestDualSendReductionEquivalence(t *testing.T) {
 					env.RawResponseEncoding, b.meta.ContentEncoding)
 			}
 
-			// --- the server side, reproduced exactly ---
-			decoded, err := ingestDecodeContentEncoding(env.RawResponse, env.RawResponseEncoding)
+			// --- the server side, run rather than reproduced ---
+			decoded, _, err := capture.DecodeContentEncoding(env.RawResponse, env.RawResponseEncoding)
 			if err != nil {
 				t.Fatalf("ingest could not decode encoding=%q: %v — raw-only would store unreducible bytes",
 					env.RawResponseEncoding, err)

--- a/extproc/rawlane_test.go
+++ b/extproc/rawlane_test.go
@@ -16,6 +16,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/papercomputeco/tapes/ingest"
+	"github.com/papercomputeco/tapes/pkg/capture"
 	"github.com/papercomputeco/tapes/pkg/llm"
 )
 
@@ -245,63 +246,66 @@ var _ = Describe("Raw response lane", func() {
 
 	// The two size limits are ingest's own constants now, so there is
 	// nothing left here to pin: a change to either is a change to the
-	// single declaration both sides read. What still needs stating is the
-	// raw-only interlock's admission set, which is extproc's decision and
-	// deliberately narrower than what ingest can decode.
-	Describe("the raw-only interlock's admission set", func() {
-		It("admits single-layer identity and gzip, however they are spelled", func() {
-			for _, ce := range []string{"", "identity", "gzip", "x-gzip", "GZIP", " gzip "} {
-				Expect(ingestCanDecodeEncoding(ce)).To(BeTrue(), "encoding %q", ce)
+	// single declaration both sides read. The interlock went the same way —
+	// it used to be a list of encoding names extproc maintained as its belief
+	// about the far side, and is now the verdict of the one decoder both sides
+	// run. So there is no admission set to assert here either; what is worth
+	// pinning is the widening that follows, and the one branch that survives.
+	Describe("the raw-only interlock", func() {
+		It("admits every encoding the shared decoder decodes, including the ones the old name list refused", func() {
+			plain := []byte(anthropicTurnSSE)
+			for _, tc := range []struct {
+				encoding string
+				body     []byte
+			}{
+				{"", plain},
+				{"identity", plain},
+				{"gzip", gzipBytes(plain)},
+				{"x-gzip", gzipBytes(plain)},
+				{" GZIP ", gzipBytes(plain)},
+				// Below this line: refused by the old list, and
+				// decodable by ingest the whole time it was refused.
+				{"zstd", zstdBytes(plain)},
+				{"gzip, gzip", gzipBytes(gzipBytes(plain))},
+				{"identity, zstd", zstdBytes(plain)},
+			} {
+				decoded, _, err := capture.DecodeContentEncoding(tc.body, tc.encoding)
+				Expect(err).NotTo(HaveOccurred(), "encoding %q", tc.encoding)
+				Expect(decoded).To(Equal(plain), "encoding %q", tc.encoding)
 			}
 		})
 
-		It("withholds raw-only for encodings the interlock has not been widened to", func() {
-			// ingest decodes zstd and stacked layers since it moved onto
-			// capture.DecodeContentEncoding. The interlock has not been
-			// widened to match, so these still fall back to dual-send.
-			// Widening it changes what goes on the wire and is its own change.
-			for _, ce := range []string{"zstd", "br", "gzip, gzip"} {
-				Expect(ingestCanDecodeEncoding(ce)).To(BeFalse(), "encoding %q", ce)
-			}
+		It("keeps the reduction when the caller could not decode the bytes", func() {
+			// Unreachable from dispatchTurn, which drops a turn whose body
+			// failed to decode before the lane is consulted. Kept as the
+			// guard for any future caller that attaches bytes it did not
+			// decode: those must degrade to dual, not ship archive.
+			d := decideRawLane(RawResponseRaw, 1024, 512, false)
+			Expect(d.attachRaw).To(BeTrue())
+			Expect(d.omitReduction).To(BeFalse())
+			Expect(d.fallbackReason).To(Equal(rawFallbackEncoding))
 		})
 	})
 
 	Describe("the attach decision", func() {
 		It("attaches nothing when the mode is off", func() {
-			d := decideRawLane(RawResponseOff, 1024, 512, "", false)
+			d := decideRawLane(RawResponseOff, 1024, 512, true)
 			Expect(d.attachRaw).To(BeFalse())
 			Expect(d.omitReduction).To(BeFalse())
 			Expect(d.skipReason).To(BeEmpty())
 		})
 
 		It("attaches bytes and keeps the reduction in dual mode", func() {
-			d := decideRawLane(RawResponseDual, 1024, 512, "gzip", false)
+			d := decideRawLane(RawResponseDual, 1024, 512, true)
 			Expect(d.attachRaw).To(BeTrue())
 			Expect(d.omitReduction).To(BeFalse())
 		})
 
 		It("drops the reduction in raw mode", func() {
-			d := decideRawLane(RawResponseRaw, 1024, 512, "gzip", false)
+			d := decideRawLane(RawResponseRaw, 1024, 512, true)
 			Expect(d.attachRaw).To(BeTrue())
 			Expect(d.omitReduction).To(BeTrue())
 			Expect(d.fallbackReason).To(BeEmpty())
-		})
-
-		It("keeps the reduction when ingest could not decode the bytes", func() {
-			d := decideRawLane(RawResponseRaw, 1024, 512, "zstd", false)
-			Expect(d.attachRaw).To(BeTrue())
-			Expect(d.omitReduction).To(BeFalse())
-			Expect(d.fallbackReason).To(Equal(rawFallbackEncoding))
-		})
-
-		It("keeps the reduction when the content was salvaged from a truncated body", func() {
-			// extproc recovers content from a truncated gzip stream;
-			// ingest's plain gzip.Reader + io.ReadAll would error, so
-			// raw-only would lose the turn's content entirely.
-			d := decideRawLane(RawResponseRaw, 1024, 512, "gzip", true)
-			Expect(d.attachRaw).To(BeTrue())
-			Expect(d.omitReduction).To(BeFalse())
-			Expect(d.fallbackReason).To(Equal(rawFallbackSalvaged))
 		})
 
 		Context("around the caps", func() {
@@ -309,13 +313,13 @@ var _ = Describe("Raw response lane", func() {
 				// This is the deliberate one. Pre-dropping here would
 				// make raw_response_dropped unreachable and the row
 				// indistinguishable from a producer that never captured.
-				d := decideRawLane(RawResponseDual, ingest.MaxRawResponseBytes+1, 1024, "", false)
+				d := decideRawLane(RawResponseDual, ingest.MaxRawResponseBytes+1, 1024, true)
 				Expect(d.attachRaw).To(BeTrue())
 				Expect(d.skipReason).To(BeEmpty())
 			})
 
 			It("withholds bytes that would not survive the transport", func() {
-				d := decideRawLane(RawResponseDual, ingest.MaxIngestBodyBytes, 1024, "", false)
+				d := decideRawLane(RawResponseDual, ingest.MaxIngestBodyBytes, 1024, true)
 				Expect(d.attachRaw).To(BeFalse())
 				Expect(d.skipReason).To(Equal(rawSkipTransportBudget))
 			})
@@ -323,7 +327,7 @@ var _ = Describe("Raw response lane", func() {
 			It("never goes raw-only when the bytes were withheld", func() {
 				// Raw-only without bytes is a turn with no response at
 				// all — strictly worse than the historical shape.
-				d := decideRawLane(RawResponseRaw, ingest.MaxIngestBodyBytes, 1024, "", false)
+				d := decideRawLane(RawResponseRaw, ingest.MaxIngestBodyBytes, 1024, true)
 				Expect(d.attachRaw).To(BeFalse())
 				Expect(d.omitReduction).To(BeFalse())
 			})
@@ -396,17 +400,65 @@ var _ = Describe("Raw response lane", func() {
 			Expect(envelope).NotTo(HaveKey("raw_response_dropped"))
 		})
 
-		It("falls back to dual when ingest could not decode the encoding", func() {
+		// Codex traffic is zstd, so while the interlock was a name list
+		// that admitted only identity and gzip, raw-only was unreachable
+		// for an entire harness by construction — silently, since a
+		// dual-send looks exactly like a working deployment.
+		It("ships zstd raw-only now that the interlock asks the shared decoder", func() {
 			in := anthropicTurn()
 			in.respBody = zstdBytes([]byte(anthropicTurnSSE))
 			in.contentEncoding = "zstd"
 
 			envelope, proc := runTurn(RawResponseRaw, in)
 
-			Expect(envelope).To(HaveKey("raw_response"))
-			Expect(envelope["response"]).NotTo(MatchJSON("null"))
-			Expect(scrapeProcessorMetrics(proc)).To(ContainSubstring(
-				`tapes_extproc_raw_response_fallback_total{provider="anthropic",reason="encoding_not_decodable"} 1`))
+			var raw []byte
+			Expect(json.Unmarshal(envelope["raw_response"], &raw)).To(Succeed())
+			Expect(raw).To(Equal(in.respBody))
+			Expect(envelope["response"]).To(MatchJSON("null"))
+
+			metrics := scrapeProcessorMetrics(proc)
+			Expect(metrics).To(ContainSubstring(
+				`tapes_extproc_raw_response_attached_total{provider="anthropic",shape="raw_only"} 1`))
+			Expect(metrics).NotTo(ContainSubstring("tapes_extproc_raw_response_fallback_total"))
+		})
+
+		It("ships stacked encodings raw-only", func() {
+			in := anthropicTurn()
+			in.respBody = gzipBytes(gzipBytes([]byte(anthropicTurnSSE)))
+			in.contentEncoding = "gzip, gzip"
+
+			envelope, _ := runTurn(RawResponseRaw, in)
+
+			var raw []byte
+			Expect(json.Unmarshal(envelope["raw_response"], &raw)).To(Succeed())
+			Expect(raw).To(Equal(in.respBody))
+			Expect(envelope["response"]).To(MatchJSON("null"))
+		})
+
+		// Salvage used to force a dual-send, on the belief that ingest's
+		// plain gzip.Reader would refuse a stream that ended early. Ingest
+		// salvages on extproc's own rule now and reduces what it recovered,
+		// so the fallback bought nothing.
+		It("ships a salvaged truncated body raw-only", func() {
+			gz := gzipBytes([]byte(anthropicTurnSSE))
+			in := anthropicTurn()
+			// Drop the 8-byte gzip trailer: every data byte survives, but
+			// the stream ends early, which is what trips the salvage path.
+			in.respBody = gz[:len(gz)-8]
+			in.contentEncoding = "gzip"
+
+			envelope, proc := runTurn(RawResponseRaw, in)
+
+			var raw []byte
+			Expect(json.Unmarshal(envelope["raw_response"], &raw)).To(Succeed())
+			Expect(raw).To(Equal(in.respBody))
+			Expect(envelope["response"]).To(MatchJSON("null"))
+
+			metrics := scrapeProcessorMetrics(proc)
+			// The salvage still happened and is still metered — what
+			// changed is that it no longer forces the reduction along.
+			Expect(metrics).To(ContainSubstring("tapes_extproc_response_decode_salvaged_total"))
+			Expect(metrics).NotTo(ContainSubstring("tapes_extproc_raw_response_fallback_total"))
 		})
 
 		It("meters the shape it dispatched", func() {
@@ -462,6 +514,82 @@ var _ = Describe("Raw response lane", func() {
 		})
 	})
 
+	// The producer half of the withheld contract. Ingest cannot see the
+	// difference between "this adapter captured nothing" and "this adapter
+	// captured and could not send it" — both arrive with no raw_response —
+	// so the fact has to ride the envelope or it is lost.
+	Describe("the withheld marker", func() {
+		It("marks a turn whose bytes lost the transport budget", func() {
+			in := anthropicTurn()
+			in.respBody = oversizeAnthropicSSE(ingest.MaxIngestBodyBytes + (1 << 20))
+
+			envelope, _ := runTurn(RawResponseDual, in)
+
+			Expect(envelope["raw_response_withheld"]).To(MatchJSON("true"))
+			// The invariant ingest relies on: the marker is honored only
+			// on an envelope carrying no bytes.
+			Expect(envelope).NotTo(HaveKey("raw_response"))
+		})
+
+		It("marks a turn the post-marshal backstop stripped", func() {
+			in := anthropicTurn()
+			// Passes the pre-dispatch estimate, exceeds the real limit
+			// once marshalled — see the transport-backstop suite.
+			in.respBody = manyDeltaAnthropicSSE(8<<20, 64<<10)
+
+			envelope, _ := runTurn(RawResponseDual, in)
+
+			Expect(envelope["raw_response_withheld"]).To(MatchJSON("true"))
+			Expect(envelope).NotTo(HaveKey("raw_response"))
+		})
+
+		It("leaves the key off a turn that shipped its bytes", func() {
+			envelope, _ := runTurn(RawResponseDual, anthropicTurn())
+
+			Expect(envelope).To(HaveKey("raw_response"))
+			// omitempty: absent means "no claim", which is what every
+			// producer built before the field says.
+			Expect(envelope).NotTo(HaveKey("raw_response_withheld"))
+		})
+
+		It("leaves the key off when the mode never asked for bytes", func() {
+			// mode=off captured nothing to withhold. Marking these would
+			// report the whole fleet as losing bytes it never had.
+			envelope, _ := runTurn(RawResponseOff, anthropicTurn())
+
+			Expect(envelope).NotTo(HaveKey("raw_response"))
+			Expect(envelope).NotTo(HaveKey("raw_response_withheld"))
+		})
+
+		// The field is declared twice — here and on ingest.TurnPayload —
+		// because the two structs are different shapes, so the tag is the
+		// only thing holding them together. Marshal one, parse the other:
+		// a renamed tag fails here rather than in a fidelity report.
+		It("parses onto ingest's TurnPayload under the name ingest reads", func() {
+			d := NewDispatcher("http://example.invalid", 1, nil)
+
+			env := TurnEnvelope{
+				Provider:            "anthropic",
+				Request:             json.RawMessage(`{}`),
+				Response:            reducedStub(),
+				RawResponse:         bytes.Repeat([]byte("x"), ingest.MaxIngestBodyBytes),
+				RawResponseEncoding: "identity",
+			}
+			payload, err := json.Marshal(env)
+			Expect(err).NotTo(HaveOccurred())
+
+			out, _ := d.enforceBodyLimit(env, payload)
+
+			var turn ingest.TurnPayload
+			Expect(json.Unmarshal(out, &turn)).To(Succeed())
+			Expect(turn.RawResponseWithheld).To(BeTrue())
+			// dropped ⟹ raw_response empty: ingest honors the marker
+			// only when no bytes arrived, so a producer that sent both
+			// would have its claim ignored.
+			Expect(turn.RawResponse).To(BeEmpty())
+		})
+	})
+
 	Describe("the transport backstop", func() {
 		It("counts a stripped turn as skipped, never as attached", func() {
 			in := anthropicTurn()
@@ -509,6 +637,9 @@ var _ = Describe("Raw response lane", func() {
 			Expect(stripped.RawResponseEncoding).To(BeEmpty())
 			// The reduction survives: the turn still lands.
 			Expect(stripped.Response).NotTo(BeNil())
+			// …and the bytes that existed are recorded as withheld
+			// rather than as never captured.
+			Expect(stripped.RawResponseWithheld).To(BeTrue())
 		})
 
 		It("restores the reduction when it strips a raw-only envelope", func() {
@@ -530,6 +661,7 @@ var _ = Describe("Raw response lane", func() {
 			// Without this the turn would carry no response at all and
 			// ingest would reject it.
 			Expect(stripped.Response).To(Equal(reduced))
+			Expect(stripped.RawResponseWithheld).To(BeTrue())
 		})
 
 		It("leaves an envelope under the limit untouched", func() {


### PR DESCRIPTION
fixes PCC-1044

The extproc half of the raw-only prerequisites — the last open scope on the issue.

**The interlock now answers by execution, not prediction.** extproc carried a name-list belief about what ingest could decode (`ingestCanDecodeEncoding`: identity/gzip only), written when ingest's raw path genuinely was that narrow. Ingest has since adopted extproc's own decoding rules via the shared `capture.DecodeContentEncoding` — so the list, and a third full copy of the decoder that extproc still carried (`decodeBodyWithStats` + friends, byte-equivalent by discipline rather than construction), are both gone. extproc decodes the exact `(bytes, encoding)` pair the envelope ships using the shared decoder; a successful decode *is* the proof the receiver can decode too. zstd, stacked encodings, and salvaged truncated bodies now ship raw-only; the salvage-forces-dual interlock is deleted (ingest salvages on the identical rule and reduces the result).

**The producer-withheld marker ships.** `raw_response_withheld` is set at both withholding sites — the pre-dispatch transport-budget skip and the post-marshal oversize backstop — preserving ingest's `dropped ⟹ raw_response empty` invariant. The field is re-declared on extproc's envelope (the structs aren't embeddable), with a round-trip test that marshals extproc's envelope and parses it onto ingest's real `TurnPayload`, so a renamed tag fails a test rather than a fidelity report.

**Deployment ordering** (also in a comment at the interlock): under `mode=dual`, roll order is harmless — the reduction always ships. Under `mode=raw`, a widened extproc in front of a pre-zstd ingest could store unreducible bytes; `raw` is enabled nowhere and gates on the PCC-1088 equivalence proof, so the rule is simply: never flip an environment to `raw` while its tapes image predates this release. No enforcement machinery.

Both behavior groups were mutation-tested (removing the marker assignments fails exactly the withheld specs; forcing the interlock closed fails exactly the raw-only shipping specs).

Gates: `make test-extproc`, `make parity`, full `make test` (57 packages), `check-lint` 0 issues, build/vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
