### PR TITLE
🔧 fix(lint): stop the contextcheck directive from flapping the lint gate

### DIFF
--- a/cmd/tapes/serve/stack.go
+++ b/cmd/tapes/serve/stack.go
@@ -249,7 +249,17 @@ func (stack *Stack) Run(ctx context.Context) error {
 
 	stack.Logger.Info("starting api server", "api_addr", stack.APIListen)
 
-	ingestServer, err := ingest.New(ingest.Config{ //nolint:contextcheck
+	// contextcheck is right that this chain drops `ctx`: the ingest server's
+	// capture workers persist each turn under context.Background()
+	// (proxy/worker/pool.go, processJob), deliberately, so that a shutdown or
+	// a cancelled request cannot abandon a captured turn mid-persist. Capture
+	// durability outranks prompt cancellation here.
+	//
+	// nolintlint rides along because contextcheck's cross-package analysis
+	// resolves this chain only some of the time: on the runs where it does
+	// not, the directive reads as unused and reds the lint gate on a tree
+	// that has not changed. Suppressing both keeps the gate deterministic.
+	ingestServer, err := ingest.New(ingest.Config{ //nolint:contextcheck,nolintlint
 		ListenAddr: stack.IngestListen,
 		Project:    stack.Project,
 	}, driver, stack.Logger)


### PR DESCRIPTION
## Summary

`tapes:check-lint` fails intermittently on trees that have not changed. This makes that one site deterministic and writes down why its `//nolint` exists.

## What is actually happening

`contextcheck`'s finding is **real**. `Stack.Run` holds a `ctx`; the chain into the capture worker pool drops it, because `processJob` persists each turn under `context.Background()` (`proxy/worker/pool.go:171`). That is deliberate and dates to the worker pool's original non-blocking design (#37) — a shutdown or a cancelled request must not abandon a captured turn mid-persist. Capture durability outranks prompt cancellation.

So the directive is load-bearing, not stale. **Deleting it would be the wrong fix** — it would trade this failure for a `contextcheck` failure on every run where the analysis does resolve.

What is not deterministic is the *detection*. `contextcheck`'s cross-package analysis resolves that chain only some of the time, and on the runs where it does not, `nolintlint` reports the directive as unused and reds the gate.

## Evidence

Identical Go trees, same `main` parent `43c69da2`, opposite results:

| Merge commit | PR head | `tapes:check-lint` |
| --- | --- | --- |
| `3d9d5439` | `02ef213` | pass — "Succeeded in 57.4s" |
| `96ad2d0d` | `77a5a51` | error — "Errored in 43.2s" |

Both are heads of #303, a docs-only PR. The delta between them is one rewritten markdown paragraph; zero Go files changed. CI's own pinned `golangci-lint` (`v2.8.0`, per `.dagger/linting.go`) run locally over `./...` with this repo's `.golangci.yml` reports the tree clean, so the finding does not reproduce outside CI.

## What this changes

Adds `nolintlint` to that one directive, so the outcome is the same whether or not `contextcheck` resolves, and records the rationale next to it. The directive arrived in #266 with no explanation, which is exactly why it read as deletable — the comment is the durable half of this change.

## The follow-up this does not do

The real fix is to stop dropping the context: thread a parent into the worker pool and detach it with `context.WithoutCancel`, keeping values while refusing cancellation. That satisfies `contextcheck` honestly and lets **both** directives go away. It changes worker lifecycle and shutdown semantics, so it wants its own review and tests rather than riding along here.

Marked `related to` rather than `fixes` for that reason — the random reds stop with this PR, but PCC-1179 also carries the durable fix. Close or re-scope it as you see fit.

## Test plan

- [x] `go build ./...` and `go vet ./cmd/tapes/serve/` — clean
- [x] `golangci-lint@v2.8.0` (CI's pinned version) over `./cmd/...` with the repo config — 0 issues
- [ ] Repeated CI runs to confirm the gate stops flapping — only observable here, since the failure does not reproduce locally

related to PCC-1179
