### PR TITLE
✨ feat(cli): prove raw-response equivalence before ratcheting capture

### DIFF
--- a/cmd/tapes/raw/equivalence.go
+++ b/cmd/tapes/raw/equivalence.go
@@ -1,0 +1,333 @@
+package rawcmder
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/spf13/cobra"
+
+	"github.com/papercomputeco/tapes/pkg/config"
+	"github.com/papercomputeco/tapes/pkg/rawequiv"
+	"github.com/papercomputeco/tapes/pkg/storage"
+)
+
+type equivalenceCommander struct {
+	flags config.FlagSet
+
+	postgresDSN string
+	since       string
+	limit       int
+	session     string
+	jsonOut     bool
+	maxDiffs    int
+	maxReport   int
+}
+
+var equivalenceFlags = config.FlagSet{
+	config.FlagPostgres: {
+		Name:        "postgres",
+		ViperKey:    "storage.postgres_dsn",
+		Description: "PostgreSQL connection string (e.g., postgres://user:pass@host:5432/db)",
+	},
+}
+
+const equivalenceLongDesc string = `Prove that stored capture bytes re-reduce to the stored reduction.
+
+Capture is moving through a ratchet: off (the adapter ships only its
+reduction) -> dual (it ships the reduction AND the verbatim upstream
+bytes) -> raw (it ships only bytes and tapes reduces server-side). The
+end state is the goal, because one reducer for every capture path is the
+only thing that makes two paths incapable of reducing differently.
+
+Dual is where that gets proven. Every dual row carries both halves of the
+same turn, so this command can decode the stored bytes, re-reduce them
+through the exact path mode=raw would run, and compare the result against
+the reduction the adapter stored beside them — over real traffic, without
+changing anything an operator sees.
+
+Two fields are excluded from the comparison because neither can survive
+moving the reduction off the capture host: created_at, which reducers
+stamp at reduction time, and usage.total_duration_ns, the wall clock only
+the party that watched the stream can measure. Everything else is
+compared strictly. The report prints both exclusions and, separately,
+which capture-side stamps mode=raw would have been able to restore --
+a window can be perfectly equivalent and still lose durations on the
+flip, and those are different questions.
+
+Exits non-zero if any row diverged or failed to reduce, so it can gate a
+ratchet step in CI.
+
+The comparison is read-only and never prints response content: a
+difference is reported as a JSON path plus the shape of what differs.
+
+Run it against a tenant's database from inside the cluster:
+
+  kubectl exec -n <tenant-ns> deploy/tapes-api -- \
+    tapes raw equivalence --since 24h --limit 5000
+
+or locally against a forwarded database:
+
+  tapes raw equivalence \
+    --postgres "postgres://user:pass@127.0.0.1:15432/tapes" \
+    --since 24h --json`
+
+func newEquivalenceCmd() *cobra.Command {
+	cmder := &equivalenceCommander{flags: equivalenceFlags}
+
+	cmd := &cobra.Command{
+		Use:   "equivalence",
+		Short: "Compare stored reductions against a re-reduction of the stored bytes",
+		Long:  equivalenceLongDesc,
+		Args:  cobra.NoArgs,
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
+			configDir, _ := cmd.Flags().GetString("config-dir")
+			v, err := config.InitViper(configDir)
+			if err != nil {
+				return fmt.Errorf("loading config: %w", err)
+			}
+			config.BindRegisteredFlags(v, cmd, cmder.flags, []string{config.FlagPostgres})
+			cmder.postgresDSN = v.GetString("storage.postgres_dsn")
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cmd.SilenceUsage = true
+			return cmder.run(cmd)
+		},
+	}
+
+	config.AddStringFlag(cmd, cmder.flags, config.FlagPostgres, &cmder.postgresDSN)
+	cmd.Flags().StringVar(&cmder.since, "since", "24h",
+		"Only turns received within this window (duration like 24h, or an RFC 3339 instant)")
+	cmd.Flags().IntVar(&cmder.limit, "limit", 1000,
+		"Maximum turns to examine, newest first")
+	cmd.Flags().StringVar(&cmder.session, "session", "",
+		"Restrict to one harness session id")
+	cmd.Flags().BoolVar(&cmder.jsonOut, "json", false,
+		"Emit the report as JSON")
+	cmd.Flags().IntVar(&cmder.maxDiffs, "max-diffs", rawequiv.DefaultMaxDiffs,
+		"Maximum differences recorded per divergent turn")
+	cmd.Flags().IntVar(&cmder.maxReport, "max-report", 20,
+		"Maximum blocking turns detailed in the report (counts stay exact)")
+	return cmd
+}
+
+// ErrDivergence is returned when the window contained rows that would not
+// survive the flip to mode=raw. It carries no detail of its own: the report is
+// already on stdout, and this exists to make the process exit non-zero.
+var ErrDivergence = errors.New("raw-response equivalence failed")
+
+func (c *equivalenceCommander) run(cmd *cobra.Command) error {
+	if c.postgresDSN == "" {
+		return errors.New("equivalence requires a postgres DSN (--postgres or storage.postgres_dsn)")
+	}
+	since, err := parseSince(c.since)
+	if err != nil {
+		return err
+	}
+
+	ctx := cmd.Context()
+	pool, err := openReadOnly(ctx, c.postgresDSN)
+	if err != nil {
+		return err
+	}
+	defer pool.Close()
+
+	report := rawequiv.NewReport(rawequiv.Window{
+		Since:   c.since,
+		Limit:   c.limit,
+		Session: c.session,
+	}, c.maxReport)
+
+	opts := rawequiv.Options{MaxDiffs: c.maxDiffs}
+	err = scanWireTurns(ctx, pool, since, c.limit, c.session, func(row rawequiv.Row) {
+		report.Add(rawequiv.Check(ctx, row, opts))
+	})
+	if err != nil {
+		return err
+	}
+
+	if err := writeReport(cmd.OutOrStdout(), report, c.jsonOut); err != nil {
+		return err
+	}
+	if n := report.Blocking(); n > 0 {
+		return fmt.Errorf("%w: %d of %d turn(s) would not survive mode=raw",
+			ErrDivergence, n, report.Total)
+	}
+	return nil
+}
+
+func writeReport(w io.Writer, report *rawequiv.Report, asJSON bool) error {
+	if !asJSON {
+		report.WriteText(w)
+		return nil
+	}
+	out, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal report: %w", err)
+	}
+	_, err = fmt.Fprintln(w, string(out))
+	return err
+}
+
+// parseSince accepts either a duration back from now or an absolute RFC 3339
+// instant. Operators reach for both: "the last day" while iterating, and a
+// fixed instant when re-running the same window after a change.
+func parseSince(s string) (time.Time, error) {
+	if s == "" {
+		return time.Time{}, nil
+	}
+	if d, err := time.ParseDuration(s); err == nil {
+		if d < 0 {
+			d = -d
+		}
+		return time.Now().Add(-d), nil
+	}
+	ts, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return time.Time{}, fmt.Errorf(
+			"--since %q is neither a duration (24h) nor an RFC 3339 instant", s)
+	}
+	return ts, nil
+}
+
+// openReadOnly opens a connection pool that performs no schema work.
+//
+// It deliberately does not use postgres.NewDriver or postgres.Open: both run
+// golang-migrate before returning the pool, so opening a database through them
+// is a DDL write. This command is a diagnostic an operator points at a live
+// tenant database — frequently one belonging to a deployment running a
+// different build — and having it migrate that schema as a side effect of
+// being run would be a genuinely dangerous surprise. Every statement issued
+// from here is a SELECT.
+func openReadOnly(ctx context.Context, dsn string) (*pgxpool.Pool, error) {
+	cfg, err := pgxpool.ParseConfig(dsn)
+	if err != nil {
+		return nil, fmt.Errorf("parse postgres dsn: %w", err)
+	}
+	// One connection: this is a single sequential scan, and a diagnostic has
+	// no business consuming a tenant database's connection budget.
+	cfg.MaxConns = 1
+	cfg.ConnConfig.RuntimeParams["default_transaction_read_only"] = "on"
+
+	pool, err := pgxpool.NewWithConfig(ctx, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("connect to postgres: %w", err)
+	}
+	if err := pool.Ping(ctx); err != nil {
+		pool.Close()
+		return nil, fmt.Errorf("ping postgres: %w", err)
+	}
+	return pool, nil
+}
+
+// wireTurnQuery selects the columns a re-reduction needs, newest first.
+//
+// It is written here rather than added to the sqlc query set on purpose. The
+// generated layer serves the deriver and the API, whose reads are hot and
+// shaped by the projection; this is a one-off diagnostic scan with its own
+// window and filters, and adding it to the shared surface would put a
+// diagnostic's shape into every build of the storage package. The SQL is
+// static and every caller value is a bound parameter.
+//
+// Attribution corrections are deliberately NOT joined. They repair which
+// session a turn belongs to; they do not touch the bytes, the reduction, or
+// the capture meta, which is everything the comparison reads. Joining them
+// would add cost to answer a question this command does not ask.
+//
+// source = 'wire' is the population under test. Transcript turns are uploaded
+// from a harness's own on-disk log, have no upstream bytes, and are not
+// affected by the capture mode at all.
+const wireTurnQuery = `
+SELECT id,
+       request_id,
+       provider,
+       harness_id,
+       harness_session_id,
+       COALESCE(meta ->> 'model', '') AS model,
+       COALESCE(raw_response, ''::bytea) AS raw_response,
+       raw_response_encoding,
+       raw_response_dropped,
+       response,
+       meta
+FROM raw_turns
+WHERE source = @wire::text
+  AND (@since::timestamptz IS NULL OR received_at >= @since::timestamptz)
+  AND (@session::text = '' OR harness_session_id = @session::text)
+ORDER BY received_at DESC, id DESC
+LIMIT @lim`
+
+// scanWireTurns streams the window through visit.
+//
+// Rows are streamed rather than collected because a raw_response is up to
+// 8 MiB and a window is thousands of turns: materializing the window would
+// cost gigabytes to answer a question that only ever looks at one row at a
+// time.
+func scanWireTurns(
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	since time.Time,
+	limit int,
+	session string,
+	visit func(rawequiv.Row),
+) error {
+	if limit <= 0 {
+		limit = 1000
+	}
+
+	args := pgx.NamedArgs{
+		"lim":     limit,
+		"session": session,
+		"wire":    storage.RawTurnSourceWire,
+	}
+	if since.IsZero() {
+		args["since"] = nil
+	} else {
+		args["since"] = since
+	}
+
+	rows, err := pool.Query(ctx, wireTurnQuery, args)
+	if err != nil {
+		return fmt.Errorf("query raw_turns: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var (
+			row      rawequiv.Row
+			response []byte
+			meta     []byte
+		)
+		if err := rows.Scan(
+			&row.ID,
+			&row.RequestID,
+			&row.Provider,
+			&row.HarnessID,
+			&row.HarnessSessionID,
+			&row.Model,
+			&row.RawResponse,
+			&row.RawResponseEncoding,
+			&row.RawResponseDropped,
+			&response,
+			&meta,
+		); err != nil {
+			return fmt.Errorf("scan raw_turn: %w", err)
+		}
+
+		row.StoredReduction = response
+		if len(meta) > 0 {
+			// A meta block this build cannot parse is not a reason to fail
+			// the scan: the fields the comparison needs are the long-standing
+			// ones, and an unknown extension elsewhere in the block is
+			// exactly what the raw layer is designed to tolerate.
+			_ = json.Unmarshal(meta, &row.Meta)
+		}
+		visit(row)
+	}
+	return rows.Err()
+}

--- a/cmd/tapes/raw/raw.go
+++ b/cmd/tapes/raw/raw.go
@@ -1,0 +1,28 @@
+// Package rawcmder holds the operator tooling for the verbatim-capture layer.
+package rawcmder
+
+import (
+	"github.com/spf13/cobra"
+)
+
+const rawLongDesc string = `Operate on the verbatim response bytes captured alongside each turn.
+
+raw_turns stores two views of the same upstream response: raw_response,
+the bytes exactly as they arrived, and response, the reduced turn a
+capture adapter produced from them. The reduction is lossy and, until
+every capture path shares one reducer, adapter-specific.
+
+The commands here inspect that relationship. They read; nothing under
+this group writes to the database.`
+
+// NewRawCmd builds the `tapes raw` command group.
+func NewRawCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "raw",
+		Short: "Inspect the verbatim capture layer",
+		Long:  rawLongDesc,
+	}
+
+	cmd.AddCommand(newEquivalenceCmd())
+	return cmd
+}

--- a/cmd/tapes/tapes.go
+++ b/cmd/tapes/tapes.go
@@ -15,6 +15,7 @@ import (
 	devcmder "github.com/papercomputeco/tapes/cmd/tapes/dev"
 	initcmder "github.com/papercomputeco/tapes/cmd/tapes/init"
 	localcmder "github.com/papercomputeco/tapes/cmd/tapes/local"
+	rawcmder "github.com/papercomputeco/tapes/cmd/tapes/raw"
 	servecmder "github.com/papercomputeco/tapes/cmd/tapes/serve"
 	statuscmder "github.com/papercomputeco/tapes/cmd/tapes/status"
 	versioncmder "github.com/papercomputeco/tapes/cmd/tapes/version"
@@ -118,6 +119,7 @@ func NewTapesCmd() *cobra.Command {
 	cmd.AddCommand(backfillcmder.NewBackfillCmd())
 	cmd.AddCommand(initcmder.NewInitCmd())
 	cmd.AddCommand(localcmder.NewLocalCmd())
+	cmd.AddCommand(rawcmder.NewRawCmd())
 	cmd.AddCommand(servecmder.NewServeCmd())
 	cmd.AddCommand(statuscmder.NewStatusCmd())
 	cmd.AddCommand(versioncmder.NewVersionCmd())

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -27,6 +27,8 @@ The transparent proxy supports Anthropic, OpenAI, and Ollama traffic. It forward
 
 Capture is append-only. Replayed turns deduplicate by capture identity instead of rewriting prior capture.
 
+A captured turn is stored twice over: `raw_response` holds the upstream bytes verbatim, and `response` holds the reduced turn an adapter produced from them. Keeping the bytes is what makes the reduction reproducible and auditable rather than authoritative — a future data-model change becomes a re-derive over existing rows instead of a re-capture. Reducing server-side from those bytes is the end state, reached through a proven ratchet: see [Proving the capture ratchet](./cli.md#proving-the-capture-ratchet).
+
 ## Derivation: sessions, traces, and spans
 
 The deriver projects raw turns into the read model:

--- a/docs/src/cli.md
+++ b/docs/src/cli.md
@@ -12,6 +12,7 @@ Run `tapes <command> --help` for the complete, version-matched flag list.
 | `tapes status` | Show active config, provider/upstream, API reachability, and capture summary. |
 | `tapes auth` | Store OpenAI or Anthropic credentials in `.tapes/credentials.toml`. |
 | `tapes config get|set|list` | Manage persistent scalar settings. |
+| `tapes raw equivalence` | Prove stored capture bytes re-reduce to the stored reduction. See [Proving the capture ratchet](#proving-the-capture-ratchet). |
 | `tapes version` | Print version information. |
 
 ## Running services
@@ -59,6 +60,56 @@ tapesctl skill sync <name> --claude
 ```
 
 Every `tapesctl` command takes `--tapes-url`, falling back to `TAPES_URL`. Arguments after `--` go directly to the agent. See [Agent integrations](./integrations.md) and the [`tapesctl` README](https://github.com/papercomputeco/tapesctl) for the full surface.
+
+## Proving the capture ratchet
+
+`raw_turns` keeps two views of the same upstream response: `raw_response`, the bytes exactly as they arrived, and `response`, the reduced turn a capture adapter produced from them. The reduction is lossy, and while a second reducer runs inside the capture adapter, two capture paths can reduce the same traffic differently.
+
+The fix is to have exactly one reducer, server-side. Getting there is a deliberate three-step ratchet, configured on the capture adapter:
+
+| Mode | What the adapter sends | Stored fidelity |
+| --- | --- | --- |
+| `off` | its reduction only | `reduced` |
+| `dual` | its reduction **and** the verbatim bytes | `raw` |
+| `raw` | verbatim bytes only; tapes reduces | `raw` |
+
+`dual` exists to make the middle step provable. It changes nothing an operator sees — ingest keeps the adapter's reduction — while putting the bytes in the database next to it. That makes the question "would `raw` have produced this same row?" answerable offline, over real traffic:
+
+```bash
+tapes raw equivalence --since 24h --limit 5000
+```
+
+For each wire turn in the window that has both halves, the command decodes the stored bytes, re-reduces them through the same server-side path `raw` would run, and compares the result against the stored reduction. It exits non-zero if anything diverged or failed to reduce, so it can gate the step in CI.
+
+Run it inside the cluster against a tenant's database:
+
+```bash
+kubectl exec -n <tenant-ns> deploy/tapes-api -- \
+  tapes raw equivalence --since 24h --limit 5000
+```
+
+or locally against a forwarded database, with `--json` for machine consumption:
+
+```bash
+tapes raw equivalence \
+  --postgres "postgres://user:pass@127.0.0.1:15432/tapes" \
+  --since 24h --json
+```
+
+The comparison is read-only, and it never prints response content — a difference is reported as a JSON path plus the shape of what differs, because these are real prompts.
+
+### Reading the result
+
+Every examined turn lands in exactly one class. `equivalent` is the one that supports a ratchet step. `divergent`, `undecodable`, `unreducible` and `no_reducer` all block it: the last three are worse than a divergence, because under `raw` those rows would carry no reduction at all. The `skipped_*` classes describe turns the flip does not affect — no bytes were captured, the bytes were withheld or dropped over a limit, or the turn was already captured raw-only.
+
+Two fields are excluded from the comparison, and the report always prints them:
+
+- **`created_at`** — reducers stamp it at reduction time, so two reductions of identical bytes taken at different instants differ by construction.
+- **`usage.total_duration_ns`** — the wall clock from request to fully-assembled response. Only the party that watched the stream can measure it; a reduction of stored bytes cannot.
+
+Everything else is compared strictly, so a third difference is reported rather than absorbed.
+
+Because both excluded fields are ones `raw` restores from the capture adapter's `meta` block rather than from the bytes, the report also counts which stamps would actually have been available. **A window can be perfectly equivalent and still lose data on the flip**: if `usage.total_duration_ns` shows `fallback`, those turns carry no usable `meta.elapsed_seconds`, and under `raw` their duration — and the derived span's `duration_ns` — would land empty. Check that line before ratcheting, not just the verdict.
 
 ## Commands not intended as everyday workflow
 

--- a/ingest/ingest.go
+++ b/ingest/ingest.go
@@ -1,7 +1,6 @@
 package ingest
 
 import (
-	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -9,16 +8,13 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"math"
 	"net"
-	"strings"
 	"sync"
 	"time"
 
 	"github.com/gofiber/adaptor/v2"
 	"github.com/gofiber/fiber/v2"
 
-	"github.com/papercomputeco/tapes/pkg/capture"
 	"github.com/papercomputeco/tapes/pkg/llm"
 	"github.com/papercomputeco/tapes/pkg/llm/provider"
 	"github.com/papercomputeco/tapes/pkg/sessions"
@@ -211,14 +207,6 @@ type Server struct {
 	providers  map[string]provider.Provider
 	metrics    *Metrics
 
-	// reducers turn verbatim upstream bytes into a canonical response for
-	// raw-only payloads. Constructed explicitly and dispatched by provider
-	// name, the same way proxy.New does it — pkg/capture deliberately keeps
-	// no global registry so import order and init() stay out of the call
-	// graph. A provider with no entry simply never gets a server-side
-	// reduction; its adapter is expected to send one.
-	reducers map[string]capture.Reducer
-
 	// openapi is the live description of this write surface, populated by the
 	// same calls that register the routes. GET /openapi compiles it, and that
 	// is the only place this contract is published.
@@ -285,10 +273,6 @@ func newServer(config Config, driver storage.Driver, log *slog.Logger, docs oas.
 		providers:  providers,
 		metrics:    NewMetrics(),
 		openapi:    NewOpenAPIParser(docs),
-		reducers: map[string]capture.Reducer{
-			capture.ProviderAnthropic: capture.NewAnthropicReducer(),
-			capture.ProviderOpenAI:    capture.NewOpenAIResponsesReducer(),
-		},
 	}
 	if rawStore, ok := driver.(storage.RawTurnStore); ok {
 		s.rawStore = rawStore
@@ -632,30 +616,48 @@ func (s *Server) reduceRawOnly(ctx context.Context, turn *TurnPayload) json.RawM
 	if len(turn.RawResponse) == 0 {
 		return nil
 	}
-	if !reducedResponseAbsent(turn.Response) {
+	if !ReducedResponseAbsent(turn.Response) {
 		return nil
 	}
 
-	reducer, ok := s.reducers[turn.Provider]
-	if !ok {
-		s.logger.Warn("raw-only turn not reduced: no reducer for provider",
-			"provider", turn.Provider,
-			"request_id", turn.Meta.RequestID,
-		)
-		return nil
-	}
-
-	body, stats, err := capture.DecodeContentEncoding(turn.RawResponse, turn.RawResponseEncoding)
+	// The reduction itself is ReduceStoredRawTurn, shared with the offline
+	// equivalence prover so the ratchet is proven over the code that runs
+	// here rather than over a second copy of it. This function keeps what is
+	// genuinely ingest's: the raw-only gate above, and the logging and
+	// metrics below.
+	out, err := ReduceStoredRawTurn(ctx, StoredRawTurn{
+		Provider:            turn.Provider,
+		RawRequest:          turn.RawRequest,
+		RawResponse:         turn.RawResponse,
+		RawResponseEncoding: turn.RawResponseEncoding,
+		Meta:                turn.Meta,
+	})
 	if err != nil {
-		s.logger.Warn("raw-only turn not reduced: decode failed",
-			"provider", turn.Provider,
-			"request_id", turn.Meta.RequestID,
-			"encoding", turn.RawResponseEncoding,
-			"error", err,
-		)
+		switch {
+		case errors.Is(err, ErrNoReducer):
+			s.logger.Warn("raw-only turn not reduced: no reducer for provider",
+				"provider", turn.Provider,
+				"request_id", turn.Meta.RequestID,
+			)
+		case errors.Is(err, ErrDecode):
+			s.logger.Warn("raw-only turn not reduced: decode failed",
+				"provider", turn.Provider,
+				"request_id", turn.Meta.RequestID,
+				"encoding", turn.RawResponseEncoding,
+				"error", err,
+			)
+		default:
+			s.logger.Warn("raw-only turn not reduced: reducer failed",
+				"provider", turn.Provider,
+				"request_id", turn.Meta.RequestID,
+				"content_type", turn.Meta.ContentType,
+				"error", err,
+			)
+		}
 		return nil
 	}
-	if stats.Truncated {
+
+	if out.Truncated {
 		// The reduction goes ahead: a turn recovered from a stream that
 		// ended early is worth more than no turn. Logged rather than
 		// dropped, because the reduction may be missing its tail and
@@ -666,202 +668,24 @@ func (s *Server) reduceRawOnly(ctx context.Context, turn *TurnPayload) json.RawM
 			"encoding", turn.RawResponseEncoding,
 		)
 	}
-
-	resp, err := reducer.Reduce(ctx,
-		bytes.NewReader(turn.RawRequest),
-		bytes.NewReader(body),
-		turn.Meta.ContentType,
-	)
-	if err != nil || resp == nil {
-		s.logger.Warn("raw-only turn not reduced: reducer failed",
-			"provider", turn.Provider,
-			"request_id", turn.Meta.RequestID,
-			"content_type", turn.Meta.ContentType,
-			"error", err,
-		)
-		return nil
-	}
-
-	// The reducer sees only the upstream bytes, which carry neither the
-	// call's duration nor the instant it happened. Both are capture-side
-	// facts, and under raw-only ingest is the first place they can be put
-	// back on the reduction. Stamp them before marshaling so the raw layer
-	// and the derived path get the same values.
-	s.stampDuration(resp, turn)
-	s.stampCaptureTime(resp, turn)
-
-	out, err := json.Marshal(resp)
-	if err != nil {
-		return nil
-	}
-	turn.Response = *resp
-	return out
-}
-
-// stampDuration sets Usage.TotalDurationNs from the capture adapter's
-// meta.elapsed_seconds, allocating Usage if needed.
-//
-// This is the raw-only counterpart of proxy.stampDuration (PCC-514/570):
-// Anthropic and OpenAI do not surface call duration on the wire, so a
-// reduction performed from stored bytes has no duration in it, and the
-// column lands NULL — the exact regression those issues fixed on the proxy
-// path. The value survives the raw-only crossing on meta.elapsed_seconds,
-// so ingest re-stamps it here.
-//
-// Overwriting rather than filling-if-empty is deliberate, and matches the
-// proxy: a provider-reported internal duration (Ollama) measures something
-// different from wall-clock time at the capture point, and aggregate stats
-// are only comparable if every turn's duration means the same thing.
-//
-// An absent elapsed_seconds leaves the reduction alone. There is no second
-// source to fall back on — ingest's own clock measures the dispatch hop,
-// not the call — so the honest outcome is an unstamped duration, counted
-// as a fallback so it is visible rather than silent.
-// maxElapsedSeconds bounds a plausible single-call duration. Beyond it
-// the value is treated as corrupt rather than stamped into timing data:
-// a week-long LLM call is not a call, it is a producer clock bug.
-const maxElapsedSeconds = 7 * 24 * 60 * 60
-
-// usableElapsed reports whether the meta elapsed value can safely be
-// turned into a duration or a timestamp offset. NaN and ±Inf survive
-// JSON-adjacent producers more often than one would hope, and either
-// would poison int64 conversion silently.
-func usableElapsed(elapsed float64) bool {
-	return !math.IsNaN(elapsed) && !math.IsInf(elapsed, 0) &&
-		elapsed > 0 && elapsed <= maxElapsedSeconds
-}
-
-func (s *Server) stampDuration(resp *llm.ChatResponse, turn *TurnPayload) {
-	if resp == nil {
-		return
-	}
-	if !usableElapsed(turn.Meta.ElapsedSeconds) {
-		s.metrics.ObserveRawOnlyStamp(turn.Provider, StampFieldDuration, StampSourceFallback)
-		return
-	}
-	if resp.Usage == nil {
-		resp.Usage = &llm.Usage{}
-	}
-	resp.Usage.TotalDurationNs = int64(turn.Meta.ElapsedSeconds * float64(time.Second))
-	s.metrics.ObserveRawOnlyStamp(turn.Provider, StampFieldDuration, StampSourceElapsed)
-}
-
-// stampCaptureTime sets CreatedAt to the capture-side instant the envelope
-// reports, so a raw-only row means the same thing a pre-reduced one does.
-//
-// The contract this enforces: CreatedAt is when the turn happened, never
-// when tapes heard about it. Under dual-send the producer reduced live and
-// stamped its own clock, so CreatedAt was capture time by construction.
-// Under raw-only the reduction moves to the server, and the reducers stamp
-// time.Now() (pkg/capture/anthropic.go, anthropic_state.go) — which is now
-// ingest time. Same field, silently different quantity: rows would sort and
-// bucket by when the ingest hop happened, and a replay of stored bytes would
-// date every turn to the replay.
-//
-// Sources, most precise first. Each is a capture-side clock; none is
-// ingest's:
-//
-//  1. meta.captured_at — the completion instant outright.
-//  2. meta.ts_request + meta.elapsed_seconds — request instant plus the
-//     call's duration, which is the same quantity by construction.
-//  3. meta.ts_request alone — the request instant, early by the call's
-//     duration but a real capture-side time, and already what
-//     derive.CapturedAt uses for the row's chronology.
-//
-// Preferring ts_request over ingest's clock is what keeps CreatedAt and the
-// derived span's StartedAt (derive.CapturedAt, same field) from disagreeing
-// about when one turn happened. It also means backfilled rows, which carry
-// ts_request today, get a correct CreatedAt without any producer change.
-//
-// With none of them present ingest keeps whatever the reducer produced and
-// counts a fallback. That fallback is not uniform, which is why it is
-// counted rather than assumed:
-//
-//   - OpenAI Responses reductions carry the upstream's own created_at
-//     (pkg/capture/openai_responses.go), so CreatedAt is already a real
-//     capture-side time and overwriting it would lose information.
-//   - Anthropic reductions carry time.Now(), so CreatedAt is ingest time —
-//     the drift this function exists to close, left visible on the counter
-//     until producers send one of the fields above.
-//
-// Guessing capture time as now-minus-elapsed is deliberately not done: it is
-// indistinguishable from the truth on a healthy dispatch and arbitrarily
-// wrong on a retried, buffered, or replayed one, which is the case that
-// matters.
-func (s *Server) stampCaptureTime(resp *llm.ChatResponse, turn *TurnPayload) {
-	if resp == nil {
-		return
-	}
-
-	if completed, ok := s.parseCaptureStamp(turn, "captured_at", turn.Meta.CapturedAt); ok {
-		resp.CreatedAt = completed
-		s.metrics.ObserveRawOnlyStamp(turn.Provider, StampFieldCreatedAt, StampSourceCapturedAt)
-		return
-	}
-
-	if requested, ok := s.parseCaptureStamp(turn, "ts_request", turn.Meta.TsRequest); ok {
-		// The elapsed offset is what turns a request instant into the
-		// completion instant CreatedAt denotes. Without it the request
-		// instant still stands — early by the call's duration, which is a
-		// far smaller error than the ingest hop it replaces.
-		if usableElapsed(turn.Meta.ElapsedSeconds) {
-			requested = requested.Add(time.Duration(turn.Meta.ElapsedSeconds * float64(time.Second)))
-		}
-		resp.CreatedAt = requested
-		s.metrics.ObserveRawOnlyStamp(turn.Provider, StampFieldCreatedAt, StampSourceTsRequest)
-		return
-	}
-
-	s.metrics.ObserveRawOnlyStamp(turn.Provider, StampFieldCreatedAt, StampSourceFallback)
-}
-
-// parseCaptureStamp parses one RFC 3339 capture-side timestamp off the meta
-// block, reporting whether it yielded a usable instant.
-//
-// RFC3339Nano matches derive.CapturedAt, so the two agree on what they
-// accept — a timestamp the deriver honors cannot be one ingest rejects.
-//
-// An absent field is ordinary: no producer sends either of these yet. A
-// present-but-malformed one is a producer bug and logged, since someone
-// meant to send it. Neither rejects the turn — the bytes are already stored,
-// and losing a whole turn over a timestamp would be a far worse trade.
-func (s *Server) parseCaptureStamp(turn *TurnPayload, field, value string) (time.Time, bool) {
-	raw := strings.TrimSpace(value)
-	if raw == "" {
-		return time.Time{}, false
-	}
-	ts, err := time.Parse(time.RFC3339Nano, raw)
-	if err != nil {
+	for _, m := range out.MalformedStamps {
 		s.logger.Warn("raw-only turn: capture timestamp not RFC 3339",
 			"provider", turn.Provider,
 			"request_id", turn.Meta.RequestID,
-			"field", field,
-			"value", raw,
-			"error", err,
+			"field", m.Field,
+			"value", m.Value,
+			"error", m.Err,
 		)
-		return time.Time{}, false
 	}
-	return ts.UTC(), true
-}
+	s.metrics.ObserveRawOnlyStamp(turn.Provider, StampFieldDuration, out.DurationSource)
+	s.metrics.ObserveRawOnlyStamp(turn.Provider, StampFieldCreatedAt, out.CreatedAtSource)
 
-// reducedResponseAbsent reports whether a payload carried no reduced response.
-//
-// It has to be decided on the parsed value, not on the envelope JSON: Response
-// is a struct rather than a pointer and has no omitempty, so a client that
-// marshals TurnPayload always emits a `response` key. Its presence in the
-// bytes therefore says nothing about whether an adapter actually reduced
-// anything — the zero value and a deliberate empty reduction are the same JSON.
-//
-// Every field is checked rather than just the message, so an adapter that
-// reduced a turn to an error envelope (stop_reason and usage, no content)
-// still counts as having reduced, and keeps its result.
-func reducedResponseAbsent(r llm.ChatResponse) bool {
-	return r.Model == "" &&
-		r.Message.Role == "" &&
-		len(r.Message.Content) == 0 &&
-		!r.Done &&
-		r.StopReason == "" &&
-		r.Usage == nil
+	marshaled, err := json.Marshal(out.Response)
+	if err != nil {
+		return nil
+	}
+	turn.Response = *out.Response
+	return marshaled
 }
 
 // MaxRawResponseBytes caps the verbatim response bytes ingest will store on a

--- a/ingest/rawreduce.go
+++ b/ingest/rawreduce.go
@@ -1,0 +1,343 @@
+package ingest
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"strings"
+	"time"
+
+	"github.com/papercomputeco/tapes/pkg/capture"
+	"github.com/papercomputeco/tapes/pkg/llm"
+)
+
+// This file holds the server-side reduction of stored capture bytes, factored
+// out of the ingest handler so it has exactly one implementation.
+//
+// The reason it is a package-level function rather than a Server method is the
+// raw-response ratchet (off → dual → raw). Moving an environment to raw is
+// only safe if re-reducing the stored bytes reproduces the reduction the
+// adapter computed live, and that has to be PROVEN over real traffic before
+// the flip. The proving tool (`tapes raw equivalence`) therefore needs to run
+// the reduction mode=raw would run — and if it ran its own copy, the proof
+// would be of the copy rather than of the code that will actually execute.
+// One function, two callers, is what makes the proof mean anything.
+//
+// Everything here is a pure function of the stored row: no clock (beyond what
+// the reducers themselves stamp), no database, no metrics, no logging. The
+// observability the ingest path needs is returned as data — which stamp source
+// fired, which stamps were malformed — and emitted by the caller, so the
+// offline tool can report the same facts without emitting server metrics.
+
+// rawReducers dispatches verbatim upstream bytes to the reducer for a
+// provider. Constructed explicitly and dispatched by provider name, the same
+// way proxy.New does it — pkg/capture deliberately keeps no global registry so
+// import order and init() stay out of the call graph.
+//
+// A provider with no entry simply never gets a server-side reduction; its
+// adapter is expected to send one. That is a real constraint on the ratchet
+// rather than an oversight: ollama is a supported provider with no reducer, so
+// ollama traffic cannot move to raw until one exists.
+var rawReducers = map[string]capture.Reducer{
+	capture.ProviderAnthropic: capture.NewAnthropicReducer(),
+	capture.ProviderOpenAI:    capture.NewOpenAIResponsesReducer(),
+}
+
+// ReducerForProvider returns the server-side reducer for a provider name, and
+// whether one exists.
+func ReducerForProvider(provider string) (capture.Reducer, bool) {
+	r, ok := rawReducers[provider]
+	return r, ok
+}
+
+// Sentinel causes for a reduction that did not produce a response. They are
+// distinguished because they mean different things for the ratchet: a decode
+// failure says the bytes are unreadable by this build, a missing reducer says
+// the provider was never wired up, and a reducer failure says the bytes were
+// readable but did not parse into a turn. Only the first is plausibly a
+// transport or encoding bug; the other two are gaps.
+var (
+	// ErrNoReducer means no server-side reducer is registered for the
+	// provider, so mode=raw would store the turn with no reduction at all.
+	ErrNoReducer = errors.New("no server-side reducer for provider")
+
+	// ErrDecode means the stored bytes could not be decoded under their
+	// recorded content-encoding.
+	ErrDecode = errors.New("decode stored raw response")
+
+	// ErrReduce means the reducer rejected the decoded bytes.
+	ErrReduce = errors.New("reduce stored raw response")
+)
+
+// StoredRawTurn is the subset of a captured turn that a server-side reduction
+// consumes. It is deliberately not TurnPayload: the reduction reads only these
+// fields, and naming them makes it explicit that the stored row carries
+// everything the reduction needs — which is the property the raw lane exists
+// to guarantee.
+type StoredRawTurn struct {
+	// Provider keys the reducer table.
+	Provider string
+
+	// RawRequest is the original provider request body. Both current
+	// reducers discard it; it is passed through because the Reducer contract
+	// admits enriching a response from request context, and a reducer that
+	// started doing so should see the same input on both paths.
+	RawRequest json.RawMessage
+
+	// RawResponse is the upstream response body exactly as it arrived,
+	// still under RawResponseEncoding.
+	RawResponse []byte
+
+	// RawResponseEncoding is the Content-Encoding the bytes are stored
+	// under. Empty means identity.
+	RawResponseEncoding string
+
+	// Meta is the capture adapter's metadata block. ContentType selects the
+	// streaming vs one-shot reduction path; the timestamp and elapsed fields
+	// supply the capture-side stamps the bytes cannot carry.
+	Meta TurnMeta
+}
+
+// MalformedStamp records a capture-side timestamp that was present but not
+// parseable. Someone meant to send it, so it is reported rather than ignored;
+// it never rejects the turn, because losing a whole turn over a timestamp is a
+// far worse trade than dating it imprecisely.
+type MalformedStamp struct {
+	Field string
+	Value string
+	Err   error
+}
+
+// RawReduction is the outcome of reducing one stored turn's bytes.
+type RawReduction struct {
+	// Response is the reduced turn. Non-nil whenever the error is nil.
+	Response *llm.ChatResponse
+
+	// Truncated reports that the stored body ended early and was salvaged.
+	// The reduction went ahead — a turn recovered from a stream that ended
+	// early is worth more than no turn — but it may be missing its tail, and
+	// nothing downstream can tell that from the row alone.
+	Truncated bool
+
+	// DurationSource and CreatedAtSource name the meta field that supplied
+	// each capture-side stamp, or StampSourceFallback when the envelope
+	// carried nothing usable.
+	DurationSource  StampSource
+	CreatedAtSource StampSource
+
+	// MalformedStamps lists capture-side timestamps that were present but
+	// unparseable.
+	MalformedStamps []MalformedStamp
+}
+
+// ReduceStoredRawTurn turns one stored turn's verbatim bytes into the reduced
+// response mode=raw would persist for it.
+//
+// This is the whole server-side reduction: decode the bytes under their
+// recorded encoding, reduce them with the shared pkg/capture reducer for the
+// provider, then restore the two capture-side facts the bytes do not carry.
+// Callers that need the ingest-path behaviour get it by emitting metrics and
+// logs from the returned outcome; callers proving equivalence offline simply
+// read the same outcome.
+func ReduceStoredRawTurn(ctx context.Context, in StoredRawTurn) (RawReduction, error) {
+	reducer, ok := rawReducers[in.Provider]
+	if !ok {
+		return RawReduction{}, fmt.Errorf("%w: %q", ErrNoReducer, in.Provider)
+	}
+
+	body, stats, err := capture.DecodeContentEncoding(in.RawResponse, in.RawResponseEncoding)
+	if err != nil {
+		return RawReduction{}, fmt.Errorf("%w (encoding %q): %w", ErrDecode, in.RawResponseEncoding, err)
+	}
+
+	resp, err := reducer.Reduce(ctx,
+		bytes.NewReader(in.RawRequest),
+		bytes.NewReader(body),
+		in.Meta.ContentType,
+	)
+	if err != nil {
+		return RawReduction{}, fmt.Errorf("%w (content-type %q): %w", ErrReduce, in.Meta.ContentType, err)
+	}
+	if resp == nil {
+		return RawReduction{}, fmt.Errorf("%w: reducer returned no response", ErrReduce)
+	}
+
+	out := RawReduction{Response: resp, Truncated: stats.Truncated}
+	out.DurationSource = stampDuration(resp, in.Meta)
+	out.CreatedAtSource, out.MalformedStamps = stampCaptureTime(resp, in.Meta)
+	return out, nil
+}
+
+// ReducedResponseAbsent reports whether a payload carried no reduced response.
+//
+// It has to be decided on the parsed value, not on the envelope JSON: Response
+// is a struct rather than a pointer and has no omitempty, so a client that
+// marshals TurnPayload always emits a `response` key. Its presence in the
+// bytes therefore says nothing about whether an adapter actually reduced
+// anything — the zero value and a deliberate empty reduction are the same JSON.
+//
+// Every field is checked rather than just the message, so an adapter that
+// reduced a turn to an error envelope (stop_reason and usage, no content)
+// still counts as having reduced, and keeps its result.
+//
+// Exported because it is the definition of "this row is raw-only". Ingest uses
+// it to decide whether to reduce server-side; the equivalence prover uses it to
+// decide whether a stored row has an adapter reduction to compare against. Two
+// spellings of that predicate would let the prover measure a different
+// population than the one the flip affects.
+func ReducedResponseAbsent(r llm.ChatResponse) bool {
+	return r.Model == "" &&
+		r.Message.Role == "" &&
+		len(r.Message.Content) == 0 &&
+		!r.Done &&
+		r.StopReason == "" &&
+		r.Usage == nil
+}
+
+// maxElapsedSeconds bounds a plausible single-call duration. Beyond it the
+// value is treated as corrupt rather than stamped into timing data: a
+// week-long LLM call is not a call, it is a producer clock bug.
+const maxElapsedSeconds = 7 * 24 * 60 * 60
+
+// usableElapsed reports whether the meta elapsed value can safely be turned
+// into a duration or a timestamp offset. NaN and ±Inf survive JSON-adjacent
+// producers more often than one would hope, and either would poison int64
+// conversion silently.
+func usableElapsed(elapsed float64) bool {
+	return !math.IsNaN(elapsed) && !math.IsInf(elapsed, 0) &&
+		elapsed > 0 && elapsed <= maxElapsedSeconds
+}
+
+// stampDuration sets Usage.TotalDurationNs from the capture adapter's
+// meta.elapsed_seconds, allocating Usage if needed, and reports which source
+// supplied the value.
+//
+// This is the raw-only counterpart of proxy.stampDuration (PCC-514/570):
+// Anthropic and OpenAI do not surface call duration on the wire, so a
+// reduction performed from stored bytes has no duration in it, and the column
+// lands NULL — the exact regression those issues fixed on the proxy path. The
+// value survives the raw-only crossing on meta.elapsed_seconds, so it is
+// re-stamped here.
+//
+// Overwriting rather than filling-if-empty is deliberate, and matches the
+// proxy: a provider-reported internal duration (Ollama) measures something
+// different from wall-clock time at the capture point, and aggregate stats are
+// only comparable if every turn's duration means the same thing.
+//
+// An absent elapsed_seconds leaves the reduction alone. There is no second
+// source to fall back on — ingest's own clock measures the dispatch hop, not
+// the call — so the honest outcome is an unstamped duration, reported as a
+// fallback so it is visible rather than silent.
+func stampDuration(resp *llm.ChatResponse, meta TurnMeta) StampSource {
+	if resp == nil {
+		return StampSourceFallback
+	}
+	if !usableElapsed(meta.ElapsedSeconds) {
+		return StampSourceFallback
+	}
+	if resp.Usage == nil {
+		resp.Usage = &llm.Usage{}
+	}
+	resp.Usage.TotalDurationNs = int64(meta.ElapsedSeconds * float64(time.Second))
+	return StampSourceElapsed
+}
+
+// stampCaptureTime sets CreatedAt to the capture-side instant the envelope
+// reports, so a raw-only row means the same thing a pre-reduced one does.
+//
+// The contract this enforces: CreatedAt is when the turn happened, never when
+// tapes heard about it. Under dual-send the producer reduced live and stamped
+// its own clock, so CreatedAt was capture time by construction. Under raw-only
+// the reduction moves to the server, and the reducers stamp time.Now()
+// (pkg/capture/anthropic.go, anthropic_state.go) — which is now ingest time.
+// Same field, silently different quantity: rows would sort and bucket by when
+// the ingest hop happened, and a replay of stored bytes would date every turn
+// to the replay.
+//
+// Sources, most precise first. Each is a capture-side clock; none is ingest's:
+//
+//  1. meta.captured_at — the completion instant outright.
+//  2. meta.ts_request + meta.elapsed_seconds — request instant plus the
+//     call's duration, which is the same quantity by construction.
+//  3. meta.ts_request alone — the request instant, early by the call's
+//     duration but a real capture-side time, and already what
+//     derive.CapturedAt uses for the row's chronology.
+//
+// Preferring ts_request over ingest's clock is what keeps CreatedAt and the
+// derived span's StartedAt (derive.CapturedAt, same field) from disagreeing
+// about when one turn happened. It also means backfilled rows, which carry
+// ts_request today, get a correct CreatedAt without any producer change.
+//
+// With none of them present the reducer's own value stands and a fallback is
+// reported. That fallback is not uniform, which is why it is reported rather
+// than assumed:
+//
+//   - OpenAI Responses reductions carry the upstream's own created_at
+//     (pkg/capture/openai_responses.go), so CreatedAt is already a real
+//     capture-side time and overwriting it would lose information.
+//   - Anthropic reductions carry time.Now(), so CreatedAt is reduction time —
+//     the drift this function exists to close, left visible on the counter
+//     until producers send one of the fields above.
+//
+// Guessing capture time as now-minus-elapsed is deliberately not done: it is
+// indistinguishable from the truth on a healthy dispatch and arbitrarily wrong
+// on a retried, buffered, or replayed one, which is the case that matters.
+func stampCaptureTime(resp *llm.ChatResponse, meta TurnMeta) (StampSource, []MalformedStamp) {
+	if resp == nil {
+		return StampSourceFallback, nil
+	}
+
+	var malformed []MalformedStamp
+
+	completed, ok, err := parseCaptureStamp(meta.CapturedAt)
+	if err != nil {
+		malformed = append(malformed, MalformedStamp{Field: "captured_at", Value: meta.CapturedAt, Err: err})
+	}
+	if ok {
+		resp.CreatedAt = completed
+		return StampSourceCapturedAt, malformed
+	}
+
+	requested, ok, err := parseCaptureStamp(meta.TsRequest)
+	if err != nil {
+		malformed = append(malformed, MalformedStamp{Field: "ts_request", Value: meta.TsRequest, Err: err})
+	}
+	if ok {
+		// The elapsed offset is what turns a request instant into the
+		// completion instant CreatedAt denotes. Without it the request
+		// instant still stands — early by the call's duration, which is a
+		// far smaller error than the ingest hop it replaces.
+		if usableElapsed(meta.ElapsedSeconds) {
+			requested = requested.Add(time.Duration(meta.ElapsedSeconds * float64(time.Second)))
+		}
+		resp.CreatedAt = requested
+		return StampSourceTsRequest, malformed
+	}
+
+	return StampSourceFallback, malformed
+}
+
+// parseCaptureStamp parses one RFC 3339 capture-side timestamp off the meta
+// block, reporting whether it yielded a usable instant and, separately,
+// whether a present value failed to parse.
+//
+// RFC3339Nano matches derive.CapturedAt, so the two agree on what they accept
+// — a timestamp the deriver honors cannot be one ingest rejects.
+//
+// An absent field is ordinary: no producer sends either of these yet. A
+// present-but-malformed one is a producer bug and is reported, since someone
+// meant to send it.
+func parseCaptureStamp(value string) (time.Time, bool, error) {
+	raw := strings.TrimSpace(value)
+	if raw == "" {
+		return time.Time{}, false, nil
+	}
+	ts, err := time.Parse(time.RFC3339Nano, raw)
+	if err != nil {
+		return time.Time{}, false, err
+	}
+	return ts.UTC(), true, nil
+}

--- a/pkg/rawequiv/diff.go
+++ b/pkg/rawequiv/diff.go
@@ -1,0 +1,289 @@
+package rawequiv
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"math"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// DiffKind classifies one structural difference.
+type DiffKind string
+
+const (
+	// DiffMissingInRecomputed marks a path the stored reduction has and the
+	// recomputed one does not — the direction that means moving to raw would
+	// LOSE a field.
+	DiffMissingInRecomputed DiffKind = "missing_in_recomputed"
+
+	// DiffMissingInStored marks a path only the recomputed reduction has.
+	DiffMissingInStored DiffKind = "missing_in_stored"
+
+	// DiffType marks a path present on both sides with different JSON types.
+	DiffType DiffKind = "type_mismatch"
+
+	// DiffValue marks a path present on both sides, same type, different
+	// value.
+	DiffValue DiffKind = "value_mismatch"
+
+	// DiffLength marks arrays of differing length. Element differences are
+	// reported separately for the overlapping prefix.
+	DiffLength DiffKind = "length_mismatch"
+)
+
+// FieldDiff is one structural difference between two reductions.
+//
+// Stored and Recomputed are RENDERINGS, never raw values. Reductions of real
+// traffic contain prompts and completions, and this tool's output goes into
+// terminals, CI logs and paste buffers; a diff that printed the values would
+// make running it on production traffic a data-handling event. Renderings
+// carry shape (type, length, digest) which is what a reviewer needs to decide
+// whether a divergence is structural or cosmetic, and identifiers from a small
+// allowlist of provider-controlled fields.
+type FieldDiff struct {
+	Path       string   `json:"path"`
+	Kind       DiffKind `json:"kind"`
+	Stored     string   `json:"stored,omitempty"`
+	Recomputed string   `json:"recomputed,omitempty"`
+}
+
+// safePaths are the JSON paths whose string values may be printed verbatim.
+//
+// Every entry is provider-controlled vocabulary rather than model output: a
+// model name, a stop reason, a role, a block or object type, a message id.
+// Knowing that `stop_reason` went from "end_turn" to "" is the whole content
+// of that divergence, and redacting it to a digest would make the report
+// useless for the one thing it exists to do. Anything not listed here is
+// rendered as shape only — the default is deny.
+//
+// Paths are normalized: array indices collapse to "[]", so
+// message.content[3].type matches message.content[].type.
+var safePaths = map[string]bool{
+	"model":                         true,
+	"stop_reason":                   true,
+	"done":                          true,
+	"message.role":                  true,
+	"message.content[].type":        true,
+	"extra.type":                    true,
+	"extra.status":                  true,
+	"extra.object":                  true,
+	"extra.id":                      true,
+	"extra.incomplete":              true,
+	"extra.partial":                 true,
+	"message.content[].name":        true,
+	"message.content[].tool_use_id": true,
+}
+
+// normalizePath collapses array indices so a path can be looked up in
+// safePaths regardless of position.
+func normalizePath(path string) string {
+	var b strings.Builder
+	for i := 0; i < len(path); i++ {
+		if path[i] != '[' {
+			b.WriteByte(path[i])
+			continue
+		}
+		end := strings.IndexByte(path[i:], ']')
+		if end < 0 {
+			b.WriteByte(path[i])
+			continue
+		}
+		b.WriteString("[]")
+		i += end
+	}
+	return b.String()
+}
+
+// render produces a printable, content-safe description of a decoded JSON
+// value at a path.
+func render(path string, v any) string {
+	switch t := v.(type) {
+	case nil:
+		return "null"
+	case bool:
+		return strconv.FormatBool(t)
+	case float64:
+		// Numbers are token counts, indices, sizes and timestamps. None of
+		// them carry prompt text, so they print verbatim.
+		if t == math.Trunc(t) && math.Abs(t) < 1e15 {
+			return strconv.FormatInt(int64(t), 10)
+		}
+		return strconv.FormatFloat(t, 'g', -1, 64)
+	case string:
+		if safePaths[normalizePath(path)] {
+			return strconv.Quote(t)
+		}
+		sum := sha256.Sum256([]byte(t))
+		return fmt.Sprintf("string(len=%d,sha256=%s)", len(t), hex.EncodeToString(sum[:4]))
+	case []any:
+		return fmt.Sprintf("array(len=%d)", len(t))
+	case map[string]any:
+		keys := make([]string, 0, len(t))
+		for k := range t {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		return fmt.Sprintf("object(keys=[%s])", strings.Join(keys, " "))
+	default:
+		return "unknown"
+	}
+}
+
+// jsonType names the JSON type of a decoded value, for type-mismatch reports.
+func jsonType(v any) string {
+	switch v.(type) {
+	case nil:
+		return "null"
+	case bool:
+		return "bool"
+	case float64:
+		return "number"
+	case string:
+		return "string"
+	case []any:
+		return "array"
+	case map[string]any:
+		return "object"
+	default:
+		return "unknown"
+	}
+}
+
+// decodeCanonical decodes JSON into the generic tree the differ walks.
+//
+// Both sides must go through this. The stored side comes back from Postgres
+// jsonb, which has already normalized key order, whitespace, duplicate keys
+// and number formatting; the recomputed side is a fresh Go marshal that has
+// not. Comparing the two as bytes would therefore report divergences that are
+// entirely artifacts of the storage round-trip. Decoding both to a generic
+// tree and comparing structurally is what makes the comparison a statement
+// about the reduction rather than about jsonb.
+//
+// Numbers land as float64, which is what makes 1e2 and 100 compare equal —
+// the normalization jsonb performs and Go's marshaller does not. The cost is
+// that integers beyond 2^53 would lose precision. Nothing in a reduction is
+// that large (token counts, byte counts, block indices, and a nanosecond
+// duration that is excluded from the comparison anyway), so the trade buys
+// jsonb-insensitivity for no reachable loss.
+func decodeCanonical(data []byte) (any, error) {
+	if len(data) == 0 {
+		return nil, nil
+	}
+	var v any
+	if err := json.Unmarshal(data, &v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+// prune removes a path from a decoded tree. Used to drop the fields that are
+// legitimately allowed to differ before the comparison runs, so those fields
+// cannot mask or manufacture a divergence.
+func prune(v any, path []string) {
+	if len(path) == 0 {
+		return
+	}
+	obj, ok := v.(map[string]any)
+	if !ok {
+		return
+	}
+	if len(path) == 1 {
+		delete(obj, path[0])
+		return
+	}
+	prune(obj[path[0]], path[1:])
+}
+
+// diffValues walks two decoded trees in parallel and appends every structural
+// difference to out, stopping once max differences have been collected.
+//
+// The bound is per comparison rather than per level: one row that diverges
+// everywhere must not be able to produce an unbounded report, and the first
+// handful of paths is enough to characterize a divergence class. The caller
+// reports that truncation happened rather than hiding it.
+func diffValues(path string, stored, recomputed any, out *[]FieldDiff, limit int) {
+	if len(*out) >= limit {
+		return
+	}
+
+	if jsonType(stored) != jsonType(recomputed) {
+		*out = append(*out, FieldDiff{
+			Path:       path,
+			Kind:       DiffType,
+			Stored:     jsonType(stored),
+			Recomputed: jsonType(recomputed),
+		})
+		return
+	}
+
+	switch s := stored.(type) {
+	case map[string]any:
+		r := recomputed.(map[string]any)
+		keys := make([]string, 0, len(s)+len(r))
+		seen := map[string]bool{}
+		for k := range s {
+			if !seen[k] {
+				keys = append(keys, k)
+				seen[k] = true
+			}
+		}
+		for k := range r {
+			if !seen[k] {
+				keys = append(keys, k)
+				seen[k] = true
+			}
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			if len(*out) >= limit {
+				return
+			}
+			child := k
+			if path != "" {
+				child = path + "." + k
+			}
+			sv, sok := s[k]
+			rv, rok := r[k]
+			switch {
+			case sok && !rok:
+				*out = append(*out, FieldDiff{Path: child, Kind: DiffMissingInRecomputed, Stored: render(child, sv)})
+			case !sok && rok:
+				*out = append(*out, FieldDiff{Path: child, Kind: DiffMissingInStored, Recomputed: render(child, rv)})
+			default:
+				diffValues(child, sv, rv, out, limit)
+			}
+		}
+
+	case []any:
+		r := recomputed.([]any)
+		if len(s) != len(r) {
+			*out = append(*out, FieldDiff{
+				Path:       path,
+				Kind:       DiffLength,
+				Stored:     strconv.Itoa(len(s)),
+				Recomputed: strconv.Itoa(len(r)),
+			})
+		}
+		n := min(len(s), len(r))
+		for i := range n {
+			if len(*out) >= limit {
+				return
+			}
+			diffValues(fmt.Sprintf("%s[%d]", path, i), s[i], r[i], out, limit)
+		}
+
+	default:
+		if stored != recomputed {
+			*out = append(*out, FieldDiff{
+				Path:       path,
+				Kind:       DiffValue,
+				Stored:     render(path, stored),
+				Recomputed: render(path, recomputed),
+			})
+		}
+	}
+}

--- a/pkg/rawequiv/rawequiv.go
+++ b/pkg/rawequiv/rawequiv.go
@@ -1,0 +1,367 @@
+// Package rawequiv proves that re-reducing a captured turn's stored verbatim
+// bytes reproduces the reduction the capture adapter computed live.
+//
+// # Why this exists
+//
+// The capture path is moving through a deliberate ratchet: off (the adapter
+// reduces and ships only the reduction) → dual (the adapter ships both its
+// reduction and the verbatim upstream bytes) → raw (the adapter ships only
+// bytes and tapes reduces server-side). The end state is worth reaching
+// because one reducer for every capture path means two paths cannot reduce
+// differently — which is the failure the shared pkg/capture library exists to
+// prevent and cannot prevent on its own while a second reducer runs in the
+// adapter.
+//
+// The middle rung is where the proof happens. Under dual, every row carries
+// both halves of the same turn, so the question "would raw have produced this
+// row?" is answerable offline, over real traffic, without changing anything an
+// operator sees. This package answers it: decode the stored bytes, re-reduce
+// them through the exact server-side path mode=raw would run
+// (ingest.ReduceStoredRawTurn), and compare against the stored reduction.
+//
+// A divergence found here is a reason not to flip. A clean window over
+// representative traffic is the evidence that flipping is safe.
+//
+// # What "equivalent" means
+//
+// Equivalence is structural, not byte-level. The stored reduction comes back
+// from Postgres jsonb, which normalizes key order, whitespace, duplicate keys
+// and number formatting; the recomputed one is a fresh Go marshal. Comparing
+// bytes would report the storage round-trip as a divergence. Both sides are
+// therefore decoded to a generic JSON tree and compared structurally.
+//
+// Exactly two fields are permitted to differ, and both are time rather than
+// content. They are removed from both sides before the comparison, so
+// everything else — model, message role, every content block, stop reason,
+// every other usage counter, extra diagnostics, and the echoed raw body on the
+// providers that carry one — is compared strictly. If a third difference ever
+// appears it is reported as a divergence rather than absorbed by a loose
+// comparison. See TolerableFields for the per-field justification.
+package rawequiv
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+
+	"github.com/papercomputeco/tapes/ingest"
+	"github.com/papercomputeco/tapes/pkg/llm"
+)
+
+// TolerableFields documents, and defines, the fields allowed to differ between
+// a stored adapter reduction and a server-side re-reduction of the same bytes.
+//
+// This list is the whole tolerance of the proof. Every entry needs a reason
+// grounded in the code, not in observed noise: a field that differs for a
+// reason nobody can name is a divergence, and the point of the tool is to find
+// those.
+var TolerableFields = []TolerableField{
+	{
+		Path: []string{"created_at"},
+		Why: "Reducers stamp CreatedAt with time.Now() at reduction time " +
+			"(pkg/capture/anthropic.go, anthropic_state.go), so two reductions of " +
+			"identical bytes taken at different instants differ by construction. " +
+			"Under mode=raw ingest overrides it from meta.captured_at or " +
+			"meta.ts_request when the producer sends one; no released producer " +
+			"sends either today, so for Anthropic the field carries reduction " +
+			"time. OpenAI Responses is the exception — it reads the upstream's own " +
+			"created_at — but the tolerance is uniform because the tool cannot " +
+			"assume a provider mix, and StampCoverage reports per row which " +
+			"source would actually have supplied it.",
+	},
+	{
+		Path: []string{"usage", "total_duration_ns"},
+		Why: "The proxy-measured wall clock from request to fully-assembled " +
+			"response (pkg/llm/response.go). Neither Anthropic nor OpenAI put a " +
+			"call duration in the response body, so only the party that watched " +
+			"the stream can know it; a reduction of stored bytes cannot. Under " +
+			"mode=raw ingest re-stamps it from meta.elapsed_seconds, a float64 " +
+			"seconds value, so even when it is restored it is a different " +
+			"rounding of the same measurement than the adapter's own nanoseconds.",
+	},
+}
+
+// TolerableField is one permitted difference and the reason it is permitted.
+type TolerableField struct {
+	// Path is the JSON path in a reduced llm.ChatResponse.
+	Path []string
+	// Why justifies the tolerance from the behaviour of the code.
+	Why string
+}
+
+// String renders the path in dotted form.
+func (f TolerableField) String() string { return strings.Join(f.Path, ".") }
+
+// Class is the verdict for one examined row.
+type Class string
+
+const (
+	// ClassEquivalent means the re-reduction reproduced the stored reduction.
+	ClassEquivalent Class = "equivalent"
+
+	// ClassDivergent means both reductions exist and differ outside the
+	// tolerated fields. This is the finding that blocks a ratchet step.
+	ClassDivergent Class = "divergent"
+
+	// ClassUndecodable means the stored bytes could not be decoded under
+	// their recorded content-encoding. Under mode=raw this row would carry no
+	// reduction at all, so it blocks just as a divergence does.
+	ClassUndecodable Class = "undecodable"
+
+	// ClassUnreducible means the bytes decoded but the reducer rejected them.
+	// Same consequence as undecodable: mode=raw would store an empty
+	// reduction.
+	ClassUnreducible Class = "unreducible"
+
+	// ClassNoReducer means no server-side reducer is registered for the
+	// row's provider (ollama today). mode=raw cannot serve this traffic.
+	ClassNoReducer Class = "no_reducer"
+
+	// ClassSkippedNoRaw means the row carries no verbatim bytes and none were
+	// reported lost — a producer that was not sending raw when the turn was
+	// captured. Nothing to prove; not a failure.
+	ClassSkippedNoRaw Class = "skipped_no_raw"
+
+	// ClassSkippedDropped means verbatim bytes existed and were not kept:
+	// either the producer withheld them at the transport limit or ingest
+	// dropped them over its storage cap. The row is marked
+	// raw_response_dropped and lands fidelity:degraded. Nothing to compare,
+	// but the count matters — these are rows a raw-only deployment would have
+	// no way to reconstruct.
+	ClassSkippedDropped Class = "skipped_dropped"
+
+	// ClassSkippedNoReduction means the row has bytes but no adapter
+	// reduction — it was captured raw-only already, so there is no second
+	// opinion to compare against.
+	ClassSkippedNoReduction Class = "skipped_no_reduction"
+)
+
+// Blocking reports whether a class should fail the run.
+//
+// The three reduction failures block alongside an outright divergence because
+// their consequence under mode=raw is strictly worse: a divergent row still
+// produces a reduction, while an undecodable, unreducible or unrouted row
+// produces none, and ingest's own comment records that recovering such a row
+// is possible in principle and not in practice. The skip classes never block —
+// they describe rows the flip does not affect.
+func (c Class) Blocking() bool {
+	switch c {
+	case ClassDivergent, ClassUndecodable, ClassUnreducible, ClassNoReducer:
+		return true
+	case ClassEquivalent, ClassSkippedNoRaw, ClassSkippedDropped, ClassSkippedNoReduction:
+		return false
+	default:
+		return false
+	}
+}
+
+// Row is one stored wire turn, as read from raw_turns.
+type Row struct {
+	ID                  int64
+	RequestID           string
+	Provider            string
+	HarnessID           string
+	HarnessSessionID    string
+	Model               string
+	RawResponse         []byte
+	RawResponseEncoding string
+	RawResponseDropped  bool
+
+	// StoredReduction is the raw_turns.response jsonb — the adapter's
+	// reduction, exactly as stored.
+	StoredReduction json.RawMessage
+
+	// Meta is the capture adapter's meta block from raw_turns.meta.
+	Meta ingest.TurnMeta
+}
+
+// StampCoverage records which capture-side stamps mode=raw would have been
+// able to restore for a row.
+//
+// This is not part of the equivalence verdict, and deliberately so: both
+// stamped fields are excluded from the comparison, so a row can be perfectly
+// equivalent while still losing its duration on the flip. Reporting coverage
+// separately is what keeps "equivalent" from being read as "loses nothing".
+type StampCoverage struct {
+	Duration  ingest.StampSource `json:"duration"`
+	CreatedAt ingest.StampSource `json:"created_at"`
+}
+
+// Outcome is the verdict for one row.
+type Outcome struct {
+	ID               int64  `json:"id"`
+	RequestID        string `json:"request_id,omitempty"`
+	Provider         string `json:"provider,omitempty"`
+	HarnessID        string `json:"harness_id,omitempty"`
+	HarnessSessionID string `json:"harness_session_id,omitempty"`
+	Model            string `json:"model,omitempty"`
+
+	Class Class `json:"class"`
+
+	// Reason explains a non-equivalent, non-skip class. It is an error
+	// string from the decode or reduce step and never contains body content.
+	Reason string `json:"reason,omitempty"`
+
+	// Diffs is the bounded structural difference for a divergent row.
+	Diffs []FieldDiff `json:"diffs,omitempty"`
+
+	// DiffsTruncated reports that more differences existed than were kept.
+	DiffsTruncated bool `json:"diffs_truncated,omitempty"`
+
+	// Truncated reports that the stored body ended early and the reduction
+	// was salvaged from a partial stream. A divergence on such a row is
+	// expected rather than alarming — the adapter saw the whole stream live.
+	Truncated bool `json:"truncated,omitempty"`
+
+	// Stamps reports which capture-side sources were available. Populated
+	// whenever a re-reduction ran.
+	Stamps *StampCoverage `json:"stamps,omitempty"`
+}
+
+// Options tunes a check.
+type Options struct {
+	// MaxDiffs bounds the structural differences recorded per row.
+	MaxDiffs int
+}
+
+// DefaultMaxDiffs is the per-row difference bound when none is given.
+const DefaultMaxDiffs = 10
+
+// Check decides whether one stored row's reduction is reproducible from its
+// stored bytes.
+//
+// The row is classified before any work is done, so the skip classes are
+// cheap and the counts are exhaustive: every row examined lands in exactly one
+// class and the classes sum to the total.
+func Check(ctx context.Context, row Row, opts Options) Outcome {
+	out := Outcome{
+		ID:               row.ID,
+		RequestID:        row.RequestID,
+		Provider:         row.Provider,
+		HarnessID:        row.HarnessID,
+		HarnessSessionID: row.HarnessSessionID,
+		Model:            row.Model,
+	}
+	if out.Model == "" {
+		out.Model = row.Meta.Model
+	}
+
+	maxDiffs := opts.MaxDiffs
+	if maxDiffs <= 0 {
+		maxDiffs = DefaultMaxDiffs
+	}
+
+	// Dropped is checked before absent bytes because it is the more specific
+	// fact: a dropped row also has no bytes, and reporting it as "producer
+	// wasn't sending raw" would erase the difference between a limit that bit
+	// and a deployment that never captured.
+	if row.RawResponseDropped {
+		out.Class = ClassSkippedDropped
+		return out
+	}
+	if len(row.RawResponse) == 0 {
+		out.Class = ClassSkippedNoRaw
+		return out
+	}
+
+	var stored llm.ChatResponse
+	if len(row.StoredReduction) > 0 {
+		if err := json.Unmarshal(row.StoredReduction, &stored); err != nil {
+			out.Class = ClassSkippedNoReduction
+			out.Reason = "stored reduction is not a ChatResponse: " + err.Error()
+			return out
+		}
+	}
+	if ingest.ReducedResponseAbsent(stored) {
+		out.Class = ClassSkippedNoReduction
+		return out
+	}
+
+	reduction, err := ingest.ReduceStoredRawTurn(ctx, ingest.StoredRawTurn{
+		Provider:            row.Provider,
+		RawResponse:         row.RawResponse,
+		RawResponseEncoding: row.RawResponseEncoding,
+		Meta:                row.Meta,
+	})
+	if err != nil {
+		switch {
+		case errors.Is(err, ingest.ErrNoReducer):
+			out.Class = ClassNoReducer
+		case errors.Is(err, ingest.ErrDecode):
+			out.Class = ClassUndecodable
+		default:
+			out.Class = ClassUnreducible
+		}
+		out.Reason = err.Error()
+		return out
+	}
+
+	out.Truncated = reduction.Truncated
+	out.Stamps = &StampCoverage{
+		Duration:  reduction.DurationSource,
+		CreatedAt: reduction.CreatedAtSource,
+	}
+
+	diffs, truncated, err := compare(row.StoredReduction, reduction.Response, maxDiffs)
+	if err != nil {
+		out.Class = ClassUnreducible
+		out.Reason = err.Error()
+		return out
+	}
+	out.Diffs = diffs
+	out.DiffsTruncated = truncated
+	if len(diffs) == 0 {
+		out.Class = ClassEquivalent
+	} else {
+		out.Class = ClassDivergent
+	}
+	return out
+}
+
+// compare canonicalizes both reductions, removes the tolerated fields, and
+// returns the bounded structural difference between what remains.
+func compare(storedJSON json.RawMessage, recomputed *llm.ChatResponse, maxDiffs int) ([]FieldDiff, bool, error) {
+	recomputedJSON, err := json.Marshal(recomputed)
+	if err != nil {
+		return nil, false, err
+	}
+
+	storedTree, err := decodeCanonical(storedJSON)
+	if err != nil {
+		return nil, false, err
+	}
+	recomputedTree, err := decodeCanonical(recomputedJSON)
+	if err != nil {
+		return nil, false, err
+	}
+
+	for _, f := range TolerableFields {
+		prune(storedTree, f.Path)
+		prune(recomputedTree, f.Path)
+	}
+	// A usage object that held nothing but the pruned duration is an artifact
+	// of the pruning, not a difference: the adapter allocates Usage to carry
+	// the wall clock, and ingest allocates it for the same reason when it
+	// stamps. Dropping an emptied usage on both sides keeps that from
+	// surfacing as a spurious object-vs-absent divergence.
+	dropEmptyObject(storedTree, "usage")
+	dropEmptyObject(recomputedTree, "usage")
+
+	var diffs []FieldDiff
+	diffValues("", storedTree, recomputedTree, &diffs, maxDiffs)
+	return diffs, len(diffs) >= maxDiffs, nil
+}
+
+// dropEmptyObject removes key from a decoded object when its value is an
+// object with no remaining members.
+func dropEmptyObject(v any, key string) {
+	obj, ok := v.(map[string]any)
+	if !ok {
+		return
+	}
+	child, ok := obj[key].(map[string]any)
+	if ok && len(child) == 0 {
+		delete(obj, key)
+	}
+}

--- a/pkg/rawequiv/rawequiv_suite_test.go
+++ b/pkg/rawequiv/rawequiv_suite_test.go
@@ -1,0 +1,13 @@
+package rawequiv_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestRawEquiv(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "RawEquiv Suite")
+}

--- a/pkg/rawequiv/rawequiv_test.go
+++ b/pkg/rawequiv/rawequiv_test.go
@@ -1,0 +1,279 @@
+package rawequiv_test
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/papercomputeco/tapes/ingest"
+	"github.com/papercomputeco/tapes/pkg/rawequiv"
+)
+
+var _ = Describe("Raw-response equivalence", func() {
+	ctx := context.Background()
+	opts := rawequiv.Options{MaxDiffs: 10}
+
+	Describe("a dual-send turn whose bytes still reduce the same way", func() {
+		It("is equivalent for every committed recording", func() {
+			for _, rec := range loadRecordings() {
+				out := rawequiv.Check(ctx, rec.row(), opts)
+				Expect(out.Class).To(Equal(rawequiv.ClassEquivalent),
+					"%s: %s %s %v", rec.name, out.Class, out.Reason, out.Diffs)
+			}
+		})
+
+		It("reports which capture-side stamps mode=raw could restore", func() {
+			rec := loadRecordings()[0]
+			out := rawequiv.Check(ctx, rec.row(), opts)
+
+			Expect(out.Stamps).NotTo(BeNil())
+			// These recordings carry duration_ms and ts_request, so both
+			// stamps resolve from the envelope rather than falling back.
+			Expect(out.Stamps.Duration).To(Equal(ingest.StampSourceElapsed))
+			Expect(out.Stamps.CreatedAt).To(Equal(ingest.StampSourceTsRequest))
+		})
+
+		It("stays equivalent through a jsonb-style normalization of the stored side", func() {
+			// Postgres jsonb reorders keys, drops insignificant whitespace and
+			// renormalizes numbers. None of that is a reduction difference, so
+			// a comparison that reported it would be unusable against a real
+			// database. Re-encoding the stored side through a generic tree
+			// reproduces exactly those transformations.
+			rec := loadRecordings()[0]
+			row := rec.row()
+
+			var tree map[string]any
+			Expect(json.Unmarshal(row.StoredReduction, &tree)).To(Succeed())
+			reordered, err := json.Marshal(tree)
+			Expect(err).NotTo(HaveOccurred())
+			row.StoredReduction = reordered
+
+			Expect(rawequiv.Check(ctx, row, opts).Class).To(Equal(rawequiv.ClassEquivalent))
+		})
+
+		It("tolerates only the two documented time fields", func() {
+			Expect(rawequiv.TolerableFields).To(HaveLen(2))
+			names := []string{
+				rawequiv.TolerableFields[0].String(),
+				rawequiv.TolerableFields[1].String(),
+			}
+			Expect(names).To(ConsistOf("created_at", "usage.total_duration_ns"))
+			for _, f := range rawequiv.TolerableFields {
+				Expect(f.Why).NotTo(BeEmpty(), "%s needs a justification", f)
+			}
+		})
+	})
+
+	Describe("a genuinely divergent turn", func() {
+		It("is reported when the stored reduction lost a field the bytes carry", func() {
+			rec := loadRecordings()[0]
+			tree := storedTree(rec.row())
+			tree["stop_reason"] = "wrong_reason"
+
+			out := rawequiv.Check(ctx, withStored(rec.row(), tree), opts)
+
+			Expect(out.Class).To(Equal(rawequiv.ClassDivergent))
+			Expect(out.Diffs).NotTo(BeEmpty())
+
+			paths := make([]string, 0, len(out.Diffs))
+			for _, d := range out.Diffs {
+				paths = append(paths, d.Path)
+			}
+			Expect(paths).To(ContainElement("stop_reason"))
+		})
+
+		It("is reported when a content block is missing from the stored reduction", func() {
+			rec := loadRecordings()[0]
+			tree := storedTree(rec.row())
+
+			message, ok := tree["message"].(map[string]any)
+			Expect(ok).To(BeTrue())
+			content, ok := message["content"].([]any)
+			Expect(ok).To(BeTrue())
+			Expect(content).NotTo(BeEmpty())
+			message["content"] = content[:len(content)-1]
+
+			out := rawequiv.Check(ctx, withStored(rec.row(), tree), opts)
+
+			Expect(out.Class).To(Equal(rawequiv.ClassDivergent))
+			Expect(out.Diffs).To(ContainElement(HaveField("Kind", rawequiv.DiffLength)))
+		})
+
+		It("never prints message text, even when the text is what differs", func() {
+			const secret = "SUPER-SECRET-PROMPT-TEXT-THAT-MUST-NOT-LEAK"
+
+			rec := loadRecordings()[0]
+			tree := storedTree(rec.row())
+			message, ok := tree["message"].(map[string]any)
+			Expect(ok).To(BeTrue())
+			content, ok := message["content"].([]any)
+			Expect(ok).To(BeTrue())
+			Expect(content).NotTo(BeEmpty())
+
+			block, ok := content[0].(map[string]any)
+			Expect(ok).To(BeTrue())
+			block["text"] = secret
+
+			out := rawequiv.Check(ctx, withStored(rec.row(), tree), opts)
+			Expect(out.Class).To(Equal(rawequiv.ClassDivergent))
+
+			report := rawequiv.NewReport(rawequiv.Window{}, 10)
+			report.Add(out)
+
+			var text strings.Builder
+			report.WriteText(&text)
+			Expect(text.String()).NotTo(ContainSubstring(secret))
+			Expect(text.String()).To(ContainSubstring("message.content[0].text"))
+
+			machine, err := json.Marshal(report)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(machine)).NotTo(ContainSubstring(secret))
+		})
+
+		It("bounds the number of differences it records", func() {
+			rec := loadRecordings()[0]
+			tree := storedTree(rec.row())
+			// Replace the whole message so nearly everything under it differs.
+			tree["message"] = map[string]any{
+				"role": "system",
+				"content": []any{
+					map[string]any{"type": "text", "text": "a"},
+					map[string]any{"type": "text", "text": "b"},
+					map[string]any{"type": "text", "text": "c"},
+				},
+			}
+
+			out := rawequiv.Check(ctx, withStored(rec.row(), tree), rawequiv.Options{MaxDiffs: 2})
+			Expect(out.Class).To(Equal(rawequiv.ClassDivergent))
+			Expect(len(out.Diffs)).To(BeNumerically("<=", 2))
+			Expect(out.DiffsTruncated).To(BeTrue())
+		})
+	})
+
+	Describe("a turn whose stored bytes cannot be decoded", func() {
+		It("is classed undecodable rather than divergent", func() {
+			rec := loadRecordings()[0]
+			row := rec.row()
+			// brotli is not a supported encoding; the decoder errors rather
+			// than handing compressed bytes to a reducer expecting text.
+			row.RawResponseEncoding = "br"
+
+			out := rawequiv.Check(ctx, row, opts)
+
+			Expect(out.Class).To(Equal(rawequiv.ClassUndecodable))
+			Expect(out.Reason).To(ContainSubstring("br"))
+			Expect(out.Class.Blocking()).To(BeTrue(),
+				"an undecodable row would carry no reduction at all under mode=raw")
+		})
+
+		It("is classed undecodable when the bytes are corrupt for their encoding", func() {
+			rec := loadRecordings()[0]
+			row := rec.row()
+			row.RawResponse = []byte("this is not gzip")
+			row.RawResponseEncoding = "gzip"
+
+			Expect(rawequiv.Check(ctx, row, opts).Class).To(Equal(rawequiv.ClassUndecodable))
+		})
+	})
+
+	Describe("rows with nothing to compare", func() {
+		It("skips a turn whose verbatim bytes were withheld or dropped", func() {
+			rec := loadRecordings()[0]
+			row := rec.row()
+			// raw_response_dropped is set both when a producer withheld the
+			// bytes at the transport limit and when ingest dropped them over
+			// its storage cap. Either way the bytes are gone.
+			row.RawResponse = nil
+			row.RawResponseDropped = true
+
+			out := rawequiv.Check(ctx, row, opts)
+
+			Expect(out.Class).To(Equal(rawequiv.ClassSkippedDropped))
+			Expect(out.Class.Blocking()).To(BeFalse())
+			Expect(out.Stamps).To(BeNil(), "no reduction should have been attempted")
+		})
+
+		It("distinguishes a dropped turn from one that never carried bytes", func() {
+			rec := loadRecordings()[0]
+			row := rec.row()
+			row.RawResponse = nil
+
+			Expect(rawequiv.Check(ctx, row, opts).Class).To(Equal(rawequiv.ClassSkippedNoRaw))
+		})
+
+		It("skips a raw-only turn, which has no adapter reduction to compare", func() {
+			rec := loadRecordings()[0]
+			row := rec.row()
+			row.StoredReduction = nil
+
+			Expect(rawequiv.Check(ctx, row, opts).Class).To(Equal(rawequiv.ClassSkippedNoReduction))
+		})
+
+		It("reports a provider with no server-side reducer as blocking", func() {
+			rec := loadRecordings()[0]
+			row := rec.row()
+			row.Provider = "ollama"
+
+			out := rawequiv.Check(ctx, row, opts)
+
+			Expect(out.Class).To(Equal(rawequiv.ClassNoReducer))
+			Expect(out.Class.Blocking()).To(BeTrue(),
+				"mode=raw cannot serve a provider it cannot reduce")
+		})
+	})
+
+	Describe("the report", func() {
+		It("counts every examined row exactly once and gates on blocking rows", func() {
+			rec := loadRecordings()[0]
+
+			report := rawequiv.NewReport(rawequiv.Window{Limit: 4}, 10)
+			report.Add(rawequiv.Check(ctx, rec.row(), opts))
+
+			dropped := rec.row()
+			dropped.RawResponse = nil
+			dropped.RawResponseDropped = true
+			report.Add(rawequiv.Check(ctx, dropped, opts))
+
+			undecodable := rec.row()
+			undecodable.RawResponseEncoding = "br"
+			report.Add(rawequiv.Check(ctx, undecodable, opts))
+
+			Expect(report.Total).To(Equal(3))
+			Expect(report.Counts[rawequiv.ClassEquivalent]).To(Equal(1))
+			Expect(report.Counts[rawequiv.ClassSkippedDropped]).To(Equal(1))
+			Expect(report.Counts[rawequiv.ClassUndecodable]).To(Equal(1))
+			Expect(report.Blocking()).To(Equal(1))
+
+			total := 0
+			for _, n := range report.Counts {
+				total += n
+			}
+			Expect(total).To(Equal(report.Total), "classes must partition the rows")
+		})
+
+		It("says nothing was proven when the window held no comparable turns", func() {
+			rec := loadRecordings()[0]
+			row := rec.row()
+			row.RawResponse = nil
+
+			report := rawequiv.NewReport(rawequiv.Window{}, 10)
+			report.Add(rawequiv.Check(ctx, row, opts))
+
+			var text strings.Builder
+			report.WriteText(&text)
+			Expect(text.String()).To(ContainSubstring("Nothing was proven"))
+		})
+
+		It("carries its own definition of equivalence", func() {
+			report := rawequiv.NewReport(rawequiv.Window{}, 10)
+			var text strings.Builder
+			report.WriteText(&text)
+
+			Expect(text.String()).To(ContainSubstring("created_at"))
+			Expect(text.String()).To(ContainSubstring("usage.total_duration_ns"))
+		})
+	})
+})

--- a/pkg/rawequiv/rawequiv_test.go
+++ b/pkg/rawequiv/rawequiv_test.go
@@ -169,6 +169,26 @@ var _ = Describe("Raw-response equivalence", func() {
 				"an undecodable row would carry no reduction at all under mode=raw")
 		})
 
+		It("is classed unreducible when the meta block lost its content type", func() {
+			// The Anthropic reducer picks its streaming path from
+			// meta.content_type alone and does not sniff the body, so a row
+			// whose content type went missing reduces an SSE stream down the
+			// one-shot path, which cannot parse it.
+			//
+			// This is the sharpest edge on the road to mode=raw. Under dual
+			// the adapter's live reduction covers for it and the row looks
+			// perfect; under raw the same row would store no reduction at
+			// all. It has to surface as blocking, not as a skip.
+			rec := loadRecordings()[0]
+			row := rec.row()
+			row.Meta.ContentType = ""
+
+			out := rawequiv.Check(ctx, row, opts)
+
+			Expect(out.Class).To(Equal(rawequiv.ClassUnreducible))
+			Expect(out.Class.Blocking()).To(BeTrue())
+		})
+
 		It("is classed undecodable when the bytes are corrupt for their encoding", func() {
 			rec := loadRecordings()[0]
 			row := rec.row()

--- a/pkg/rawequiv/recordings_test.go
+++ b/pkg/rawequiv/recordings_test.go
@@ -1,0 +1,174 @@
+package rawequiv_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"time"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/papercomputeco/tapes/ingest"
+	"github.com/papercomputeco/tapes/pkg/capture"
+	"github.com/papercomputeco/tapes/pkg/llm"
+	"github.com/papercomputeco/tapes/pkg/rawequiv"
+)
+
+// The cases here are built from the committed L1 wire recordings rather than
+// from hand-written JSON, because the property under test is about real
+// provider framing: an SSE stream reduced two ways. A synthetic body would
+// exercise the comparison and prove nothing about the reduction.
+//
+// No new fixture files are added. Each recording is turned into the raw_turns
+// row it would have produced under dual-send — verbatim bytes in
+// raw_response, the adapter's live reduction in response — entirely in memory.
+
+// recordingMeta is the subset of a recording's meta.json these tests read.
+type recordingMeta struct {
+	Status          int     `json:"status"`
+	ContentType     string  `json:"content_type"`
+	ContentEncoding string  `json:"content_encoding"`
+	DurationMS      float64 `json:"duration_ms"`
+	TsRequest       string  `json:"ts_request"`
+	TsComplete      string  `json:"ts_complete"`
+}
+
+// recording is one committed turn bundle.
+type recording struct {
+	name string
+	resp []byte
+	meta recordingMeta
+}
+
+// recordingsDir resolves fixtures/recordings relative to this source file, so
+// the tests do not depend on the working directory.
+func recordingsDir() string {
+	_, file, _, ok := runtime.Caller(0)
+	Expect(ok).To(BeTrue(), "runtime.Caller failed")
+	return filepath.Join(filepath.Dir(file), "..", "..", "fixtures", "recordings")
+}
+
+// loadRecordings reads every committed turn bundle. It fails rather than skips
+// on an empty corpus: a silently empty corpus turns every spec below into a
+// vacuous pass, which is the failure mode a fixture-driven gate must not have.
+func loadRecordings() []recording {
+	root := recordingsDir()
+	sets, err := os.ReadDir(root)
+	Expect(err).NotTo(HaveOccurred(), "reading %s", root)
+
+	var out []recording
+	for _, set := range sets {
+		if !set.IsDir() {
+			continue
+		}
+		turns, err := os.ReadDir(filepath.Join(root, set.Name()))
+		Expect(err).NotTo(HaveOccurred())
+		for _, turn := range turns {
+			if !turn.IsDir() {
+				continue
+			}
+			dir := filepath.Join(root, set.Name(), turn.Name())
+
+			resp, err := os.ReadFile(filepath.Join(dir, "response.sse"))
+			if err != nil {
+				continue
+			}
+			metaRaw, err := os.ReadFile(filepath.Join(dir, "meta.json"))
+			Expect(err).NotTo(HaveOccurred())
+
+			var meta recordingMeta
+			Expect(json.Unmarshal(metaRaw, &meta)).To(Succeed())
+
+			out = append(out, recording{
+				name: set.Name() + "/" + turn.Name(),
+				resp: resp,
+				meta: meta,
+			})
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].name < out[j].name })
+	Expect(out).NotTo(BeEmpty(), "no wire recordings found under %s", root)
+	return out
+}
+
+// turnMeta builds the capture meta block the row would carry.
+func (r recording) turnMeta() ingest.TurnMeta {
+	return ingest.TurnMeta{
+		RequestID:       "fixture-" + r.name,
+		ContentType:     r.meta.ContentType,
+		ContentEncoding: r.meta.ContentEncoding,
+		Model:           "claude-sonnet-4-6",
+		ElapsedSeconds:  r.meta.DurationMS / 1000,
+		TsRequest:       r.meta.TsRequest,
+	}
+}
+
+// adapterReduction reproduces what a dual-send producer stores in
+// raw_turns.response: the shared reducer's output over the same bytes, plus
+// the two capture-side stamps only the live producer can take.
+//
+// It deliberately uses the same pkg/capture reducer the server side uses,
+// because that is the real deployment — extproc and ingest share the library.
+// What differs between the two paths, and what these specs exist to hold, is
+// everything around it: the storage round-trip, the encoding layer, and the
+// clock.
+func (r recording) adapterReduction() *llm.ChatResponse {
+	decoded, _, err := capture.DecodeContentEncoding(r.resp, r.meta.ContentEncoding)
+	Expect(err).NotTo(HaveOccurred(), "decoding %s", r.name)
+
+	resp, err := capture.NewAnthropicReducer().Reduce(
+		context.Background(), nil, bytes.NewReader(decoded), r.meta.ContentType)
+	Expect(err).NotTo(HaveOccurred(), "reducing %s", r.name)
+	Expect(resp).NotTo(BeNil())
+
+	// The producer measured the call and stamped its own clock. Both values
+	// are deliberately unlike anything a re-reduction could produce, so a
+	// spec that passes proves the tolerance is doing the work rather than the
+	// two sides coincidentally agreeing.
+	if resp.Usage == nil {
+		resp.Usage = &llm.Usage{}
+	}
+	resp.Usage.TotalDurationNs = int64(r.meta.DurationMS * float64(time.Millisecond))
+	if ts, err := time.Parse(time.RFC3339Nano, r.meta.TsComplete); err == nil {
+		resp.CreatedAt = ts.UTC()
+	}
+	return resp
+}
+
+// row assembles the raw_turns row this recording would have produced under
+// dual-send.
+func (r recording) row() rawequiv.Row {
+	stored, err := json.Marshal(r.adapterReduction())
+	Expect(err).NotTo(HaveOccurred())
+
+	return rawequiv.Row{
+		ID:                  1,
+		RequestID:           "fixture-" + r.name,
+		Provider:            capture.ProviderAnthropic,
+		HarnessID:           "claude-code",
+		HarnessSessionID:    "fixture-session",
+		RawResponse:         r.resp,
+		RawResponseEncoding: r.meta.ContentEncoding,
+		StoredReduction:     stored,
+		Meta:                r.turnMeta(),
+	}
+}
+
+// storedTree decodes a row's stored reduction for mutation.
+func storedTree(row rawequiv.Row) map[string]any {
+	var tree map[string]any
+	Expect(json.Unmarshal(row.StoredReduction, &tree)).To(Succeed())
+	return tree
+}
+
+// withStored re-encodes a mutated reduction back onto a row.
+func withStored(row rawequiv.Row, tree map[string]any) rawequiv.Row {
+	encoded, err := json.Marshal(tree)
+	Expect(err).NotTo(HaveOccurred())
+	row.StoredReduction = encoded
+	return row
+}

--- a/pkg/rawequiv/report.go
+++ b/pkg/rawequiv/report.go
@@ -1,0 +1,241 @@
+package rawequiv
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/papercomputeco/tapes/ingest"
+)
+
+// Report accumulates outcomes and renders the verdict.
+type Report struct {
+	// Window describes what was scanned, echoed back so a pasted report says
+	// what it covered.
+	Window Window `json:"window"`
+
+	// Counts is every class with a non-zero tally.
+	Counts map[Class]int `json:"counts"`
+
+	// Total is the number of rows examined.
+	Total int `json:"total"`
+
+	// Divergences holds the detail for blocking rows, bounded by MaxReported.
+	Divergences []Outcome `json:"divergences,omitempty"`
+
+	// DivergencesTruncated reports that more blocking rows existed than are
+	// listed. The counts stay exact regardless.
+	DivergencesTruncated bool `json:"divergences_truncated,omitempty"`
+
+	// StampCoverage counts, over rows that were actually re-reduced, which
+	// source would have supplied each capture-side stamp under mode=raw.
+	StampCoverage StampCoverageReport `json:"stamp_coverage"`
+
+	// Tolerated echoes the fields excluded from the comparison, so a report
+	// carries its own definition of equivalence rather than depending on the
+	// reader knowing it.
+	Tolerated []ToleratedNote `json:"tolerated"`
+
+	maxReported int
+}
+
+// Window records the scan parameters.
+type Window struct {
+	Since   string `json:"since,omitempty"`
+	Limit   int    `json:"limit,omitempty"`
+	Session string `json:"session,omitempty"`
+}
+
+// ToleratedNote is a serializable TolerableField.
+type ToleratedNote struct {
+	Field string `json:"field"`
+	Why   string `json:"why"`
+}
+
+// StampCoverageReport counts stamp sources across re-reduced rows.
+type StampCoverageReport struct {
+	Reduced   int                        `json:"reduced"`
+	Duration  map[ingest.StampSource]int `json:"duration"`
+	CreatedAt map[ingest.StampSource]int `json:"created_at"`
+}
+
+// NewReport creates an empty report. maxReported bounds how many blocking
+// outcomes are retained for detail; the counts are always exact.
+func NewReport(window Window, maxReported int) *Report {
+	notes := make([]ToleratedNote, 0, len(TolerableFields))
+	for _, f := range TolerableFields {
+		notes = append(notes, ToleratedNote{Field: f.String(), Why: f.Why})
+	}
+	return &Report{
+		Window: window,
+		Counts: map[Class]int{},
+		StampCoverage: StampCoverageReport{
+			Duration:  map[ingest.StampSource]int{},
+			CreatedAt: map[ingest.StampSource]int{},
+		},
+		Tolerated:   notes,
+		maxReported: maxReported,
+	}
+}
+
+// Add folds one outcome into the report.
+func (r *Report) Add(o Outcome) {
+	r.Total++
+	r.Counts[o.Class]++
+
+	if o.Stamps != nil {
+		r.StampCoverage.Reduced++
+		r.StampCoverage.Duration[o.Stamps.Duration]++
+		r.StampCoverage.CreatedAt[o.Stamps.CreatedAt]++
+	}
+
+	if !o.Class.Blocking() {
+		return
+	}
+	if len(r.Divergences) < r.maxReported {
+		r.Divergences = append(r.Divergences, o)
+		return
+	}
+	r.DivergencesTruncated = true
+}
+
+// Blocking reports the number of rows that fail the run.
+func (r *Report) Blocking() int {
+	n := 0
+	for class, count := range r.Counts {
+		if class.Blocking() {
+			n += count
+		}
+	}
+	return n
+}
+
+// classOrder fixes the reporting order so two runs read the same way.
+var classOrder = []Class{
+	ClassEquivalent,
+	ClassDivergent,
+	ClassUndecodable,
+	ClassUnreducible,
+	ClassNoReducer,
+	ClassSkippedNoRaw,
+	ClassSkippedDropped,
+	ClassSkippedNoReduction,
+}
+
+// WriteText renders the human-readable report.
+func (r *Report) WriteText(w io.Writer) {
+	fmt.Fprintf(w, "raw-response equivalence over %d wire turn(s)\n", r.Total)
+	if r.Window.Since != "" || r.Window.Session != "" || r.Window.Limit > 0 {
+		fmt.Fprintf(w, "  window: since=%s limit=%d session=%s\n",
+			orNone(r.Window.Since), r.Window.Limit, orNone(r.Window.Session))
+	}
+	fmt.Fprintln(w)
+
+	for _, class := range classOrder {
+		if n, ok := r.Counts[class]; ok && n > 0 {
+			fmt.Fprintf(w, "  %-22s %d\n", string(class), n)
+		}
+	}
+	fmt.Fprintln(w)
+
+	if r.StampCoverage.Reduced > 0 {
+		fmt.Fprintf(w, "capture-side stamps mode=raw could restore (%d re-reduced turn(s)):\n",
+			r.StampCoverage.Reduced)
+		fmt.Fprintf(w, "  usage.total_duration_ns  %s\n", renderSources(r.StampCoverage.Duration))
+		fmt.Fprintf(w, "  created_at               %s\n", renderSources(r.StampCoverage.CreatedAt))
+		if r.StampCoverage.Duration[ingest.StampSourceFallback] > 0 {
+			fmt.Fprintf(w, "  note: %d turn(s) carry no usable meta.elapsed_seconds; under mode=raw\n"+
+				"        their duration would land empty and the derived span duration NULL.\n",
+				r.StampCoverage.Duration[ingest.StampSourceFallback])
+		}
+		fmt.Fprintln(w)
+	}
+
+	if len(r.Divergences) > 0 {
+		fmt.Fprintln(w, "blocking rows:")
+		for _, o := range r.Divergences {
+			fmt.Fprintf(w, "\n  raw_turn %d  class=%s provider=%s harness=%s model=%s\n",
+				o.ID, o.Class, orNone(o.Provider), orNone(o.HarnessID), orNone(o.Model))
+			if o.RequestID != "" {
+				fmt.Fprintf(w, "    request_id: %s\n", o.RequestID)
+			}
+			if o.HarnessSessionID != "" {
+				fmt.Fprintf(w, "    session:    %s\n", o.HarnessSessionID)
+			}
+			if o.Truncated {
+				fmt.Fprintln(w, "    note:       stored body was truncated and salvaged;"+
+					" the adapter saw the whole stream live")
+			}
+			if o.Reason != "" {
+				fmt.Fprintf(w, "    reason:     %s\n", o.Reason)
+			}
+			for _, d := range o.Diffs {
+				fmt.Fprintf(w, "    %-28s %s\n", d.Path, describeDiff(d))
+			}
+			if o.DiffsTruncated {
+				fmt.Fprintln(w, "    (further differences omitted)")
+			}
+		}
+		if r.DivergencesTruncated {
+			fmt.Fprintf(w, "\n  (%d further blocking row(s) omitted; counts above are exact)\n",
+				r.Blocking()-len(r.Divergences))
+		}
+		fmt.Fprintln(w)
+	}
+
+	fmt.Fprintln(w, "equivalence excludes, by design:")
+	for _, t := range r.Tolerated {
+		fmt.Fprintf(w, "  %s\n", t.Field)
+	}
+	fmt.Fprintln(w)
+
+	if n := r.Blocking(); n > 0 {
+		fmt.Fprintf(w, "VERDICT: %d row(s) would not survive mode=raw. Do not ratchet.\n", n)
+		return
+	}
+	if r.Counts[ClassEquivalent] == 0 {
+		fmt.Fprintln(w, "VERDICT: no comparable turns in this window. Nothing was proven.")
+		return
+	}
+	fmt.Fprintf(w, "VERDICT: %d turn(s) re-reduce identically. This window supports the ratchet.\n",
+		r.Counts[ClassEquivalent])
+}
+
+// describeDiff renders one difference as a single line.
+func describeDiff(d FieldDiff) string {
+	switch d.Kind {
+	case DiffMissingInRecomputed:
+		return fmt.Sprintf("%s (stored %s, absent server-side)", d.Kind, d.Stored)
+	case DiffMissingInStored:
+		return fmt.Sprintf("%s (server-side %s, absent in stored)", d.Kind, d.Recomputed)
+	case DiffType, DiffValue, DiffLength:
+		return fmt.Sprintf("%s stored=%s server-side=%s", d.Kind, d.Stored, d.Recomputed)
+	default:
+		return fmt.Sprintf("%s stored=%s server-side=%s", d.Kind, d.Stored, d.Recomputed)
+	}
+}
+
+// renderSources renders a stamp-source tally in a stable order.
+func renderSources(m map[ingest.StampSource]int) string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, string(k))
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		parts = append(parts, fmt.Sprintf("%s=%d", k, m[ingest.StampSource(k)]))
+	}
+	if len(parts) == 0 {
+		return "none"
+	}
+	return strings.Join(parts, " ")
+}
+
+func orNone(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
+}


### PR DESCRIPTION
related to PCC-1088

Step 3 of the raw-response ratchet: `tapes raw equivalence`, the operator command that decides whether an environment may move from `dual` to `raw`.

**What it does:** for every wire turn in a window that stores both verbatim bytes and an adapter reduction, decode the bytes with the shared decoder, re-reduce them through **ingest's own mode=raw reduction path**, and compare structurally against the stored reduction. Summary partitions (equivalent / divergent / undecodable / blocked / skipped), bounded structural diffs that never print response content (path + type/length/hash, verbatim values only for an allowlisted provider vocabulary — content-safety is spec-asserted), `--json`, and a nonzero exit on anything that would make the flip unsafe.

**Why the first commit refactors ingest:** the server-side reduction was a `*Server` method that early-returns whenever a reduction already exists — i.e. on every dual row, exactly the rows the proof must run over. It's extracted as the pure function `ingest.ReduceStoredRawTurn` with one implementation and two callers; if the tool ran its own copy, the proof would be of the copy rather than of the code the flip enables. No behavior change (ingest's raw-response suite and extproc's equivalence test unchanged-green).

**Equivalence definition:** structural compare with exactly two tolerated fields, both pinned by test and both restored under raw only from producer metadata — `created_at` (reducers stamp reduction time by construction) and `usage.total_duration_ns` (proxy wall-clock, absent from provider bodies). Stamp coverage is reported separately from the verdict: an "equivalent" window can still lose every turn duration, and the report says so rather than hiding it in the pass.

**Findings that set the ratchet's exit criteria** (each classed and counted by the tool): a missing `meta.content_type` sends Anthropic SSE down the one-shot parse and stores *no reduction* under raw — invisible under dual, blocking under raw; ollama has no server-side reducer, so its traffic cannot ratchet; a failed server-side reduction is unrecoverable today (derive doesn't select `raw_response`); zstd rows remain unproven in production until the widened interlock ships and the environment runs ≥ this release.

Validated end-to-end against a migrated Postgres with seeded rows (17 equivalent / 1 divergent / 1 undecodable / 1 dropped → exit 1). Read-only by construction: its own pool with `default_transaction_read_only=on` (the standard storage drivers run migrations on open — a DDL write against a tenant DB). Docs in the mdBook CLI page.

Gates: `check-lint` 0 issues, `check-parity`, full test suite, `check-extproc`, vet, `mdbook build` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
