### PR TITLE
✨ feat(extproc): observe request sizes before the gRPC boundary and export build info

### DIFF
--- a/api/sessions_export_all_handlers_test.go
+++ b/api/sessions_export_all_handlers_test.go
@@ -129,7 +129,9 @@ func newPagingDriver(org string, n int, latest time.Time) *pagingExportStubDrive
 var _ = Describe("GET /v1/sessions/export", func() {
 	// Reads are scoped to the single tenant, so seeded data must live there.
 	const org = singleTenantOrgID
-	now := time.Date(2026, 7, 8, 12, 0, 0, 0, time.UTC)
+	// Relative to the wall clock: the handler clamps its window to
+	// time.Now()-30d, so a pinned calendar date ages out of range.
+	now := time.Now().UTC().Truncate(time.Second)
 
 	// T-7: default window (no since/until) + bypasses the 200-row UI cap.
 	It("streams every session in the default 30-day window, past the 200-row cap", func() {

--- a/cli/tapes-extproc/main.go
+++ b/cli/tapes-extproc/main.go
@@ -25,6 +25,7 @@ import (
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 
 	"github.com/papercomputeco/tapes/extproc"
+	"github.com/papercomputeco/tapes/pkg/utils"
 )
 
 func main() {
@@ -36,6 +37,8 @@ func main() {
 	slog.SetDefault(logger)
 
 	slog.Info("Starting tapes-extproc",
+		"version", utils.Version,
+		"commit", utils.Sha,
 		"listen_addr", cfg.ListenAddr,
 		"metrics_addr", cfg.MetricsAddr,
 		"ingest_url", cfg.IngestURL,
@@ -48,6 +51,9 @@ func main() {
 		slog.Error("Failed to create processor", "error", err)
 		os.Exit(1)
 	}
+	// utils.Version/utils.Sha are stamped by the image build's ldflags
+	// (releaseLDFlags in .dagger/build.go); "dev"/"HEAD" mean an unstamped build.
+	processor.Metrics().SetBuildInfo(utils.Version, utils.Sha)
 
 	// gRPC server.
 	grpcServer := grpc.NewServer()

--- a/extproc/headers/headers.go
+++ b/extproc/headers/headers.go
@@ -48,6 +48,13 @@ const (
 	// must be undone before captured bytes reach parsing or ingest.
 	// If a new encoding shows up, this is the single read site to audit.
 	ContentEncoding = "content-encoding"
+
+	// ContentLength feeds pre-boundary request-size observation.
+	// Envoy always delivers request headers, even when the body is
+	// later rejected at the gRPC recv limit — so the declared length
+	// read here at the headers phase is the only size signal that
+	// covers requests too large to ever reach a body-phase callback.
+	ContentLength = "content-length"
 )
 
 // Extension headers (x-*) used by adjacent components.

--- a/extproc/metrics.go
+++ b/extproc/metrics.go
@@ -28,6 +28,14 @@ import (
 // observability knob wearing a policy's shape.
 const DefaultLargeTurnThreshold = 4 * 1024 * 1024
 
+// bodySizeBuckets is the single bucket scheme shared by every body-size
+// histogram (tapes_extproc_body_bytes, tapes_extproc_body_bytes_by_outcome,
+// tapes_extproc_request_content_length_bytes): 256 B → 64 MiB across 14
+// buckets. 64 MiB tops the 32 MB Anthropic Messages contract plus
+// gRPC/framing headroom; defining it once keeps the histograms comparable
+// bucket-for-bucket in PromQL. Do not fork per-histogram copies.
+var bodySizeBuckets = prometheus.ExponentialBucketsRange(256, 64*1024*1024, 14)
+
 // Recurring label values. These are wire-visible: they appear verbatim in the
 // Prometheus label set and in the dispatched envelope, so every dashboard,
 // alert and downstream consumer reads these exact strings. Naming them keeps
@@ -78,6 +86,9 @@ type Metrics struct {
 	bodyBytesByOutcome *prometheus.HistogramVec
 	dispatchSeconds    *prometheus.HistogramVec
 	inflight           prometheus.Gauge
+
+	requestContentLength        *prometheus.HistogramVec
+	requestContentLengthUnknown *prometheus.CounterVec
 
 	largeTurnThreshold int
 }
@@ -195,7 +206,7 @@ func NewMetrics() *Metrics {
 			prometheus.HistogramOpts{
 				Name:    "tapes_extproc_body_bytes",
 				Help:    "Accumulated body size at EndOfStream, by provider and side.",
-				Buckets: prometheus.ExponentialBucketsRange(256, 16*1024*1024, 12),
+				Buckets: bodySizeBuckets,
 			},
 			[]string{"provider", "side"},
 		),
@@ -203,7 +214,7 @@ func NewMetrics() *Metrics {
 			prometheus.HistogramOpts{
 				Name:    "tapes_extproc_body_bytes_by_outcome",
 				Help:    "Accumulated request/response body size by terminal outcome. Use this to compare failed and captured turn sizes without relying on success-only body_bytes.",
-				Buckets: prometheus.ExponentialBucketsRange(256, 16*1024*1024, 12),
+				Buckets: bodySizeBuckets,
 			},
 			[]string{"provider", "side", "outcome", "reason"},
 		),
@@ -219,8 +230,23 @@ func NewMetrics() *Metrics {
 			Name: "tapes_extproc_inflight_dispatches",
 			Help: "Number of dispatches currently awaiting completion.",
 		}),
+		requestContentLength: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Name:    "tapes_extproc_request_content_length_bytes",
+				Help:    "Request Content-Length as observed at the request-headers phase, before any body message can be rejected at the gRPC recv boundary — so >4 MiB requests that never survive the body phase are still sized here. Absent or unparseable Content-Length is never observed (not even as 0); those requests are counted in tapes_extproc_request_content_length_unknown_total instead.",
+				Buckets: bodySizeBuckets,
+			},
+			[]string{"provider"},
+		),
+		requestContentLengthUnknown: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "tapes_extproc_request_content_length_unknown_total",
+				Help: "Requests whose Content-Length header was absent or unparseable at the request-headers phase (e.g. chunked/streaming clients). These requests make no observation in tapes_extproc_request_content_length_bytes, so this counter measures exactly the population that histogram cannot see.",
+			},
+			[]string{"provider"},
+		),
 	}
-	reg.MustRegister(m.captured, m.terminal, m.largeTurns, m.dropped, m.reducerEmpty, m.responseDecoded, m.responseSalvaged, m.rawAttached, m.rawSkipped, m.rawFallback, m.sseChunks, m.turnDuration, m.terminalDuration, m.bodyBytes, m.bodyBytesByOutcome, m.dispatchSeconds, m.inflight)
+	reg.MustRegister(m.captured, m.terminal, m.largeTurns, m.dropped, m.reducerEmpty, m.responseDecoded, m.responseSalvaged, m.rawAttached, m.rawSkipped, m.rawFallback, m.sseChunks, m.turnDuration, m.terminalDuration, m.bodyBytes, m.bodyBytesByOutcome, m.dispatchSeconds, m.inflight, m.requestContentLength, m.requestContentLengthUnknown)
 	m.largeTurnThreshold = DefaultLargeTurnThreshold
 
 	// Pre-create a zero row for every known drop reason × every provider we
@@ -548,6 +574,21 @@ func (m *Metrics) ObserveBodyBytes(provider, side string, bytes int) {
 		provider = labelUnknown
 	}
 	m.bodyBytes.WithLabelValues(provider, side).Observe(float64(bytes))
+}
+
+// ObserveRequestContentLength records a parsed request Content-Length at the
+// request-headers phase. Callers must only pass successfully parsed values;
+// absent/unparseable headers go through ObserveRequestContentLengthUnknown
+// instead so the histogram's low buckets are never corrupted by zero stand-ins.
+func (m *Metrics) ObserveRequestContentLength(provider string, bytes int64) {
+	m.requestContentLength.WithLabelValues(normalizeProvider(provider)).Observe(float64(bytes))
+}
+
+// ObserveRequestContentLengthUnknown counts a request whose Content-Length was
+// absent or unparseable at the request-headers phase. Increments only the
+// unknown counter — never the content-length histogram.
+func (m *Metrics) ObserveRequestContentLengthUnknown(provider string) {
+	m.requestContentLengthUnknown.WithLabelValues(normalizeProvider(provider)).Inc()
 }
 
 // ObserveDispatchLatency records the HTTP POST roundtrip to ingest.

--- a/extproc/metrics.go
+++ b/extproc/metrics.go
@@ -90,6 +90,8 @@ type Metrics struct {
 	requestContentLength        *prometheus.HistogramVec
 	requestContentLengthUnknown *prometheus.CounterVec
 
+	buildInfo *prometheus.GaugeVec
+
 	largeTurnThreshold int
 }
 
@@ -245,8 +247,15 @@ func NewMetrics() *Metrics {
 			},
 			[]string{"provider"},
 		),
+		buildInfo: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "tapes_extproc_build_info",
+				Help: "Build metadata for the running binary. Value is always 1 so other metrics can be joined onto version and commit with a group_left on this series.",
+			},
+			[]string{"version", "commit"},
+		),
 	}
-	reg.MustRegister(m.captured, m.terminal, m.largeTurns, m.dropped, m.reducerEmpty, m.responseDecoded, m.responseSalvaged, m.rawAttached, m.rawSkipped, m.rawFallback, m.sseChunks, m.turnDuration, m.terminalDuration, m.bodyBytes, m.bodyBytesByOutcome, m.dispatchSeconds, m.inflight, m.requestContentLength, m.requestContentLengthUnknown)
+	reg.MustRegister(m.captured, m.terminal, m.largeTurns, m.dropped, m.reducerEmpty, m.responseDecoded, m.responseSalvaged, m.rawAttached, m.rawSkipped, m.rawFallback, m.sseChunks, m.turnDuration, m.terminalDuration, m.bodyBytes, m.bodyBytesByOutcome, m.dispatchSeconds, m.inflight, m.requestContentLength, m.requestContentLengthUnknown, m.buildInfo)
 	m.largeTurnThreshold = DefaultLargeTurnThreshold
 
 	// Pre-create a zero row for every known drop reason × every provider we
@@ -597,6 +606,12 @@ func (m *Metrics) ObserveDispatchLatency(provider string, seconds float64) {
 		provider = labelUnknown
 	}
 	m.dispatchSeconds.WithLabelValues(provider).Observe(seconds)
+}
+
+// SetBuildInfo publishes the build metadata series. The value is always
+// exactly 1 (Prometheus build_info convention — enables group_left joins).
+func (m *Metrics) SetBuildInfo(version, commit string) {
+	m.buildInfo.WithLabelValues(version, commit).Set(1)
 }
 
 // SetInflight updates the gauge of currently-dispatching turns.

--- a/extproc/metrics_test.go
+++ b/extproc/metrics_test.go
@@ -3,13 +3,18 @@ package extproc
 import (
 	"io"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/papercomputeco/tapes/pkg/utils"
 )
 
 var _ = Describe("Extproc metrics", func() {
@@ -248,6 +253,43 @@ var _ = Describe("Extproc metrics", func() {
 		Expect(txt).NotTo(ContainSubstring(`tapes_extproc_request_content_length_bytes_bucket`))
 		Expect(txt).NotTo(ContainSubstring(`tapes_extproc_request_content_length_bytes_count`))
 		Expect(txt).NotTo(ContainSubstring(`tapes_extproc_request_content_length_bytes_sum`))
+	})
+
+	It("declares utils.Version/utils.Sha for the ldflags contract and renders build_info as 1", func() {
+		// Referencing the package vars directly means compiling this file
+		// proves the utils.Version/utils.Sha ldflags symbols still exist.
+		// Values are not pinned: release builds stamp them via -X.
+		Expect(utils.Version).NotTo(BeEmpty())
+		Expect(utils.Sha).NotTo(BeEmpty())
+
+		// Lock the other side of the contract: the Dagger build must still
+		// stamp exactly these symbol names, and the extproc image build must
+		// still route through it.
+		_, file, _, ok := runtime.Caller(0)
+		Expect(ok).To(BeTrue(), "runtime.Caller failed")
+		build, err := os.ReadFile(filepath.Join(filepath.Dir(file), "..", ".dagger", "build.go"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(build)).To(ContainSubstring(`-X 'github.com/papercomputeco/tapes/pkg/utils.Version=`))
+		Expect(string(build)).To(ContainSubstring(`-X 'github.com/papercomputeco/tapes/pkg/utils.Sha=`))
+		img, err := os.ReadFile(filepath.Join(filepath.Dir(file), "..", ".dagger", "extproc.go"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(img)).To(ContainSubstring(`releaseLDFlags(`))
+
+		m := NewMetrics()
+		m.SetBuildInfo("v1.2.3", "abc1234")
+
+		srv := httptest.NewServer(m.Handler())
+		defer srv.Close()
+
+		resp, err := srv.Client().Get(srv.URL + "/")
+		Expect(err).NotTo(HaveOccurred())
+		defer resp.Body.Close()
+		body, _ := io.ReadAll(resp.Body)
+		txt := string(body)
+
+		// Exact line: value 1 (build_info join convention) and only the
+		// version/commit labels.
+		Expect(txt).To(ContainSubstring(`tapes_extproc_build_info{commit="abc1234",version="v1.2.3"} 1`))
 	})
 
 	It("AllDropReasons has no duplicates and no whitespace", func() {

--- a/extproc/metrics_test.go
+++ b/extproc/metrics_test.go
@@ -3,10 +3,13 @@ package extproc
 import (
 	"io"
 	"net/http/httptest"
+	"regexp"
+	"strconv"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 var _ = Describe("Extproc metrics", func() {
@@ -159,6 +162,94 @@ var _ = Describe("Extproc metrics", func() {
 		Expect(txt).To(ContainSubstring(`model_family="other"`))
 	})
 
+	It("shares one 256B-to-64MiB 14-bucket scheme across all three body-size histograms", func() {
+		// bodySizeBuckets must be exactly the 14-bucket exponential range
+		// from 256 B to 64 MiB.
+		Expect(bodySizeBuckets).To(Equal(prometheus.ExponentialBucketsRange(256, 64*1024*1024, 14)))
+		Expect(bodySizeBuckets).To(HaveLen(14))
+		Expect(bodySizeBuckets[0]).To(BeNumerically("~", 256, 1e-6))
+		Expect(bodySizeBuckets[13]).To(BeNumerically("~", 64*1024*1024, 1))
+
+		// Cross-check the rendered exposition: all three body-size
+		// histograms must scrape identical le= boundary sets.
+		m := NewMetrics()
+		m.ObserveBodyBytes("anthropic", "request", 1024)
+		m.ObserveBodyBytesByOutcome("anthropic", "request", "accepted", "accepted", 1024)
+		m.ObserveRequestContentLength("anthropic", 1024)
+
+		srv := httptest.NewServer(m.Handler())
+		defer srv.Close()
+
+		resp, err := srv.Client().Get(srv.URL + "/")
+		Expect(err).NotTo(HaveOccurred())
+		defer resp.Body.Close()
+		body, _ := io.ReadAll(resp.Body)
+		txt := string(body)
+
+		bodyLes := metricsBucketBoundaries(txt, "tapes_extproc_body_bytes")
+		outcomeLes := metricsBucketBoundaries(txt, "tapes_extproc_body_bytes_by_outcome")
+		contentLengthLes := metricsBucketBoundaries(txt, "tapes_extproc_request_content_length_bytes")
+
+		// 14 finite boundaries plus the implicit +Inf bucket.
+		Expect(bodyLes).To(HaveLen(15))
+		Expect(outcomeLes).To(Equal(bodyLes))
+		Expect(contentLengthLes).To(Equal(bodyLes))
+
+		Expect(bodyLes[len(bodyLes)-1]).To(Equal("+Inf"))
+		first, err := strconv.ParseFloat(bodyLes[0], 64)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(first).To(BeNumerically("~", 256, 1e-6))
+		last, err := strconv.ParseFloat(bodyLes[len(bodyLes)-2], 64)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(last).To(BeNumerically("~", 64*1024*1024, 1))
+	})
+
+	It("routes content-length metric providers through the normalizeProvider allowlist", func() {
+		m := NewMetrics()
+		m.ObserveRequestContentLength("custom-weird-provider", 512)
+		m.ObserveRequestContentLengthUnknown("custom-weird-provider")
+
+		srv := httptest.NewServer(m.Handler())
+		defer srv.Close()
+
+		resp, err := srv.Client().Get(srv.URL + "/")
+		Expect(err).NotTo(HaveOccurred())
+		defer resp.Body.Close()
+		body, _ := io.ReadAll(resp.Body)
+		txt := string(body)
+
+		// Exact sample lines: off-allowlist providers normalize to "other",
+		// and the full-line match proves provider is the only label.
+		Expect(txt).To(ContainSubstring(`tapes_extproc_request_content_length_bytes_count{provider="other"} 1`))
+		Expect(txt).To(ContainSubstring(`tapes_extproc_request_content_length_unknown_total{provider="other"} 1`))
+
+		// The raw provider string must never leak into a label row.
+		Expect(txt).NotTo(ContainSubstring(`provider="custom-weird-provider"`))
+	})
+
+	It("ObserveRequestContentLengthUnknown increments the counter and never touches the histogram", func() {
+		m := NewMetrics()
+		m.ObserveRequestContentLengthUnknown("anthropic")
+		m.ObserveRequestContentLengthUnknown("anthropic")
+
+		srv := httptest.NewServer(m.Handler())
+		defer srv.Close()
+
+		resp, err := srv.Client().Get(srv.URL + "/")
+		Expect(err).NotTo(HaveOccurred())
+		defer resp.Body.Close()
+		body, _ := io.ReadAll(resp.Body)
+		txt := string(body)
+
+		Expect(txt).To(ContainSubstring(`tapes_extproc_request_content_length_unknown_total{provider="anthropic"} 2`))
+
+		// No histogram series may render at all: absent series means _count
+		// is 0 and the le="256" bucket is 0 (no Observe(0) stand-in).
+		Expect(txt).NotTo(ContainSubstring(`tapes_extproc_request_content_length_bytes_bucket`))
+		Expect(txt).NotTo(ContainSubstring(`tapes_extproc_request_content_length_bytes_count`))
+		Expect(txt).NotTo(ContainSubstring(`tapes_extproc_request_content_length_bytes_sum`))
+	})
+
 	It("AllDropReasons has no duplicates and no whitespace", func() {
 		seen := map[string]bool{}
 		for _, r := range AllDropReasons() {
@@ -169,3 +260,18 @@ var _ = Describe("Extproc metrics", func() {
 		}
 	})
 })
+
+// metricsBucketBoundaries extracts the ordered, de-duplicated le= boundary
+// values rendered for a histogram's _bucket samples in a scraped exposition body.
+func metricsBucketBoundaries(txt, metric string) []string {
+	re := regexp.MustCompile(`(?m)^` + regexp.QuoteMeta(metric) + `_bucket\{[^}]*le="([^"]+)"[^}]*\} `)
+	var les []string
+	seen := map[string]bool{}
+	for _, match := range re.FindAllStringSubmatch(txt, -1) {
+		if !seen[match[1]] {
+			seen[match[1]] = true
+			les = append(les, match[1])
+		}
+	}
+	return les
+}

--- a/extproc/processor.go
+++ b/extproc/processor.go
@@ -353,6 +353,22 @@ func (p *Processor) onRequestHeaders(st *streamState, hdrs *extprocv3.HttpHeader
 	st.session = headers.ParseSessionEnvelope(hdrs)
 	st.orgID = headers.Get(hdrs, headers.PaperAuthOrgID)
 	st.authSubject = headers.Get(hdrs, headers.PaperAuthSubject)
+
+	// The headers phase is the only callback guaranteed for every
+	// request — bodies over the gRPC recv limit never reach
+	// onRequestBody — so pre-boundary size observation must live here.
+	// Unknown lengths are counted, never observed as 0.
+	if p.metrics != nil {
+		if v := headers.Get(hdrs, headers.ContentLength); v != "" {
+			if n, err := strconv.ParseInt(v, 10, 64); err == nil {
+				p.metrics.ObserveRequestContentLength(st.provider, n)
+			} else {
+				p.metrics.ObserveRequestContentLengthUnknown(st.provider)
+			}
+		} else {
+			p.metrics.ObserveRequestContentLengthUnknown(st.provider)
+		}
+	}
 }
 
 // onRequestBody accumulates request-body chunks and, on EndOfStream, parses

--- a/extproc/processor_test.go
+++ b/extproc/processor_test.go
@@ -18,6 +18,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/proto"
 )
 
 // fakeStream is a hand-rolled ExternalProcessor_ProcessServer that feeds
@@ -769,6 +770,79 @@ data: {"type":"response.completed","response":{"id":"resp_1","object":"response"
 		Expect(recorded.lastRequestID).NotTo(BeEmpty(),
 			"request ID should be synthesized when upstream didn't set x-request-id")
 		Expect(recorded.lastRequestID).To(HavePrefix("extproc-"))
+	})
+
+	It("observes Content-Length in onRequestHeaders before any body message arrives", func() {
+		// Headers-only stream: no RequestBody frame ever exists, so a nonzero
+		// histogram count can only have been observed at the headers phase.
+		stream := &fakeStream{
+			ctx: context.Background(),
+			toSend: []*extprocv3.ProcessingRequest{
+				headerReq(map[string]string{":method": "POST", ":path": "/v1/messages", "content-length": "12345"}),
+			},
+		}
+		Expect(proc.Process(stream)).To(Succeed())
+
+		txt := scrapeProcessorMetrics(proc)
+		Expect(txt).To(ContainSubstring(`tapes_extproc_request_content_length_bytes_count{provider="anthropic"} 1`))
+		Expect(txt).To(ContainSubstring(`tapes_extproc_request_content_length_bytes_sum{provider="anthropic"} 12345`))
+	})
+
+	It("counts absent and garbage Content-Length as unknown, with no histogram observation", func() {
+		// Absent and unparseable headers both count as unknown; neither may
+		// land in the histogram, not even as an Observe(0).
+		absent := &fakeStream{
+			ctx: context.Background(),
+			toSend: []*extprocv3.ProcessingRequest{
+				headerReq(map[string]string{":method": "POST", ":path": "/v1/messages"}),
+			},
+		}
+		garbage := &fakeStream{
+			ctx: context.Background(),
+			toSend: []*extprocv3.ProcessingRequest{
+				headerReq(map[string]string{":method": "POST", ":path": "/v1/messages", "content-length": "banana"}),
+			},
+		}
+		Expect(proc.Process(absent)).To(Succeed())
+		Expect(proc.Process(garbage)).To(Succeed())
+
+		txt := scrapeProcessorMetrics(proc)
+		Expect(txt).To(ContainSubstring(`tapes_extproc_request_content_length_unknown_total{provider="anthropic"} 2`))
+		Expect(txt).NotTo(ContainSubstring(`tapes_extproc_request_content_length_bytes_count{provider="anthropic"}`))
+	})
+
+	It("keeps the headers-phase ProcessingResponse byte-identical regardless of Content-Length", func() {
+		// Observation must not alter forwarding: with and without a huge
+		// Content-Length, the headers response and dispatch outcome match.
+		body := []byte(`{"id":"msg_1","type":"message","role":"assistant","model":"claude-3-5-sonnet-20241022","content":[{"type":"text","text":"hi"}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}`)
+		reqBody := []byte(`{"model":"claude-3-5-sonnet-20241022","max_tokens":8,"messages":[{"role":"user","content":"hi"}]}`)
+		turnStream := func(hdrs map[string]string) *fakeStream {
+			return &fakeStream{
+				ctx: context.Background(),
+				toSend: []*extprocv3.ProcessingRequest{
+					headerReq(hdrs),
+					reqBodyReq(reqBody, true),
+					respHeaderReq("200", "application/json"),
+					respBodyReq(body, true),
+				},
+			}
+		}
+		without := turnStream(map[string]string{":method": "POST", ":path": "/v1/messages"})
+		with := turnStream(map[string]string{":method": "POST", ":path": "/v1/messages", "content-length": "99999999999"})
+
+		Expect(proc.Process(without)).To(Succeed())
+		Eventually(obs.accepted.Load).WithTimeout(2 * time.Second).Should(Equal(int32(1)))
+		Expect(proc.Process(with)).To(Succeed())
+		Eventually(obs.accepted.Load).WithTimeout(2 * time.Second).Should(Equal(int32(2)))
+		for _, reason := range AllDropReasons() {
+			Expect(obs.DropCount(reason)).To(BeZero(), "unexpected drop %q", reason)
+		}
+
+		withoutFirst, err := proto.Marshal(without.Responses()[0])
+		Expect(err).NotTo(HaveOccurred())
+		withFirst, err := proto.Marshal(with.Responses()[0])
+		Expect(err).NotTo(HaveOccurred())
+		Expect(withFirst).To(Equal(withoutFirst))
 	})
 
 	It("enumerates every DropReason exactly once so metric label rows stay closed", func() {

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	golang.org/x/mod v0.32.0
 	golang.org/x/term v0.40.0
 	google.golang.org/grpc v1.79.3
+	google.golang.org/protobuf v1.36.11
 	gopkg.in/yaml.v3 v3.0.1
 	sigs.k8s.io/yaml v1.6.0
 )
@@ -111,5 +112,4 @@ require (
 	golang.org/x/text v0.34.0 // indirect
 	golang.org/x/tools v0.41.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect
-	google.golang.org/protobuf v1.36.11 // indirect
 )


### PR DESCRIPTION
## Summary

- Requests larger than extproc's gRPC receive limit (grpc-go default 4 MiB) die before any existing metric observes them, so the size distribution that motivates raising the limit is survivorship-biased (~177 production failures/30d for one tenant). This PR observes `Content-Length` at the request-headers phase — the only callback guaranteed for every request — in a new `tapes_extproc_request_content_length_bytes{provider}` histogram, with absent/unparseable lengths counted in `tapes_extproc_request_content_length_unknown_total{provider}` (never observed as 0).
- All body-size histograms move to one shared bucket scheme topping out at 64 MiB (256 B → 64 MiB, 14 buckets) so the 4–32 MB band under study stops piling into `+Inf`.
- `tapes_extproc_build_info{version,commit} 1` joins the registry, populated from the existing `pkg/utils.Version` / `utils.Sha` ldflags — deployed-version verification from metrics.
- Observation-only: no change to forwarding, dispatch, drops, or the headers-phase `ProcessingResponse` (pinned by a byte-identity differential spec).

## Verification

- [x] 7 new Ginkgo specs; `make parity`, `make test-extproc`, `make test`, `make e2e-test` all green locally
- [x] Clearing end-to-end: a 4.1/4.5/10/32 MB size ladder shows the new histogram observing 4/4 requests with a byte-exact sum while the pre-existing body-bytes histogram observes 0/4; `build_info` renders the branch SHA through the real image build

Part of PCC-1167