### PR TITLE
Update README splash for tapes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <h1>
 <p align="center">
-  <img width="1280" height="640" alt="image" src="https://github.com/user-attachments/assets/133642d6-88e6-4f96-be7a-e6e109a59e5d" />
+  <img width="1280" height="640" alt="Tapes logo" src="https://github.com/user-attachments/assets/133642d6-88e6-4f96-be7a-e6e109a59e5d" />
   <br><code>tapes</code>
 </h1>
 </p>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <h1>
 <p align="center">
-  <img src="./tapes.png" alt="Tapes Logo">
+  <img width="1280" height="640" alt="image" src="https://github.com/user-attachments/assets/133642d6-88e6-4f96-be7a-e6e109a59e5d" />
   <br><code>tapes</code>
 </h1>
 </p>
@@ -19,6 +19,7 @@
 
 <p align="center">
   <img src="https://img.shields.io/github/stars/papercomputeco/tapes">
+
   ·
   <a target="_blank" href="https://github.com/papercomputeco/tapes/releases/latest">
     <img src="https://img.shields.io/github/v/release/papercomputeco/tapes?style=flat-square">


### PR DESCRIPTION
Updated splash image for tapes 


<img width="1280" height="640" alt="image" src="https://github.com/user-attachments/assets/20d34fd8-be72-4e65-ab87-54a2d811a2ae" />
