### PR TITLE
✨ feat: seal and publish the OpenAPI contracts

### DIFF
--- a/.dagger/contracts.go
+++ b/.dagger/contracts.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"dagger/tapes/internal/dagger"
+)
+
+// Contracts compiles both published OpenAPI documents and returns them as a
+// directory: tapes-api.yaml and tapes-ingest.yaml.
+//
+// These are the documents consumers vendor. Nothing in this repository reads
+// them, and they are not checked in — a contract file is a copy of what the
+// server already states, and a copy can go stale. What is checked in is the
+// fingerprint of each (api/CONTRACT, ingest/CONTRACT), which is a copy that
+// cannot go stale quietly because a spec recompiles and compares it.
+//
+// Prose is INCLUDED here, the opposite of what the seals cover. The two want
+// opposite things for the same reason: a seal should fire only when the shape
+// changes, so it excludes comments; a vendored document is read by a person
+// writing a client, so it carries every field's prose. `--docs-root .` is what
+// folds those comments in, and it needs a checkout — which is why this runs in
+// the source container rather than being something a released binary could do.
+//
+// The documents are CORE only. Neither is the aggregate a running server
+// publishes at /openapi, which is this document with each mounted cassette's
+// spec merged in and therefore a function of deployment rather than of release.
+func (t *Tapes) Contracts() *dagger.Directory {
+	return t.goContainer().
+		WithExec([]string{"mkdir", "-p", "/out"}).
+		WithExec([]string{
+			"go", "run", "./cli/tapes", "dev", "openapi", "api",
+			"--docs-root", ".", "--out", "/out/tapes-api.yaml",
+		}).
+		WithExec([]string{
+			"go", "run", "./cli/tapes", "dev", "openapi", "ingest",
+			"--docs-root", ".", "--out", "/out/tapes-ingest.yaml",
+		}).
+		Directory("/out")
+}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -95,6 +95,29 @@ jobs:
           BUCKET_SECRET_ACCESS_KEY: ${{ secrets.BUCKET_SECRET_ACCESS_KEY }}
           DAGGER_CLOUD_TOKEN: ${{ secrets.DAGGER_CLOUD_TOKEN }}
 
+      # The two published OpenAPI contracts, attached so a consumer can generate
+      # a client against a fixed release instead of against whatever a live
+      # server happens to be serving. Names are load-bearing: consumers fetch
+      # tapes-api-<tag>.yaml and tapes-ingest-<tag>.yaml by predictable name.
+      #
+      # These are the CORE compiled documents — the routes each server
+      # registers, with field prose folded in from this checkout. Neither is the
+      # runtime aggregate a server publishes at GET /openapi: that document has
+      # each mounted cassette's spec merged into it, which makes it a property
+      # of a deployment's cassettes rather than of this release, and it is not
+      # something a release asset can honestly stand in for.
+      #
+      # Exported outside build/ deliberately: the upload step below derives an
+      # os/arch suffix from each path under build/, and a contract has neither.
+      - name: Build API contracts
+        run: |
+          nix develop --command dagger call \
+            contracts \
+            export \
+              --path=./contracts
+        env:
+          DAGGER_CLOUD_TOKEN: ${{ secrets.DAGGER_CLOUD_TOKEN }}
+
       - name: Upload artifacts to release
         run: |
           mkdir -p dist
@@ -113,6 +136,10 @@ jobs:
 
             cp "$file" "dist/$new_name"
           done
+
+          tag="${{ github.event.release.tag_name }}"
+          cp contracts/tapes-api.yaml "dist/tapes-api-${tag}.yaml"
+          cp contracts/tapes-ingest.yaml "dist/tapes-ingest-${tag}.yaml"
 
           gh release upload "${{ github.event.release.tag_name }}" dist/*
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -137,9 +137,16 @@ jobs:
             cp "$file" "dist/$new_name"
           done
 
+          # A git tag may legally contain a slash (v1.0/rc1). Interpolated into
+          # a filename it reads as a directory that was never created, so the
+          # copy fails and takes the release with it. Flattened for the asset
+          # name only; the upload below still addresses the release by its real
+          # tag. This repo tags vX.Y.Z, where the substitution is a no-op — a
+          # consumer building the name from a version it knows is unaffected.
           tag="${{ github.event.release.tag_name }}"
-          cp contracts/tapes-api.yaml "dist/tapes-api-${tag}.yaml"
-          cp contracts/tapes-ingest.yaml "dist/tapes-ingest-${tag}.yaml"
+          asset_tag="${tag//\//-}"
+          cp contracts/tapes-api.yaml "dist/tapes-api-${asset_tag}.yaml"
+          cp contracts/tapes-ingest.yaml "dist/tapes-ingest-${asset_tag}.yaml"
 
           gh release upload "${{ github.event.release.tag_name }}" dist/*
         env:

--- a/api/CONTRACT
+++ b/api/CONTRACT
@@ -1,0 +1,16 @@
+# Seal for the read API's published OpenAPI contract.
+#
+# The value is CompiledDoc.Fingerprint() — sha256 over the rendered JSON — of
+# the CORE document compiled from this server's route registrations with no doc
+# comments folded in. That is what `tapes dev openapi api --docs-root ''`
+# renders. It is not what a running server serves at GET /openapi once
+# cassettes are mounted: that document is the core one with each mounted
+# cassette's spec merged into it, and it changes as cassettes come and go.
+#
+# Prose is deliberately excluded so that editing a doc comment is not a
+# contract event. Everything a generated client is built from — paths,
+# operations, parameters, schemas, status codes — is included.
+#
+# api/openapi_seal_test.go recompiles and compares. If it fails, it prints the
+# value to write here. Bump it in the same change that moved the contract.
+sha256:c966a65a6c3ab126a908e9a7db55905323686e50077441f52f5675752c9ff8ea

--- a/api/openapi_seal_test.go
+++ b/api/openapi_seal_test.go
@@ -1,0 +1,93 @@
+package api
+
+// Seal gate for the read API's published contract. The rule and its rendering
+// live in internal/openapicheck; this file supplies only what is specific to
+// this server — how to compile it and where its seal is kept.
+//
+// The coverage gate next door proves the contract describes what the server
+// serves. It cannot notice a change: it compares the document against the
+// routes it was compiled from, so a rename that breaks every generated client
+// keeps it green. This notices.
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/papercomputeco/tapes/internal/openapicheck"
+	"github.com/papercomputeco/tapes/pkg/tapesoapi/gosource"
+)
+
+var _ = Describe("OpenAPI contract seal", func() {
+	It("matches the fingerprint recorded in api/CONTRACT", func(ctx SpecContext) {
+		// nil docs is the whole point: this compiles the prose-stripped
+		// document, so the seal moves for a route or schema change and stays
+		// put for a doc-comment edit.
+		compiled, err := CompileOpenAPI(ctx, nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		contents, err := os.ReadFile("CONTRACT")
+		Expect(err).NotTo(HaveOccurred(),
+			"api/CONTRACT is missing; it seals the document every generated client is built from")
+
+		res := openapicheck.CheckSeal("api", "api/CONTRACT", contents, compiled)
+		Expect(res.OK()).To(BeTrue(), res.Explain())
+	})
+
+	It("compiles the same fingerprint twice", func(ctx SpecContext) {
+		// A fingerprint that varied between runs would make the seal a flake
+		// and get it deleted. Map iteration order is the way that happens, and
+		// it is not visible from a single compile.
+		first, err := CompileOpenAPI(ctx, nil)
+		Expect(err).NotTo(HaveOccurred())
+		second, err := CompileOpenAPI(ctx, nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(second.Fingerprint()).To(Equal(first.Fingerprint()))
+	})
+
+	It("seals the stripped document, not the documented one", func(ctx SpecContext) {
+		// Guards the plausible wrong fix. `make contracts` and `tapes dev
+		// openapi` both default to prose INCLUDED, so someone bumping this
+		// seal has a documented fingerprint close at hand; pasting that one
+		// would silently retarget the gate at a value that moves whenever a
+		// comment is edited. Asserting the two differ keeps that mistake from
+		// passing.
+		docs, err := gosource.Load(moduleRoot(),
+			gosource.SkipDirs("oapi-reference", "build", "migrations"))
+		Expect(err).NotTo(HaveOccurred())
+
+		documented, err := CompileOpenAPI(ctx, docs)
+		Expect(err).NotTo(HaveOccurred())
+		stripped, err := CompileOpenAPI(ctx, nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(documented.Fingerprint()).NotTo(Equal(stripped.Fingerprint()),
+			"folding in doc comments changed nothing, so this spec is no longer proving "+
+				"the seal is the stripped document; check that gosource still reads this module")
+
+		contents, err := os.ReadFile("CONTRACT")
+		Expect(err).NotTo(HaveOccurred())
+		sealed, err := openapicheck.ParseSeal(contents)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(sealed).NotTo(Equal(documented.Fingerprint()),
+			"api/CONTRACT holds the documented fingerprint. It must hold the prose-stripped "+
+				"one, or every doc-comment edit becomes a contract change: recompile with "+
+				"`tapes dev openapi api --docs-root ''` and seal that value instead")
+	})
+})
+
+// moduleRoot locates the checkout so the doc reader can walk it, without
+// depending on the working directory a test binary happens to be run from.
+func moduleRoot() string {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		panic("runtime.Caller failed")
+	}
+
+	return filepath.Join(filepath.Dir(file), "..")
+}

--- a/ingest/CONTRACT
+++ b/ingest/CONTRACT
@@ -1,0 +1,19 @@
+# Seal for the ingest write surface's published OpenAPI contract.
+#
+# The value is CompiledDoc.Fingerprint() — sha256 over the rendered JSON — of
+# the document compiled from this server's route registrations with no doc
+# comments folded in. That is what `tapes dev openapi ingest --docs-root ''`
+# renders.
+#
+# Prose is deliberately excluded so that editing a doc comment is not a
+# contract event. Everything a capture adapter is built against — the envelope
+# schema, its required fields, the accepted status codes — is included.
+#
+# This surface is the one every capture adapter writes through, in this repo
+# and in others (tapes-extproc, tapesctl, paperd). A change to it that lands
+# unannounced is a change those adapters discover in production, which is why
+# it is sealed rather than merely covered.
+#
+# ingest/openapi_seal_test.go recompiles and compares. If it fails, it prints
+# the value to write here. Bump it in the same change that moved the contract.
+sha256:b51bebaecb5e0942cd2fba11d694126e36c6a4e33088a77b8171eb8c3acecfb7

--- a/ingest/openapi_seal_test.go
+++ b/ingest/openapi_seal_test.go
@@ -1,0 +1,95 @@
+package ingest_test
+
+// Seal gate for the ingest write surface's published contract. The rule and
+// its rendering live in internal/openapicheck; this file supplies only what is
+// specific to this server — how to compile it and where its seal is kept.
+//
+// This surface matters more than the read API's for the same reason it is
+// harder to notice breaking: its clients are capture adapters in other
+// repositories (tapes-extproc, tapesctl, paperd), none of which are built by
+// this repo's CI. A field that changes name here compiles fine, passes the
+// coverage gate, and surfaces as turns that stop being captured.
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/papercomputeco/tapes/ingest"
+	"github.com/papercomputeco/tapes/internal/openapicheck"
+	"github.com/papercomputeco/tapes/pkg/tapesoapi/gosource"
+)
+
+var _ = Describe("OpenAPI contract seal", func() {
+	It("matches the fingerprint recorded in ingest/CONTRACT", func(ctx SpecContext) {
+		// nil docs is the whole point: this compiles the prose-stripped
+		// document, so the seal moves for a route or schema change and stays
+		// put for a doc-comment edit.
+		compiled, err := ingest.CompileOpenAPI(ctx, nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		contents, err := os.ReadFile("CONTRACT")
+		Expect(err).NotTo(HaveOccurred(),
+			"ingest/CONTRACT is missing; it seals the envelope every capture adapter writes")
+
+		res := openapicheck.CheckSeal("ingest", "ingest/CONTRACT", contents, compiled)
+		Expect(res.OK()).To(BeTrue(), res.Explain())
+	})
+
+	It("compiles the same fingerprint twice", func(ctx SpecContext) {
+		// A fingerprint that varied between runs would make the seal a flake
+		// and get it deleted. Map iteration order is the way that happens, and
+		// it is not visible from a single compile.
+		first, err := ingest.CompileOpenAPI(ctx, nil)
+		Expect(err).NotTo(HaveOccurred())
+		second, err := ingest.CompileOpenAPI(ctx, nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(second.Fingerprint()).To(Equal(first.Fingerprint()))
+	})
+
+	It("seals the stripped document, not the documented one", func(ctx SpecContext) {
+		// Guards the plausible wrong fix. `make contracts` and `tapes dev
+		// openapi` both default to prose INCLUDED, so someone bumping this
+		// seal has a documented fingerprint close at hand; pasting that one
+		// would silently retarget the gate at a value that moves whenever a
+		// comment is edited. Asserting the two differ keeps that mistake from
+		// passing.
+		docs, err := gosource.Load(moduleRoot(),
+			gosource.SkipDirs("oapi-reference", "build", "migrations"))
+		Expect(err).NotTo(HaveOccurred())
+
+		documented, err := ingest.CompileOpenAPI(ctx, docs)
+		Expect(err).NotTo(HaveOccurred())
+		stripped, err := ingest.CompileOpenAPI(ctx, nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(documented.Fingerprint()).NotTo(Equal(stripped.Fingerprint()),
+			"folding in doc comments changed nothing, so this spec is no longer proving "+
+				"the seal is the stripped document; check that gosource still reads this module")
+
+		contents, err := os.ReadFile("CONTRACT")
+		Expect(err).NotTo(HaveOccurred())
+		sealed, err := openapicheck.ParseSeal(contents)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(sealed).NotTo(Equal(documented.Fingerprint()),
+			"ingest/CONTRACT holds the documented fingerprint. It must hold the prose-stripped "+
+				"one, or every doc-comment edit becomes a contract change: recompile with "+
+				"`tapes dev openapi ingest --docs-root ''` and seal that value instead")
+	})
+})
+
+// moduleRoot locates the checkout so the doc reader can walk it, without
+// depending on the working directory a test binary happens to be run from.
+func moduleRoot() string {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		panic("runtime.Caller failed")
+	}
+
+	return filepath.Join(filepath.Dir(file), "..")
+}

--- a/internal/openapicheck/seal.go
+++ b/internal/openapicheck/seal.go
@@ -1,0 +1,154 @@
+package openapicheck
+
+// Contract seals.
+//
+// The coverage check in this package answers "does the contract describe the
+// surface the server serves". It cannot answer "did the contract change",
+// because it compares the document against the routes it was compiled from —
+// both move together, and a rename that alters every consumer's generated
+// client leaves coverage perfectly green.
+//
+// A seal answers that second question. Each surface commits the fingerprint of
+// its compiled document to a CONTRACT file next to the server that publishes
+// it, and a spec recompiles and compares. A change to a route, a schema, a
+// status code or a field name moves the fingerprint and fails until someone
+// writes the new value in — which turns "this pull request changes a published
+// contract" from something a reviewer has to infer out of a diff into a
+// one-line diff that says so.
+//
+// What is sealed is the PROSE-STRIPPED document: compiled with nil TypeDocs,
+// the same thing `tapes dev openapi --docs-root ''` renders and the same thing
+// a deployed binary serves, since it has no source tree to read comments from.
+// Sealing the documented document instead would make every doc-comment edit a
+// contract event, and a gate that fires on prose is a gate that gets bumped
+// without being read. The published artifacts under `make contracts` are the
+// opposite choice for the opposite reason: consumers reading a vendored
+// document want the field prose, and nothing gates those bytes.
+//
+// The rule lives here for the reason the coverage rule does — two servers, one
+// rule, and no second copy to drift.
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/papercomputeco/tapes/pkg/tapesoapi"
+)
+
+// SealResult reports whether a compiled contract still matches its seal.
+type SealResult struct {
+	// Surface names the contract, as a developer refers to it: "api", "ingest".
+	Surface string
+
+	// Path is the CONTRACT file, relative to the repository root, for the
+	// failure message to name.
+	Path string
+
+	// Sealed is the fingerprint the CONTRACT file records. Empty when the file
+	// could not be understood, in which case Problem says why.
+	Sealed string
+
+	// Compiled is the fingerprint recompiling the surface just produced.
+	Compiled string
+
+	// Problem describes an unreadable CONTRACT file. Empty when the file
+	// parsed, whether or not the two fingerprints agree.
+	Problem string
+}
+
+// OK reports whether the seal still describes the compiled contract.
+func (r SealResult) OK() bool {
+	return r.Problem == "" && r.Sealed == r.Compiled
+}
+
+// CheckSeal compares a compiled document against the contents of its CONTRACT
+// file.
+//
+// It takes the file's bytes rather than its path so that the caller owns the
+// read: a spec that reads the file itself can say "this file is missing" in its
+// own voice, and this package stays free of filesystem access.
+func CheckSeal(surface, path string, contents []byte, compiled *tapesoapi.CompiledDoc) SealResult {
+	res := SealResult{Surface: surface, Path: path, Compiled: compiled.Fingerprint()}
+
+	sealed, err := ParseSeal(contents)
+	if err != nil {
+		res.Problem = err.Error()
+
+		return res
+	}
+	res.Sealed = sealed
+
+	return res
+}
+
+// ParseSeal reads the fingerprint out of a CONTRACT file.
+//
+// The format is one fingerprint, with `#` comment lines and blank lines
+// ignored. The comments are why this is not just a bare line the way
+// fixtures/envelope/DIGEST is: a CONTRACT file is the first thing a developer
+// opens after the gate fails, and it should be able to say what it seals
+// without them going to find the spec that reads it. Everything else about it
+// is deliberately the same — one line, so a deliberate bump is a one-line diff
+// a reviewer cannot miss.
+func ParseSeal(contents []byte) (string, error) {
+	var found []string
+	for line := range strings.SplitSeq(string(contents), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		found = append(found, line)
+	}
+
+	switch {
+	case len(found) == 0:
+		return "", fmt.Errorf("no fingerprint found; expected one %q line", "sha256:...")
+	case len(found) > 1:
+		return "", fmt.Errorf("found %d fingerprints; expected exactly one", len(found))
+	case !strings.HasPrefix(found[0], "sha256:"):
+		return "", fmt.Errorf("fingerprint %q does not start with %q", found[0], "sha256:")
+	}
+
+	return found[0], nil
+}
+
+// Explain renders a failed seal as instructions. Empty when the seal holds.
+//
+// The new fingerprint goes in the message so that a legitimate contract change
+// is a copy-paste rather than a hunt for the command that prints it. A gate
+// nobody can satisfy quickly is a gate someone deletes.
+func (r SealResult) Explain() string {
+	if r.OK() {
+		return ""
+	}
+
+	var b strings.Builder
+	if r.Problem != "" {
+		fmt.Fprintf(&b, "\n%s could not be read: %s\n", r.Path, r.Problem)
+	} else {
+		fmt.Fprintf(&b, "\nthe %s contract no longer matches %s.\n\n", r.Surface, r.Path)
+		fmt.Fprintf(&b, "  sealed:   %s\n", r.Sealed)
+		fmt.Fprintf(&b, "  compiled: %s\n", r.Compiled)
+	}
+
+	fmt.Fprintf(&b, `
+This fingerprint covers the prose-stripped document — the routes, schemas,
+parameters and responses the %s server registers. Doc comments are not in it,
+so a comment edit cannot have caused this: something about the published shape
+moved.
+
+If you changed the %s contract on purpose, write this line into %s:
+
+    %s
+
+Bump it in the same change that moved the contract, never as a follow-up: the
+seal is the record that a reviewer was told the surface changed, and a bump
+that arrives separately is a change nobody was asked about.
+
+To see what moved, render both documents and diff them:
+
+    make contracts   # writes build/contracts/tapes-{api,ingest}.yaml
+`, r.Surface, r.Surface, r.Path, r.Compiled)
+
+	return b.String()
+}

--- a/makefile
+++ b/makefile
@@ -36,15 +36,20 @@ format: ## Runs golangci-lint linters and formatters with auto-fixes applied.
 	$(call print-target)
 	dagger call fix-lint export --path . --quiet
 
-# There is no openapi target. tapes publishes two contracts — the read API and
-# the ingest write surface are different servers with different trust models,
-# see the header of ingest/openapi.go — and each server compiles its own from
-# the routes it registered and serves it at GET /openapi. Nothing is generated,
-# so nothing can be stale, so there is nothing to check.
+# tapes publishes two contracts — the read API and the ingest write surface are
+# different servers with different trust models, see the header of
+# ingest/openapi.go — and each server compiles its own from the routes it
+# registered and serves it at GET /openapi. Neither is generated into a checked-in
+# file, so neither can be stale, so there is nothing to regenerate or verify.
 #
-# `tapes dev openapi [api|ingest]` prints the same document with per-field prose
-# folded in from a checkout, for consumers that want bytes on disk. Its output
-# is not read by anything here and is not checked in.
+# `contracts` below writes the documents themselves, with per-field prose folded
+# in from a checkout, for consumers that want bytes on disk. Still not checked
+# in, and still read by nothing here.
+
+.PHONY: contracts
+contracts: ## Compiles both published OpenAPI contracts into ./build/contracts
+	$(call print-target)
+	dagger call contracts export --path ./build/contracts
 
 .PHONY: generate
 generate: ## Regenerates sqlc queries

--- a/makefile
+++ b/makefile
@@ -42,6 +42,14 @@ format: ## Runs golangci-lint linters and formatters with auto-fixes applied.
 # registered and serves it at GET /openapi. Neither is generated into a checked-in
 # file, so neither can be stale, so there is nothing to regenerate or verify.
 #
+# What IS checked in is a fingerprint per surface: api/CONTRACT and
+# ingest/CONTRACT. Those are not copies of the document, they are copies of its
+# identity, and the specs beside them recompile and compare on every run — so a
+# change to a published contract fails until someone writes the new value in,
+# which turns "this changes a contract" into a line in the diff rather than
+# something a reviewer has to infer. They seal the PROSE-STRIPPED document, so a
+# doc-comment edit is not a contract event.
+#
 # `contracts` below writes the documents themselves, with per-field prose folded
 # in from a checkout, for consumers that want bytes on disk. Still not checked
 # in, and still read by nothing here.


### PR DESCRIPTION
related to PCC-1065

Stage S1 of the client-generation track: seal the published OpenAPI contracts so generated clients have a stable, reviewable upstream.

- `api/CONTRACT` + `ingest/CONTRACT` record the **prose-stripped** `Fingerprint()` (the exact document a deployed binary serves — doc-comment prose requires a source tree and is excluded; Go-value prose is always present). Ginkgo gates in both packages fail with copy-paste bump instructions when the published shape moves; a third spec per package pins that CONTRACT does *not* hold the prose-included fingerprint, which is the plausible wrong paste.
- Seal bumps must ride the change that moved the contract — the seal is the record that a reviewer was told the surface changed.
- `make contracts` (via a new dagger `contracts` function) writes both prose-included YAMLs to `build/contracts/`; output proven byte-identical between macOS-local and linux-container compiles.
- Release workflow attaches `tapes-api-<tag>.yaml` / `tapes-ingest-<tag>.yaml` as assets — the CORE compiled documents, not the runtime aggregate (a running server's `/openapi` merges mounted cassette specs, which is a property of a deployment).

Gates: build/vet/lint/full test suite/parity green; tamper run proves the seal fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
