### PR TITLE
✨ feat(migrations): publish the tapes_v1 contract views cassettes read

### DIFF
--- a/docs/src/cassettes.md
+++ b/docs/src/cassettes.md
@@ -205,6 +205,21 @@ at most 63 bytes. `raw_turns` is explicitly forbidden: it is an internal capture
 log, not a cassette contract view. The manifest derives requested grants as
 `tapes_<core>.<view>`, for example `tapes_v1.spans`.
 
+The `v1` contract publishes four views, created by core's migrations in the
+`tapes_v1` schema:
+
+| View                 | Fronts                                        |
+| -------------------- | --------------------------------------------- |
+| `tapes_v1.sessions`  | the sessions table                            |
+| `tapes_v1.spans`     | the current span projection generation        |
+| `tapes_v1.span_turns`| the current span-turn projection generation   |
+| `tapes_v1.span_links`| the current span-link projection generation   |
+
+The views are the stable names. The physical projection tables behind them are
+date-versioned and rotate when a new projection generation lands; the views are
+repointed in the same migration, so a cassette granted the views never notices.
+Point queries and grants at `tapes_v1.*`, never at a physical table name.
+
 This is a declaration only. Tapes does not check that a named view exists, apply
 grants, create roles, or give the cassette a database credential. Deployment
 tooling owns those actions.

--- a/migrations/1781500000_tapes_v1_contract_views.down.sql
+++ b/migrations/1781500000_tapes_v1_contract_views.down.sql
@@ -1,0 +1,5 @@
+-- Withdraw the v1 read contract. CASCADE is safe here: the schema holds only
+-- the four contract views, and any GRANTs on them (a deployment's, not
+-- core's) fall away with the views themselves.
+
+DROP SCHEMA IF EXISTS tapes_v1 CASCADE;

--- a/migrations/1781500000_tapes_v1_contract_views.up.sql
+++ b/migrations/1781500000_tapes_v1_contract_views.up.sql
@@ -1,0 +1,150 @@
+-- tapes_v1: the published read contract for cassettes.
+--
+-- A cassette's manifest declares `depends.core = "v1"` and names the views it
+-- wants SELECT on; the grant plan derives `tapes_v1.<view>` from that
+-- declaration (pkg/cassette/v1alpha1/grants.go). Until now the schema those
+-- grants name did not exist, so every deployment granted the physical
+-- projection tables instead — tables that are deliberately date-versioned
+-- (1781310000_version_span_projection_tables) and therefore rotate out from
+-- under any grant that names them.
+--
+-- These views are that contract. Deployments grant SELECT on them and never
+-- on the physical tables, so a projection-generation rotation is invisible to
+-- cassettes: the new generation's migration repoints the views and the grants
+-- keep working.
+--
+-- Two properties are load-bearing:
+--
+--   - The column lists are explicit, not SELECT *. The view IS the v1
+--     contract; a column added to a physical table later does not join the
+--     contract by default, it joins when a migration deliberately re-creates
+--     the view. (Postgres freezes a view's columns at creation either way —
+--     the explicit list just makes the contract reviewable in this file.)
+--
+--   - A migration that registers a new projection generation in
+--     derived_projection_schemas MUST also CREATE OR REPLACE the three
+--     projection views here to front the new tables. A test pins this:
+--     the views' base relations are asserted against the registry's latest
+--     row, so forgetting the repoint turns the suite red instead of silently
+--     starving every deployed cassette.
+--
+-- No GRANTs happen here. Publishing the contract is core's job; deciding who
+-- reads it is the deployment's (tko grants per-cassette from the manifest's
+-- grant plan, docker-compose examples do it in provision.sql).
+
+CREATE SCHEMA IF NOT EXISTS tapes_v1;
+
+COMMENT ON SCHEMA tapes_v1 IS
+    'Published v1 read contract for cassettes. Grant SELECT on these views, never on the physical tables they front.';
+
+-- sessions is a stable-named table (not generation-versioned), but it is
+-- still fronted by a view: the contract must be uniform — one schema, one
+-- grant shape — and core keeps the freedom to version sessions later without
+-- a flag day for cassettes.
+CREATE OR REPLACE VIEW tapes_v1.sessions AS
+SELECT
+    id,
+    org_id,
+    auth_subject,
+    harness_id,
+    harness_session_id,
+    name,
+    cwd,
+    harness_version,
+    parent_session_id,
+    started_at,
+    last_seen_at,
+    ended_at,
+    harness_metadata,
+    total_input_tokens,
+    total_output_tokens,
+    total_cost_usd,
+    turn_count,
+    derived_status,
+    has_git_activity,
+    tool_result_count,
+    tool_error_count,
+    derived_title,
+    derived_model,
+    model_usage,
+    total_tokens,
+    duration_ns,
+    tasks,
+    kind_counts,
+    display_name
+FROM sessions;
+
+CREATE OR REPLACE VIEW tapes_v1.spans AS
+SELECT
+    org_id,
+    trace_id,
+    span_id,
+    parent_span_id,
+    session_id,
+    kind,
+    name,
+    status,
+    call_kind,
+    thread_id,
+    model,
+    stop_reason,
+    started_at,
+    duration_ns,
+    input,
+    output,
+    usage,
+    raw_turn_id,
+    node_hash,
+    seq,
+    verdict,
+    content_hash,
+    derive_seq,
+    fidelity
+FROM spans_20260615;
+
+CREATE OR REPLACE VIEW tapes_v1.span_turns AS
+SELECT
+    org_id,
+    trace_id,
+    session_id,
+    user_prompt,
+    synthetic,
+    status,
+    started_at,
+    ended_at,
+    duration_ns,
+    total_input_tokens,
+    total_output_tokens,
+    total_cost_usd,
+    main_input_tokens,
+    main_output_tokens,
+    cache_read_tokens,
+    cache_creation_tokens,
+    response_preview,
+    source,
+    content_hash,
+    derive_seq,
+    fidelity
+FROM span_turns_20260615;
+
+CREATE OR REPLACE VIEW tapes_v1.span_links AS
+SELECT
+    org_id,
+    from_trace_id,
+    from_span_id,
+    from_io,
+    to_trace_id,
+    to_span_id,
+    to_io,
+    kind,
+    session_id
+FROM span_links_20260615;
+
+COMMENT ON VIEW tapes_v1.sessions IS
+    'v1 contract view over the sessions table.';
+COMMENT ON VIEW tapes_v1.spans IS
+    'v1 contract view over the current span projection generation (see derived_projection_schemas).';
+COMMENT ON VIEW tapes_v1.span_turns IS
+    'v1 contract view over the current span-turn projection generation (see derived_projection_schemas).';
+COMMENT ON VIEW tapes_v1.span_links IS
+    'v1 contract view over the current span-link projection generation (see derived_projection_schemas).';

--- a/pkg/storage/postgres/contract_views_test.go
+++ b/pkg/storage/postgres/contract_views_test.go
@@ -1,0 +1,99 @@
+package postgres_test
+
+// The tapes_v1 contract: cassettes are granted SELECT on tapes_v1 views and
+// never on the physical tables they front, so the views must always point at
+// the projection generation the deriver actually writes. These specs pin the
+// convention that a migration registering a new generation in
+// derived_projection_schemas also repoints the views — forgetting that would
+// silently starve every deployed cassette (the grant still succeeds, the
+// queries still run, the data quietly stops being current).
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/papercomputeco/tapes/pkg/storage/postgres"
+)
+
+var _ = Describe("tapes_v1 contract views [postgres]", func() {
+	var (
+		ctx    context.Context
+		driver *postgres.Driver
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		var err error
+		driver, err = postgres.NewDriver(ctx, testPostgresDSN)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(driver.Close)
+	})
+
+	// baseTables resolves the ordinary tables a view's rewrite rule reads,
+	// straight from the catalogs. pg_get_viewdef would need string parsing;
+	// pg_depend is the planner's own answer to "what does this view front".
+	baseTables := func(view string) []string {
+		rows, err := driver.DB().Query(ctx, `
+			SELECT DISTINCT ref.relname
+			FROM pg_rewrite rw
+			JOIN pg_depend dep
+			  ON dep.objid = rw.oid AND dep.classid = 'pg_rewrite'::regclass
+			JOIN pg_class ref
+			  ON ref.oid = dep.refobjid AND dep.refclassid = 'pg_class'::regclass
+			WHERE rw.ev_class = $1::regclass
+			  AND ref.relkind = 'r'
+		`, view)
+		Expect(err).NotTo(HaveOccurred())
+		defer rows.Close()
+
+		var names []string
+		for rows.Next() {
+			var name string
+			Expect(rows.Scan(&name)).To(Succeed())
+			names = append(names, name)
+		}
+		Expect(rows.Err()).NotTo(HaveOccurred())
+		return names
+	}
+
+	It("fronts the registry's newest projection generation", func() {
+		var spansTable, spanTurnsTable, spanLinksTable string
+		err := driver.DB().QueryRow(ctx, `
+			SELECT spans_table, span_turns_table, span_links_table
+			FROM derived_projection_schemas
+			ORDER BY compatibility_date DESC
+			LIMIT 1
+		`).Scan(&spansTable, &spanTurnsTable, &spanLinksTable)
+		Expect(err).NotTo(HaveOccurred())
+
+		// One base table each, and it is the registered one. A future
+		// generation migration that inserts a new registry row without
+		// CREATE OR REPLACE-ing these views fails here, which is the
+		// entire reason this spec exists.
+		Expect(baseTables("tapes_v1.spans")).To(ConsistOf(spansTable))
+		Expect(baseTables("tapes_v1.span_turns")).To(ConsistOf(spanTurnsTable))
+		Expect(baseTables("tapes_v1.span_links")).To(ConsistOf(spanLinksTable))
+	})
+
+	It("fronts sessions through the same contract shape", func() {
+		// sessions is not generation-versioned today, but the contract is
+		// uniform: one schema, one grant shape, no physical names.
+		Expect(baseTables("tapes_v1.sessions")).To(ConsistOf("sessions"))
+	})
+
+	It("serves every contract view to a plain SELECT", func() {
+		// The freshly migrated database may be empty; what is being proven
+		// is that the views are well-formed against the real tables — a
+		// column renamed or dropped out from under an explicit view column
+		// list fails the migration itself, and a view accidentally created
+		// against a stale name fails here.
+		for _, view := range []string{"sessions", "spans", "span_turns", "span_links"} {
+			var count int64
+			err := driver.DB().QueryRow(ctx,
+				"SELECT count(*) FROM tapes_v1."+view).Scan(&count)
+			Expect(err).NotTo(HaveOccurred(), "tapes_v1.%s must be selectable", view)
+		}
+	})
+})

--- a/pkg/storage/postgres/gensqlc/models.go
+++ b/pkg/storage/postgres/gensqlc/models.go
@@ -183,3 +183,102 @@ type Spans20260615 struct {
 	DeriveSeq    int64
 	Fidelity     string
 }
+
+// v1 contract view over the sessions table.
+type TapesV1Session struct {
+	ID                pgtype.UUID
+	OrgID             pgtype.UUID
+	AuthSubject       string
+	HarnessID         string
+	HarnessSessionID  string
+	Name              pgtype.Text
+	Cwd               pgtype.Text
+	HarnessVersion    pgtype.Text
+	ParentSessionID   pgtype.UUID
+	StartedAt         pgtype.Timestamptz
+	LastSeenAt        pgtype.Timestamptz
+	EndedAt           pgtype.Timestamptz
+	HarnessMetadata   []byte
+	TotalInputTokens  int64
+	TotalOutputTokens int64
+	TotalCostUsd      pgtype.Numeric
+	TurnCount         int32
+	DerivedStatus     string
+	HasGitActivity    bool
+	ToolResultCount   int32
+	ToolErrorCount    int32
+	DerivedTitle      pgtype.Text
+	DerivedModel      string
+	ModelUsage        []byte
+	TotalTokens       pgtype.Int8
+	DurationNs        pgtype.Int8
+	Tasks             []byte
+	KindCounts        []byte
+	DisplayName       pgtype.Text
+}
+
+// v1 contract view over the current span projection generation (see derived_projection_schemas).
+type TapesV1Span struct {
+	OrgID        pgtype.UUID
+	TraceID      string
+	SpanID       string
+	ParentSpanID string
+	SessionID    pgtype.UUID
+	Kind         string
+	Name         string
+	Status       string
+	CallKind     string
+	ThreadID     string
+	Model        string
+	StopReason   string
+	StartedAt    pgtype.Timestamptz
+	DurationNs   int64
+	Input        []byte
+	Output       []byte
+	Usage        []byte
+	RawTurnID    pgtype.Int8
+	NodeHash     string
+	Seq          int64
+	Verdict      []byte
+	ContentHash  string
+	DeriveSeq    int64
+	Fidelity     string
+}
+
+// v1 contract view over the current span-link projection generation (see derived_projection_schemas).
+type TapesV1SpanLink struct {
+	OrgID       pgtype.UUID
+	FromTraceID string
+	FromSpanID  string
+	FromIo      string
+	ToTraceID   string
+	ToSpanID    string
+	ToIo        string
+	Kind        string
+	SessionID   pgtype.UUID
+}
+
+// v1 contract view over the current span-turn projection generation (see derived_projection_schemas).
+type TapesV1SpanTurn struct {
+	OrgID               pgtype.UUID
+	TraceID             string
+	SessionID           pgtype.UUID
+	UserPrompt          string
+	Synthetic           string
+	Status              string
+	StartedAt           pgtype.Timestamptz
+	EndedAt             pgtype.Timestamptz
+	DurationNs          int64
+	TotalInputTokens    int64
+	TotalOutputTokens   int64
+	TotalCostUsd        pgtype.Numeric
+	MainInputTokens     int64
+	MainOutputTokens    int64
+	CacheReadTokens     int64
+	CacheCreationTokens int64
+	ResponsePreview     string
+	Source              string
+	ContentHash         string
+	DeriveSeq           int64
+	Fidelity            string
+}

--- a/pkg/tapesoapi/reflect.go
+++ b/pkg/tapesoapi/reflect.go
@@ -183,7 +183,7 @@ func (r *reflector) reflectConcrete(t reflect.Type) (*Schema, error) {
 		return schema, nil
 	}
 
-	switch t.Kind() { //nolint:exhaustive // the default reports every kind with no JSON shape
+	switch t.Kind() {
 	case reflect.Bool:
 		return Boolean(), nil
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32:
@@ -227,6 +227,11 @@ func (r *reflector) reflectConcrete(t reflect.Type) (*Schema, error) {
 		return AnyValue(), nil
 	case reflect.Pointer:
 		return r.reflect(t.Elem(), fieldTags{})
+	case reflect.Invalid, reflect.Uintptr, reflect.Complex64, reflect.Complex128,
+		reflect.Chan, reflect.Func, reflect.UnsafePointer:
+		// Named rather than left to the default so the switch stays
+		// exhaustive: these kinds have no JSON shape by construction.
+		return nil, fmt.Errorf("cannot derive an OpenAPI schema for %s (kind %s)", t, t.Kind())
 	default:
 		return nil, fmt.Errorf("cannot derive an OpenAPI schema for %s (kind %s)", t, t.Kind())
 	}


### PR DESCRIPTION
## Summary

- A cassette manifest's `depends.views` derives its grant plan as `tapes_v1.<view>`, but that schema never existed — so every deployed cassette shipped a documented workaround granting the date-versioned physical projection tables, names tapes deliberately rotates on a new projection generation. The grant survives the rotation; the data quietly stops being current.
- Migration `1781500000_tapes_v1_contract_views` creates the `tapes_v1` schema with four views — `sessions`, `spans`, `span_turns`, `span_links` — fronting the current projection generation. Column lists are explicit: the view IS the v1 contract, and a column added to a physical table joins the contract only when a migration deliberately re-creates the view.
- The convention that a new-generation migration must repoint the views is pinned by a DB-backed spec: it resolves each view's base relation from `pg_depend` and asserts it matches the newest `derived_projection_schemas` row, so a forgotten repoint turns the suite red instead of silently starving every deployed cassette.
- No GRANTs happen in core — publishing the contract is core's job; deciding who reads it stays with the deployment (tko's grant executor already emits per-schema USAGE + per-view SELECT for exactly these names).
- `docs/src/cassettes.md` documents the four published views and the "grant the views, never the physical tables" rule.

## Verification

- [x] Full `go test ./...` green against the CI Postgres image (`postgres:17.7-pgduckdb-1.1.1`), including the three new contract-view specs
- [x] `make parity` green locally
- [x] Down-migration executed cleanly (schema + 4 views drop, rolled back in a transaction)
- [x] Grant flow rehearsed end-to-end on a fresh database: provision role + default privileges → migrations → cassette role reads `tapes_v1.*` with zero post-migration grants
- [ ] `make e2e-test` — could not complete locally (the Ollama `qwen3:0.6b` stage times out on this network before any test request executes); relying on this PR's CI run

Part of PCC-1153