### PR TITLE
:wrench: fix: re-seal the read API contract, and say what moves it

### DIFF
--- a/api/CONTRACT
+++ b/api/CONTRACT
@@ -13,4 +13,4 @@
 #
 # api/openapi_seal_test.go recompiles and compares. If it fails, it prints the
 # value to write here. Bump it in the same change that moved the contract.
-sha256:c966a65a6c3ab126a908e9a7db55905323686e50077441f52f5675752c9ff8ea
+sha256:26755fe576fbd4a9eb57639472a00e8ca1f9de7be1e27296bd85975add46e9c8

--- a/internal/openapicheck/seal.go
+++ b/internal/openapicheck/seal.go
@@ -133,9 +133,10 @@ func (r SealResult) Explain() string {
 
 	fmt.Fprintf(&b, `
 This fingerprint covers the prose-stripped document — the routes, schemas,
-parameters and responses the %s server registers. Doc comments are not in it,
-so a comment edit cannot have caused this: something about the published shape
-moved.
+parameters and responses the %s server registers. Doc comments folded in from a
+docs root are not in it, so editing one cannot have caused this. Text declared
+inline on a registration — a Summary or a Description — is in it, and is the
+likeliest cause of a move that touches no route, schema or status code.
 
 If you changed the %s contract on purpose, write this line into %s:
 


### PR DESCRIPTION
`main` has been failing its own test suite since the MCP cassette merge. Four changes have
landed on top of it, and every PR opened since inherits a red check that has nothing to do
with the change under review — which is how a seal stops being read.

## What moved

The seal compares the compiled contract against `api/CONTRACT`. Rendering the document at
the last green commit and at `main`, the whole delta is **48 bytes on one line**: the
`description` declared inline on the `POST /v1/mcp` registration. No route, schema,
parameter, response or status code changed.

That description is published surface — a generated client embeds it — so the fingerprint
moved correctly and by design. What did not arrive is the matching bump. The seal's own
documentation is explicit that it has to: the value of a seal is that it is the record a
reviewer was shown the surface changing, and a bump landing separately is a change nobody
was asked about. This one is landing separately, which is worse than landing with it, and
better than main staying red.

## And the message that pointed the wrong way

> Doc comments are not in it, so a comment edit cannot have caused this: something about
> the published shape moved.

Literally true, and read naturally it says *go find the route or schema that changed*.
There wasn't one. Prose folded in from a docs root is excluded; text declared **inline on a
registration** — a `Summary` or a `Description` — is not, and is the likeliest cause of a
move that touches no structure at all.

That sentence is what made a one-line prose change expensive to diagnose, so it is fixed
here too. It now separates the two kinds of prose and names the one that is in the
fingerprint.

## Worth a follow-up

Nothing stops this recurring: the seal is enforced by a test on a branch that was already
red. Once `main` is green it is worth deciding whether the seal should be a required check,
so a stale one cannot merge in the first place.

fixes PCC-1138
