### PR TITLE
✨ feat(ingest): observable body-limit 413s and 64 MiB size buckets

### DIFF
--- a/api/sessions_export_all_handlers_test.go
+++ b/api/sessions_export_all_handlers_test.go
@@ -129,7 +129,9 @@ func newPagingDriver(org string, n int, latest time.Time) *pagingExportStubDrive
 var _ = Describe("GET /v1/sessions/export", func() {
 	// Reads are scoped to the single tenant, so seeded data must live there.
 	const org = singleTenantOrgID
-	now := time.Date(2026, 7, 8, 12, 0, 0, 0, time.UTC)
+	// Relative to the wall clock: the handler clamps its window to
+	// time.Now()-30d, so a pinned calendar date ages out of range.
+	now := time.Now().UTC().Truncate(time.Second)
 
 	// T-7: default window (no since/until) + bypasses the 200-row UI cap.
 	It("streams every session in the default 30-day window, past the 200-row cap", func() {

--- a/docs/src/apis.md
+++ b/docs/src/apis.md
@@ -41,6 +41,8 @@ Run the standalone form only for sidecar/gateway capture:
 tapes serve ingest --postgres "$TAPES_STORAGE_POSTGRES_DSN"
 ```
 
+Request bodies are capped at roughly 14.67 MiB. A POST over the limit is rejected with `413` and the surface's standard JSON error envelope (`{"error": "..."}`), the same shape as every other rejection, so capture adapters can parse all failures uniformly. Each body-limit rejection is counted in `tapes_ingest_writes_total{provider="unknown",status="reject_oversize"}` (the body is never parsed, so the provider is unknown) and logged with the declared content length, the configured limit, and the request path.
+
 The ingest server appends to immutable `raw_turns`; it does not provide the read API. Treat it as a private trusted write surface, not as a public application endpoint. Authentication, network policy, and gateway grants are deployment responsibilities.
 
 ## Provider proxy

--- a/ingest/CONTRACT
+++ b/ingest/CONTRACT
@@ -16,4 +16,4 @@
 #
 # ingest/openapi_seal_test.go recompiles and compares. If it fails, it prints
 # the value to write here. Bump it in the same change that moved the contract.
-sha256:b51bebaecb5e0942cd2fba11d694126e36c6a4e33088a77b8171eb8c3acecfb7
+sha256:8d92b4f6b146158078c9323ec0169bc99f02413ba4d67e0691cda50c51e9b054

--- a/ingest/errorhandler.go
+++ b/ingest/errorhandler.go
@@ -1,0 +1,40 @@
+package ingest
+
+import (
+	"errors"
+	"log/slog"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/papercomputeco/tapes/pkg/llm"
+)
+
+// newBodyLimitErrorHandler returns the app-level error handler: it makes the
+// body-limit 413 observable (one metric sample, one warn line, JSON envelope)
+// and delegates every other error verbatim to fiber.DefaultErrorHandler.
+func newBodyLimitErrorHandler(log *slog.Logger, metrics *Metrics) fiber.ErrorHandler {
+	return func(c *fiber.Ctx, err error) error {
+		// Match the sentinel, not the status: a handler-returned 413 is not a
+		// body-limit rejection. Only ingest routes are counted — an oversized
+		// POST to any other path keeps the default response and no sample.
+		p := c.Path()
+		ingestRoute := c.Method() == fiber.MethodPost &&
+			(p == "/v1/ingest" || p == "/v1/ingest/transcript")
+		if !errors.Is(err, fiber.ErrRequestEntityTooLarge) || !ingestRoute {
+			return fiber.DefaultErrorHandler(c, err)
+		}
+
+		// The body was never parsed, so the provider is genuinely unknown;
+		// zero bodyBytes keeps the accepted-size histogram untouched.
+		metrics.ObserveWrite("", ResultRejectOversize, 0)
+		log.Warn("ingest body over limit",
+			"content_length", c.Request().Header.ContentLength(),
+			"limit", MaxIngestBodyBytes,
+			"path", c.Path(),
+		)
+
+		return c.Status(fiber.StatusRequestEntityTooLarge).JSON(llm.ErrorResponse{
+			Error: "request body exceeds the ingest size limit",
+		})
+	}
+}

--- a/ingest/errorhandler_test.go
+++ b/ingest/errorhandler_test.go
@@ -1,0 +1,256 @@
+package ingest_test
+
+// The app-level body-limit error handler: an oversized POST must be observable
+// (one metric sample, one warn line, JSON envelope) while every other error
+// keeps Fiber's default handling byte-for-byte.
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/papercomputeco/tapes/ingest"
+	"github.com/papercomputeco/tapes/pkg/llm"
+)
+
+// syncBuffer is a goroutine-safe log sink: the server logs from its own
+// goroutines while specs read the captured output.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+// newWarnCapturingServer mirrors newTestServer but routes warn-and-above slog
+// output into the returned buffer so specs can assert on emitted lines.
+func newWarnCapturingServer() (*ingest.Server, *captureDriver, string, *syncBuffer) {
+	logBuf := &syncBuffer{}
+	logger := slog.New(slog.NewTextHandler(logBuf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	driver := newCaptureDriver()
+
+	s, err := ingest.New(
+		ingest.Config{
+			ListenAddr: ":0",
+			Project:    "test-project",
+		},
+		driver,
+		logger,
+	)
+	Expect(err).NotTo(HaveOccurred())
+
+	ln, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", "127.0.0.1:0")
+	Expect(err).NotTo(HaveOccurred())
+
+	go func() {
+		_ = s.RunWithListener(ln)
+	}()
+
+	return s, driver, "http://" + ln.Addr().String(), logBuf
+}
+
+// postOverLimit POSTs a MaxIngestBodyBytes+1 body over a raw connection: the
+// server rejects on the declared Content-Length and closes without reading, so
+// a streamed net/http POST would race its body write against the early 413.
+func postOverLimit(baseURL, path string) (*http.Response, []byte) {
+	return overLimitRequest(http.MethodPost, baseURL, path)
+}
+
+func overLimitRequest(method, baseURL, path string) (*http.Response, []byte) {
+	size := ingest.MaxIngestBodyBytes + 1
+	dialer := &net.Dialer{Timeout: 5 * time.Second}
+	conn, err := dialer.DialContext(context.Background(), "tcp", strings.TrimPrefix(baseURL, "http://"))
+	Expect(err).NotTo(HaveOccurred())
+	defer conn.Close()
+	Expect(conn.SetDeadline(time.Now().Add(10 * time.Second))).To(Succeed())
+
+	head := fmt.Sprintf("%s %s HTTP/1.1\r\nHost: tapes-test\r\nContent-Type: application/json\r\nContent-Length: %d\r\n\r\n", method, path, size)
+	_, err = io.WriteString(conn, head)
+	Expect(err).NotTo(HaveOccurred())
+	// The upload may die partway once the server has rejected and closed;
+	// the 413 already sits in our receive buffer.
+	_, _ = conn.Write(bytes.Repeat([]byte("x"), size))
+
+	resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
+	Expect(err).NotTo(HaveOccurred())
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	Expect(err).NotTo(HaveOccurred())
+	return resp, body
+}
+
+var _ = Describe("body-limit rejections", func() {
+	var (
+		server  *ingest.Server
+		driver  *captureDriver
+		baseURL string
+		logBuf  *syncBuffer
+		client  *http.Client
+	)
+
+	BeforeEach(func() {
+		server, driver, baseURL, logBuf = newWarnCapturingServer()
+		client = &http.Client{Timeout: 5 * time.Second}
+	})
+
+	AfterEach(func() {
+		Expect(server.Close()).To(Succeed())
+	})
+
+	It("rejects an over-limit POST with 413 and the llm.ErrorResponse JSON envelope", func() {
+		resp, body := postOverLimit(baseURL, "/v1/ingest")
+
+		Expect(resp.StatusCode).To(Equal(http.StatusRequestEntityTooLarge))
+		Expect(resp.Header.Get("Content-Type")).To(ContainSubstring("application/json"))
+
+		var envelope llm.ErrorResponse
+		Expect(json.Unmarshal(body, &envelope)).To(Succeed(),
+			"the 413 body must be the surface's standard JSON error envelope, got: %s", body)
+		Expect(envelope.Error).NotTo(BeEmpty())
+	})
+
+	It("records exactly one reject_oversize sample and one structured warn line per rejection", func() {
+		resp, _ := postOverLimit(baseURL, "/v1/ingest")
+		Expect(resp.StatusCode).To(Equal(http.StatusRequestEntityTooLarge))
+
+		scrape, err := client.Get(baseURL + "/metrics")
+		Expect(err).NotTo(HaveOccurred())
+		defer scrape.Body.Close()
+		txt, _ := io.ReadAll(scrape.Body)
+
+		// The whole sample line: value exactly 1, and the full label set —
+		// no path/size/org label may ride on the rejection counter.
+		Expect(string(txt)).To(ContainSubstring(
+			`tapes_ingest_writes_total{provider="unknown",status="reject_oversize"} 1`))
+		Expect(strings.Count(string(txt), `status="reject_oversize"`)).To(Equal(1))
+		// Zero bodyBytes on the rejection keeps the accepted-size histogram empty.
+		Expect(string(txt)).NotTo(ContainSubstring("tapes_ingest_body_bytes_bucket"))
+
+		logs := logBuf.String()
+		Expect(strings.Count(logs, "ingest body over limit")).To(Equal(1))
+		Expect(logs).To(ContainSubstring(fmt.Sprintf("content_length=%d", ingest.MaxIngestBodyBytes+1)))
+		Expect(logs).To(ContainSubstring(fmt.Sprintf("limit=%d", ingest.MaxIngestBodyBytes)))
+		Expect(logs).To(ContainSubstring("path=/v1/ingest"))
+	})
+
+	It("delegates non-body-limit errors verbatim to fiber.DefaultErrorHandler", func() {
+		// A default-handler app with the same route shape: what these requests
+		// produce there is byte-for-byte what the ingest server must produce.
+		ref := fiber.New(fiber.Config{DisableStartupMessage: true})
+		ref.Post("/v1/ingest", func(c *fiber.Ctx) error { return c.SendStatus(fiber.StatusAccepted) })
+		ln, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", "127.0.0.1:0")
+		Expect(err).NotTo(HaveOccurred())
+		go func() {
+			_ = ref.Listener(ln)
+		}()
+		defer func() {
+			Expect(ref.Shutdown()).To(Succeed())
+		}()
+		refURL := "http://" + ln.Addr().String()
+
+		do := func(base, method, path string) (int, string, string) {
+			req, err := http.NewRequest(method, base+path, nil)
+			Expect(err).NotTo(HaveOccurred())
+			resp, err := client.Do(req)
+			Expect(err).NotTo(HaveOccurred())
+			defer resp.Body.Close()
+			body, err := io.ReadAll(resp.Body)
+			Expect(err).NotTo(HaveOccurred())
+			return resp.StatusCode, resp.Header.Get("Content-Type"), string(body)
+		}
+
+		status, contentType, body := do(baseURL, http.MethodGet, "/nope")
+		refStatus, refContentType, refBody := do(refURL, http.MethodGet, "/nope")
+		Expect(status).To(Equal(refStatus))
+		Expect(contentType).To(Equal(refContentType))
+		Expect(body).To(Equal(refBody))
+		// Fiber's plain text, untouched: JSON here would mean the custom
+		// handler re-encoded an error it must only pass through.
+		Expect(body).To(Equal("Cannot GET /nope"))
+
+		status, contentType, body = do(baseURL, http.MethodDelete, "/v1/ingest")
+		refStatus, refContentType, refBody = do(refURL, http.MethodDelete, "/v1/ingest")
+		Expect(status).To(Equal(refStatus))
+		Expect(contentType).To(Equal(refContentType))
+		Expect(body).To(Equal(refBody))
+		Expect(status).To(Equal(http.StatusMethodNotAllowed))
+	})
+
+	It("leaves body-limit rejections on non-ingest routes to the default handler", func() {
+		// Only ingest routes are counted: an oversized POST elsewhere keeps
+		// Fiber's plain-text 413 and must not record a reject_oversize sample.
+		resp, body := postOverLimit(baseURL, "/nope")
+		Expect(resp.StatusCode).To(Equal(http.StatusRequestEntityTooLarge))
+		Expect(resp.Header.Get("Content-Type")).NotTo(ContainSubstring("application/json"))
+		Expect(string(body)).NotTo(ContainSubstring(`"error"`))
+
+		// Same for an unsupported method on an ingest path: only POST counts.
+		resp, body = overLimitRequest(http.MethodDelete, baseURL, "/v1/ingest")
+		Expect(resp.StatusCode).To(Equal(http.StatusRequestEntityTooLarge))
+		Expect(string(body)).NotTo(ContainSubstring(`"error"`))
+
+		scrape, err := client.Get(baseURL + "/metrics")
+		Expect(err).NotTo(HaveOccurred())
+		defer scrape.Body.Close()
+		txt, _ := io.ReadAll(scrape.Body)
+		Expect(string(txt)).NotTo(ContainSubstring(`status="reject_oversize"`))
+	})
+
+	It("still accepts a just-under-limit turn through handleIngest", func() {
+		payload := ingest.TurnPayload{
+			Provider: "ollama",
+			RawRequest: mustJSON(ollamaRequest{
+				Model:    "llama3",
+				Messages: []ollamaMessage{{Role: "user", Content: "Hello"}},
+			}),
+			Response:    reducedResponse("llama3", "Hi", nil),
+			RawResponse: bytes.Repeat([]byte("x"), 3),
+		}
+		base, err := json.Marshal(payload)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Base64 grows 3 raw bytes into exactly 4 body bytes, so pad the turn
+		// to a few bytes under the real MaxIngestBodyBytes — the shipped
+		// boundary, not an injected test limit.
+		extra := (ingest.MaxIngestBodyBytes - len(base) - 8) / 4
+		payload.RawResponse = bytes.Repeat([]byte("x"), 3+3*extra)
+		body, err := json.Marshal(payload)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(len(body)).To(BeNumerically("<=", ingest.MaxIngestBodyBytes))
+		Expect(len(body)).To(BeNumerically(">", ingest.MaxIngestBodyBytes-16))
+
+		resp, err := client.Post(baseURL+"/v1/ingest", "application/json", bytes.NewReader(body))
+		Expect(err).NotTo(HaveOccurred())
+		defer resp.Body.Close()
+		Expect(resp.StatusCode).To(Equal(http.StatusAccepted))
+
+		// The handler, not the error handler, answered: the turn landed.
+		Eventually(driver.CountRaw).
+			WithTimeout(2 * time.Second).WithPolling(25 * time.Millisecond).
+			Should(Equal(1))
+		Expect(driver.RawTurns()[0].Provider).To(Equal("ollama"))
+	})
+})

--- a/ingest/ingest.go
+++ b/ingest/ingest.go
@@ -250,9 +250,14 @@ func newServer(config Config, driver storage.Driver, log *slog.Logger, docs oas.
 		providers[name] = prov
 	}
 
+	// Built before the Server struct because the fiber.Config needs it: the
+	// body-limit error handler records rejections on the same registry.
+	metrics := NewMetrics()
+
 	app := fiber.New(fiber.Config{
 		DisableStartupMessage: true,
 		BodyLimit:             MaxIngestBodyBytes,
+		ErrorHandler:          newBodyLimitErrorHandler(log, metrics),
 	})
 
 	wp, err := worker.NewPool(&worker.Config{
@@ -271,7 +276,7 @@ func newServer(config Config, driver storage.Driver, log *slog.Logger, docs oas.
 		logger:     log,
 		server:     app,
 		providers:  providers,
-		metrics:    NewMetrics(),
+		metrics:    metrics,
 		openapi:    NewOpenAPIParser(docs),
 	}
 	if rawStore, ok := driver.(storage.RawTurnStore); ok {

--- a/ingest/ingest_test.go
+++ b/ingest/ingest_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -175,6 +176,40 @@ var _ = Describe("Ingest Server", func() {
 			defer scrape.Body.Close()
 			txt, _ := io.ReadAll(scrape.Body)
 			Expect(string(txt)).To(ContainSubstring(`status="unknown_provider"`))
+		})
+
+		It("exposes tapes_ingest_body_bytes buckets topping out at 64 MiB", func() {
+			payload := ingest.TurnPayload{
+				Provider: "ollama",
+				RawRequest: mustJSON(ollamaRequest{
+					Model:    "llama3",
+					Messages: []ollamaMessage{{Role: "user", Content: "Hello"}},
+				}),
+				Response: reducedResponse("llama3", "Hi", nil),
+			}
+			body, _ := json.Marshal(payload)
+			resp, err := client.Post(baseURL+"/v1/ingest", "application/json", bytes.NewReader(body))
+			Expect(err).NotTo(HaveOccurred())
+			resp.Body.Close()
+
+			scrape, err := client.Get(baseURL + "/metrics")
+			Expect(err).NotTo(HaveOccurred())
+			defer scrape.Body.Close()
+			txt, _ := io.ReadAll(scrape.Body)
+
+			// 64<<20 renders as 6.7108864e+07; the top finite bucket must sit
+			// there so a near-limit envelope doesn't just saturate into +Inf.
+			Expect(string(txt)).To(ContainSubstring(`tapes_ingest_body_bytes_bucket{provider="ollama",le="6.7108864e+07"}`))
+			Expect(string(txt)).To(ContainSubstring("# HELP tapes_ingest_body_bytes Size of accepted ingest envelopes by provider."))
+
+			// 14 mirrors the bucket count in metrics.go's ExponentialBucketsRange.
+			finite := 0
+			for line := range strings.SplitSeq(string(txt), "\n") {
+				if strings.HasPrefix(line, "tapes_ingest_body_bytes_bucket{") && !strings.Contains(line, `le="+Inf"`) {
+					finite++
+				}
+			}
+			Expect(finite).To(Equal(14))
 		})
 	})
 

--- a/ingest/metrics.go
+++ b/ingest/metrics.go
@@ -99,6 +99,9 @@ const (
 	// payload or a downstream outage — so no handler exit is invisible to the
 	// writes counter.
 	ResultInternalErr Result = "internal_error"
+	// ResultRejectOversize is a body-limit 413, recorded pre-parse by the
+	// app-level error handler — always under provider "unknown".
+	ResultRejectOversize Result = "reject_oversize"
 )
 
 // ObserveWrite increments the writes counter for a given provider/result.

--- a/ingest/metrics.go
+++ b/ingest/metrics.go
@@ -57,7 +57,7 @@ func NewMetrics() *Metrics {
 			prometheus.HistogramOpts{
 				Name:    "tapes_ingest_body_bytes",
 				Help:    "Size of accepted ingest envelopes by provider.",
-				Buckets: prometheus.ExponentialBucketsRange(256, 16*1024*1024, 12),
+				Buckets: prometheus.ExponentialBucketsRange(256, 64*1024*1024, 14),
 			},
 			[]string{"provider"},
 		),

--- a/ingest/openapi.go
+++ b/ingest/openapi.go
@@ -142,6 +142,7 @@ func (s *Server) mountRoutes(router *oasfiber.Router) {
 			JSONBody("Captured turn", s.schema(TurnPayload{})).
 			JSONResponse(202, "Captured and queued for derivation", s.schema(ingestAcceptedResponse{})).
 			JSONResponse(400, "Malformed envelope or invalid session block", s.errorSchema()).
+			JSONResponse(413, "Body exceeds the ingest size limit", s.errorSchema()).
 			JSONResponse(422, "Well-formed but unprocessable (e.g. unknown provider)", s.errorSchema()).
 			JSONResponse(502, "A downstream dependency failed", s.errorSchema()))
 
@@ -162,6 +163,7 @@ func (s *Server) mountRoutes(router *oasfiber.Router) {
 				s.schema(transcriptAcceptedResponse{})).
 			JSONResponse(400, "Malformed body, invalid session block, or records not a JSON array",
 				s.errorSchema()).
+			JSONResponse(413, "Body exceeds the ingest size limit", s.errorSchema()).
 			JSONResponse(500, "Persisting the transcript failed", s.errorSchema()).
 			JSONResponse(501, "Driver does not host the raw-turn layer", s.errorSchema()))
 }

--- a/ingest/openapi_coverage_test.go
+++ b/ingest/openapi_coverage_test.go
@@ -38,4 +38,36 @@ var _ = Describe("Ingest OpenAPI route coverage", func() {
 		)
 		Expect(res.OK()).To(BeTrue(), res.Explain("the compiled ingest contract"))
 	})
+
+	It("documents the 413 body-limit response for ingest operations", func(ctx SpecContext) {
+		server, err := New(Config{ListenAddr: ":0"}, inmemory.NewDriver(), tapeslogger.NewNoop())
+		Expect(err).NotTo(HaveOccurred())
+
+		contract, err := server.OpenAPIParser().Compile(ctx)
+		Expect(err).NotTo(HaveOccurred())
+
+		tree := contract.Tree()
+		for _, path := range []string{"/v1/ingest", "/v1/ingest/transcript"} {
+			responses := treeAt(tree, "paths", path, "post", "responses")
+			Expect(treeAt(responses, "413")).NotTo(BeNil(),
+				"POST %s does not document the 413 body-limit rejection", path)
+			// Same schema as the surface's other rejections, so adapters can
+			// parse every error from this surface uniformly.
+			Expect(treeAt(responses, "413", "content", "application/json", "schema")).
+				To(Equal(treeAt(responses, "400", "content", "application/json", "schema")),
+					"POST %s must document the 413 body with the shared error schema", path)
+		}
+	})
 })
+
+// treeAt walks nested map[string]any keys, returning nil when any is absent.
+func treeAt(node any, keys ...string) any {
+	for _, key := range keys {
+		m, ok := node.(map[string]any)
+		if !ok {
+			return nil
+		}
+		node = m[key]
+	}
+	return node
+}


### PR DESCRIPTION
## Summary

- An oversized `POST /v1/ingest` is rejected by Fiber's transport-level body limit before `handleIngest` runs: no metric, no log, plain-text 413 — the turn vanishes invisibly. A custom app-level error handler now intercepts exactly `fiber.ErrRequestEntityTooLarge`, counts it as `tapes_ingest_writes_total{provider="unknown",status="reject_oversize"}`, emits one structured warn (content_length, limit, path), and returns the surface's standard `llm.ErrorResponse` JSON envelope; every other error delegates verbatim to Fiber's default handler.
- `tapes_ingest_body_bytes` buckets widen to 64 MiB ahead of the later-phase limit raises.
- Who gets rejected is unchanged — the body limit itself is untouched. The OpenAPI contract documents the 413 on both ingest operations (CONTRACT resealed), and the ingest docs page covers the new behavior.

## Verification

- [x] 6 new Ginkgo specs (incl. a raw-conn over-limit POST to sidestep fasthttp's early-413 race, and a default-handler differential); full CI-mirror matrix green locally: `make parity`, `make test-extproc`, `make test`, `make e2e-test`

Part of PCC-1167