### PR TITLE
📚 docs: cover subagent threads, spawn anchors, and attribution repair

### DIFF
--- a/docs/src/apis.md
+++ b/docs/src/apis.md
@@ -14,7 +14,7 @@ The default read API listens on `:8081`. It serves health, derived data, search,
 | Search and aggregates | `GET /v1/search/spans`, `GET /v1/stats` |
 | Skills | `/v1/skills` and session skill routes |
 | MCP | `/v1/mcp` |
-| Operator actions | `/v1/admin/derive/run`, `/v1/admin/seed/demo` |
+| Operator actions | `/v1/admin/derive/run`, `/v1/admin/seed/demo`, `/v1/admin/raw-turns/attribution-repair` |
 | Cassettes | `GET /v1/cassettes`, `GET /v1/cassettes/{name}/openapi.json`, `/v1/cassettes/{name}`, `/v1/cassettes/{name}/*` |
 
 The authoritative parameters, schemas, and methods are compiled from route registrations and served by the running API at `GET /openapi`; no generated contract is checked in. The aggregate includes admitted cassette operations. See [Cassettes](./cassettes.md) for their manifest and proxy contract. Notable current behavior:
@@ -27,13 +27,23 @@ The authoritative parameters, schemas, and methods are compiled from route regis
 
 There is no `/v1/search`, `/v1/sessions/summary`, or hash-based session route.
 
+### Attribution repair
+
+`POST /v1/admin/raw-turns/attribution-repair` records an audited, append-only attribution correction for exactly one raw turn — selected by `raw_turn_id` or `paper_proxy_request_id` — without modifying `raw_turns`, then synchronously re-derives the previous and effective sessions.
+
+A `200` is a completed repair. A `202` means the correction committed and is effective, but the synchronous projection rebuild did not finish: `projections_pending` names the stale sessions, which the derive worker converges on its own — the repair is recorded, so do not retry it.
+
+`source_cleanup_pending` is independent of the status code and can accompany either. It discloses an emptied source-session row the cleanup step failed to delete: cosmetic, anchoring no effective turns, and — unlike `projections_pending` — retried by nothing. It does not resolve on its own.
+
 ## Private ingest API
 
 The private ingest API defaults to `:8082` and serves its separate contract at `GET /openapi`. The all-in-one `tapes serve` stack starts it alongside the proxy and read API; `tapes serve ingest` runs it as a standalone sidecar. Its write routes are:
 
 - `POST /v1/ingest` — append one completed conversation turn;
-- `POST /v1/ingest/transcript` — append transcript capture data;
+- `POST /v1/ingest/transcript` — append one harness transcript file or spawn-anchor row;
 - `GET /ping` — health.
+
+A transcript payload is the main session transcript, one subagent's transcript, or a Codex spawn-anchor row (a `sub_agent_activity` rollout record). `agent_id` and `tool_use_id` carry the subagent fork edge the deriver reconciles against the wire capture. The optional `kind` field qualifies Codex anchor rows: absent or empty means spawn evidence; `"interacted"` marks a re-entry record (`send_message`, `followup_task`) that is stored for future rendering and deliberately ignored by derivation. Rows deduplicate on a content hash of `records`, so re-uploading unchanged content is a no-op while a grown transcript appends a new version; the deriver reads the latest version per (session, agent, lifecycle kind), so an interacted row never supersedes a spawn anchor.
 
 Run the standalone form only for sidecar/gateway capture:
 

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -39,6 +39,16 @@ The deriver projects raw turns into the read model:
 
 Derived IDs are deterministic. Re-deriving unchanged raw input reproduces the same projection, and the deriver prunes derived records no longer present in the projection. This makes derivation idempotent and safe to run repeatedly.
 
+### Subagent threads
+
+Raw turns carry a per-turn thread id when a harness runs subagents. Which of a harness's own request headers resolve to that id is harness-native knowledge, and its canonical home is the `tapes-harnesses` crate (`src/envelope.rs`); the language-neutral corpus in `fixtures/thread/` pins the same contract for every independent reader. Start at both when adding a harness or writing a second implementation.
+
+The deriver keeps a session's threads inside that session's projection: each thread becomes an `agent` span named `subagent`, parented to the tool span that spawned it, with the thread's own LLM and tool spans nested beneath it and a `rejoin` link back to the spawning tool span. Claude Code and Codex both project this shape — Claude threads anchor through the `Task` tool, Codex threads through `spawn_agent`, recursively for nested spawns. For Codex it holds for the terminal CLI and the ChatGPT desktop app alike: the shape depends on the anchors a capture client uploads, not on how the harness was launched.
+
+The spawn anchor — which tool call created which thread — is not on the wire for either harness. It arrives as transcript-source rows through the private ingest API: Claude's per-agent transcript names its spawning `tool_use_id`; Codex parent rollouts carry `sub_agent_activity` records joining the `spawn_agent` call id to the child thread id. Reconciliation joins those rows against the wire capture during derivation. A thread without a usable anchor degrades safely: its agent span parents to the trace root instead of a guessed tool call, and the derive report's reconcile block counts it (`codex_threads_unanchored`).
+
+Codex subagents share the root session's harness session id, so a captured run is one session: only the root appears in the sessions list, its traces contain the child runs inline, and rollups fold child usage into the root. Re-entering an existing thread (`followup_task`, `send_message`) does not open a new agent span — the thread's whole conversation collapses under its first spawn anchor, matching Claude subagent semantics.
+
 ## Search
 
 The embedding worker embeds **main-conversation LLM spans** into PostgreSQL using pgvector. Search is span-only: `/v1/search/spans`, `tapesctl search`, and the MCP `search` tool all return individual span hits with session, trace, and turn context. They do not search session objects or a conversation DAG.


### PR DESCRIPTION
## Summary

- Documents the subagent-thread shape the deriver has produced since Codex nesting landed. The mdBook never mentioned threads or subagents at all.
- Adds the **Subagent threads** section to Architecture: the `agent` span named `subagent` parented to the spawning tool span, its own LLM/tool spans nested beneath, the `rejoin` link back, recursively for nested spawns.
- Says where spawn anchors come from, because they are not on the wire for either harness: Claude's per-agent transcript names its spawning `tool_use_id`; Codex parent rollouts carry `sub_agent_activity` records joining the `spawn_agent` call id to the child thread id. Both arrive as transcript-source rows through the private ingest API.
- Points the thread-id paragraph at the two homes a second implementation needs: the `tapes-harnesses` crate (`src/envelope.rs`) that owns the header vocabulary, and the `fixtures/thread/` corpus that pins it for every independent reader. That resolution is already implemented four times across two languages, so the corpus is what keeps a fifth from drifting.
- Documents `POST /v1/admin/raw-turns/attribution-repair` with its 200/202 semantics, `projections_pending`, and `source_cleanup_pending`.
- Documents the transcript-ingest `kind` field contract: absent means spawn evidence, `"interacted"` marks an inert re-entry row, plus the dedup and version-selection rules that keep an interacted row from superseding a spawn anchor.

## How it works

The section is written against the deriver and the ingest API, not against any one capture client — which is what makes it stay true as clients change. Nesting needs two pieces of evidence: a per-turn thread id (on the request) and a spawn anchor (only in transcript-source rows). A thread that arrives without a usable anchor degrades visibly rather than guessing: its agent span parents to the trace root and the derive report's reconcile block counts it as `codex_threads_unanchored`.

For the same reason the Codex sentence covers the terminal CLI and the ChatGPT desktop app together. The shape follows from the anchors a client uploads, not from how the harness was launched, and both `tapesctl start codex` and Paper's daemon upload them.

## Notes for the reviewer

This branch originally carried a second commit repointing OpenAPI references at the generated `/openapi` contract. `main` has since made that change itself (#272, #283), so the commit was dropped rather than rebased — the only surviving conflict was in the `apis.md` route table, resolved by keeping main's cassette routes *and* adding the attribution-repair route.

## Test plan

- [x] `nix develop --command make docs-build` — mdBook builds clean
- [x] Verified against `main` that the architecture section is still novel (no subagent/thread/spawn content there) and that `apis.md` lacks both the attribution-repair route and the transcript `kind` contract
- [x] Every identifier this PR names re-checked against current `main` source: `attribution-repair`, `paper_proxy_request_id`, `source_cleanup_pending`, `projections_pending`, `codex_threads_unanchored`, `sub_agent_activity`, `interacted`, and the `fixtures/thread/` corpus path
- [ ] Prose accuracy review of the derive/reconcile claims by someone who owns that code

Related to PCC-1021
