### PR TITLE
✨ feat: propagate canonical request IDs through capture

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -90,7 +90,12 @@ func newServer(config Config, driver storage.Driver, log *slog.Logger, docs tape
 		openapi:        NewOpenAPIParser(docs),
 	}
 
-	// RED metrics is registered first so it sits as the outermost wrapper.
+	// Correlation is the outermost request middleware so every downstream log,
+	// including metrics/recovery error paths, can share one validated ID.
+	app.Use(requestIDMiddleware(log))
+
+	// RED metrics is registered after correlation so it remains outside the
+	// recovery middleware while inheriting the request context.
 	// Order matters: the request-count and duration increments run AFTER
 	// c.Next() returns, not in a defer, so a panic unwinding through them
 	// would skip those updates. Putting recover.New() inside the metrics

--- a/api/middleware_test.go
+++ b/api/middleware_test.go
@@ -1,0 +1,80 @@
+package api
+
+import (
+	"bytes"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	tapeslogger "github.com/papercomputeco/tapes/pkg/logger"
+	"github.com/papercomputeco/tapes/pkg/storage/inmemory"
+)
+
+var _ = Describe("request ID middleware", func() {
+	It("TestTapesAPIRequestIDMiddlewarePropagation", func() {
+		validRequestID := uuid.NewString()
+		uppercaseRequestID := strings.ToUpper(validRequestID)
+		compactRequestID := strings.ReplaceAll(validRequestID, "-", "")
+		scenarios := []struct {
+			name     string
+			provided string
+			preserve bool
+		}{
+			{name: "valid", provided: validRequestID, preserve: true},
+			{name: "missing"},
+			{name: "malformed", provided: "not-a-uuid"},
+			{name: "non-v4", provided: "6ba7b810-9dad-11d1-80b4-00c04fd430c8"},
+			{name: "uppercase", provided: uppercaseRequestID},
+			{name: "compact", provided: compactRequestID},
+			{name: "oversized", provided: strings.Repeat("a", 1024)},
+		}
+
+		generated := map[string]struct{}{}
+		for _, scenario := range scenarios {
+			var logs bytes.Buffer
+			baseLogger := slog.New(slog.NewJSONHandler(&logs, nil))
+			server, err := NewServer(Config{ListenAddr: ":0"}, inmemory.NewDriver(), baseLogger)
+			Expect(err).NotTo(HaveOccurred())
+
+			var contextRequestID string
+			var contextLogger *slog.Logger
+			server.app.Get("/request-id-probe", func(c *fiber.Ctx) error {
+				contextRequestID = tapeslogger.RequestIDFromContext(c.UserContext())
+				contextLogger = tapeslogger.RequestLoggerFromContext(c.UserContext())
+				contextLogger.Info("handled probe")
+				return c.SendStatus(http.StatusNoContent)
+			})
+
+			req, err := http.NewRequest(http.MethodGet, "/request-id-probe", nil)
+			Expect(err).NotTo(HaveOccurred())
+			if scenario.provided != "" {
+				req.Header.Set("X-Request-Id", scenario.provided)
+			}
+
+			resp, err := server.app.Test(req)
+			Expect(err).NotTo(HaveOccurred(), scenario.name)
+			requestID := resp.Header.Get("X-Request-Id")
+			Expect(requestID).NotTo(BeEmpty(), scenario.name)
+			Expect(contextRequestID).To(Equal(requestID), scenario.name)
+			Expect(contextLogger).NotTo(BeNil(), scenario.name)
+			Expect(logs.String()).To(ContainSubstring(`"request_id":"`+requestID+`"`), scenario.name)
+
+			parsed, err := uuid.Parse(requestID)
+			Expect(err).NotTo(HaveOccurred(), scenario.name)
+			Expect(parsed.Version()).To(Equal(uuid.Version(4)), scenario.name)
+			if scenario.preserve {
+				Expect(requestID).To(Equal(scenario.provided), scenario.name)
+			} else {
+				Expect(requestID).NotTo(Equal(scenario.provided), scenario.name)
+				generated[requestID] = struct{}{}
+			}
+		}
+
+		Expect(generated).To(HaveLen(6), "separate invalid or missing attempts need unique IDs")
+	})
+})

--- a/api/openapi.go
+++ b/api/openapi.go
@@ -72,7 +72,7 @@ func NewOpenAPIParser(docs tapesoapi.TypeDocs) *tapesoapi.Parser {
 // driver — the handlers it registers are function values, and nothing calls
 // them.
 func CompileOpenAPI(ctx context.Context, docs tapesoapi.TypeDocs) (*tapesoapi.CompiledDoc, error) {
-	server, err := newServer(
+	server, err := newServer( //nolint:contextcheck // Fiber establishes context only when a request arrives.
 		Config{ListenAddr: ":0"},
 		nil,
 		slog.New(slog.DiscardHandler),

--- a/api/request_id_middleware.go
+++ b/api/request_id_middleware.go
@@ -1,0 +1,40 @@
+package api
+
+import (
+	"log/slog"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
+
+	tapeslogger "github.com/papercomputeco/tapes/pkg/logger"
+)
+
+const (
+	requestIDHeader       = "X-Request-Id"
+	maxRequestIDTextBytes = 36
+)
+
+func requestIDMiddleware(log *slog.Logger) fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		requestID := canonicalRequestID(c.Get(requestIDHeader))
+		requestLog := log.With("request_id", requestID)
+
+		// Replace the untrusted header before any downstream middleware or
+		// handler can read, forward, or log it.
+		c.Request().Header.Set(requestIDHeader, requestID)
+		c.Set(requestIDHeader, requestID)
+		c.SetUserContext(tapeslogger.WithRequest(c.Context(), requestID, requestLog))
+
+		return c.Next()
+	}
+}
+
+func canonicalRequestID(candidate string) string {
+	if len(candidate) <= maxRequestIDTextBytes {
+		if parsed, err := uuid.Parse(candidate); err == nil &&
+			parsed.Version() == uuid.Version(4) && parsed.String() == candidate {
+			return candidate
+		}
+	}
+	return uuid.NewString()
+}

--- a/cmd/tapes/serve/api/api.go
+++ b/cmd/tapes/serve/api/api.go
@@ -213,7 +213,7 @@ func (c *apiCommander) run(ctx context.Context) error {
 		)
 	}
 
-	server, err := api.NewServer(apiConfig, driver, c.logger)
+	server, err := api.NewServer(apiConfig, driver, c.logger) //nolint:contextcheck // Fiber owns request contexts.
 	if err != nil {
 		return fmt.Errorf("could not build new api server: %w", err)
 	}

--- a/cmd/tapes/serve/stack.go
+++ b/cmd/tapes/serve/stack.go
@@ -235,7 +235,7 @@ func (stack *Stack) Run(ctx context.Context) error {
 		"provider", stack.ProviderType,
 	)
 
-	apiServer, err := api.NewServer(api.Config{
+	apiServer, err := api.NewServer(api.Config{ //nolint:contextcheck // Fiber owns request contexts.
 		ListenAddr:       stack.APIListen,
 		Embedder:         embedder,
 		SpanSearcher:     spanSearcher,

--- a/extproc/processor_test.go
+++ b/extproc/processor_test.go
@@ -3,6 +3,7 @@ package extproc
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"io"
 	"log/slog"
 	"net/http"
@@ -721,6 +722,80 @@ data: {"type":"response.completed","response":{"id":"resp_1","object":"response"
 		Expect(line).To(ContainSubstring(`"model_family":"claude-opus-4"`))
 		Expect(line).To(ContainSubstring(`"req_bytes":`))
 		Expect(line).To(ContainSubstring(`"elapsed_ms":`))
+	})
+
+	It("TestExtProcPreservesCanonicalRequestIDAndSignalsMissingFallback", func() {
+		// Given a canonical request ID arriving from the trusted upstream
+		// gateways and a structured logger that captures ext-proc events.
+		const canonicalRequestID = "18a36a78-1038-4bcb-8965-8e0d4c0f51c2"
+		var logs bytes.Buffer
+		previous := slog.Default()
+		slog.SetDefault(slog.New(slog.NewJSONHandler(&logs, &slog.HandlerOptions{Level: slog.LevelInfo})))
+		defer slog.SetDefault(previous)
+		requestBody := []byte(`{"model":"claude-3-5-sonnet-20241022","max_tokens":8,"messages":[{"role":"user","content":"hi"}]}`)
+		responseBody := []byte(`{"id":"msg_1","type":"message","role":"assistant","model":"claude-3-5-sonnet-20241022","content":[{"type":"text","text":"hi"}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}`)
+
+		// When a complete turn is captured with that header.
+		canonicalStream := &fakeStream{
+			ctx: context.Background(),
+			toSend: []*extprocv3.ProcessingRequest{
+				headerReq(map[string]string{
+					":method":      "POST",
+					":path":        "/v1/messages",
+					"x-request-id": canonicalRequestID,
+				}),
+				reqBodyReq(requestBody, true),
+				respHeaderReq("200", "application/json"),
+				respBodyReq(responseBody, true),
+			},
+		}
+		Expect(proc.Process(canonicalStream)).To(Succeed())
+
+		// Then the dispatched TurnEnvelope preserves the canonical value
+		// byte-for-byte rather than replacing it.
+		var captured TurnEnvelope
+		Eventually(func() string {
+			body := ingestBody.Load()
+			if body == nil {
+				return ""
+			}
+			Expect(json.Unmarshal(body.([]byte), &captured)).To(Succeed())
+			return captured.Meta.RequestID
+		}).WithTimeout(2 * time.Second).Should(Equal(canonicalRequestID))
+
+		// When the same canonical ID reaches a terminal log path, and a
+		// separate request arrives without any upstream correlation header.
+		canonicalDrop := &fakeStream{
+			ctx: context.Background(),
+			toSend: []*extprocv3.ProcessingRequest{
+				headerReq(map[string]string{
+					":method":      "POST",
+					":path":        "/v1/messages",
+					"x-request-id": canonicalRequestID,
+				}),
+				reqBodyReq(requestBody, true),
+			},
+		}
+		Expect(proc.Process(canonicalDrop)).To(Succeed())
+
+		fallbackObserver := newRecordingObserver()
+		proc.Dispatcher().SetObserver(fallbackObserver)
+		missingIDStream := &fakeStream{
+			ctx: context.Background(),
+			toSend: []*extprocv3.ProcessingRequest{
+				headerReq(map[string]string{":method": "POST", ":path": "/v1/messages"}),
+				reqBodyReq(requestBody, true),
+			},
+		}
+		Expect(proc.Process(missingIDStream)).To(Succeed())
+
+		// Then logs retain the canonical ID, while only the missing-header
+		// request receives the visibly non-canonical extproc-* fallback that
+		// the observer sees on the same terminal outcome.
+		fallbackRequestID := fallbackObserver.lastRequestID
+		Expect(fallbackRequestID).To(MatchRegexp(`^extproc-[0-9a-f]{16}$`))
+		Expect(logs.String()).To(ContainSubstring(`"request_id":"` + canonicalRequestID + `"`))
+		Expect(logs.String()).To(ContainSubstring(`"request_id":"` + fallbackRequestID + `"`))
 	})
 
 	It("empty 200 upstream body: drops with reason=empty_response, not reducer_error", func() {

--- a/ingest/CONTRACT
+++ b/ingest/CONTRACT
@@ -16,4 +16,4 @@
 #
 # ingest/openapi_seal_test.go recompiles and compares. If it fails, it prints
 # the value to write here. Bump it in the same change that moved the contract.
-sha256:8d92b4f6b146158078c9323ec0169bc99f02413ba4d67e0691cda50c51e9b054
+sha256:d958365eddecd8dfafabe205043defc4535da93371ee121cbf3d66d28a7098c6

--- a/ingest/capture_fake_test.go
+++ b/ingest/capture_fake_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sync"
 
+	tapeslogger "github.com/papercomputeco/tapes/pkg/logger"
 	"github.com/papercomputeco/tapes/pkg/storage"
 	"github.com/papercomputeco/tapes/pkg/storage/inmemory"
 )
@@ -24,6 +25,8 @@ type captureDriver struct {
 	mu          sync.Mutex
 	rawTurns    []storage.RawTurnRecord
 	ingestCalls []storage.IngestTurnRequest
+	requestIDs  []string
+	upstreamIDs []string
 }
 
 func newCaptureDriver() *captureDriver {
@@ -47,11 +50,23 @@ func (d *captureDriver) CountRawTurns(_ context.Context) (int64, error) {
 	return int64(len(d.rawTurns)), nil
 }
 
-func (d *captureDriver) IngestTurn(_ context.Context, req storage.IngestTurnRequest) (storage.IngestTurnResult, error) {
+func (d *captureDriver) IngestTurn(ctx context.Context, req storage.IngestTurnRequest) (storage.IngestTurnResult, error) {
 	d.mu.Lock()
 	d.ingestCalls = append(d.ingestCalls, req)
+	d.requestIDs = append(d.requestIDs, tapeslogger.RequestIDFromContext(ctx))
+	d.upstreamIDs = append(d.upstreamIDs, tapeslogger.UpstreamRequestIDFromContext(ctx))
 	d.mu.Unlock()
+	if log := tapeslogger.RequestLoggerFromContext(ctx); log != nil {
+		log.Info("test dependency write")
+	}
 	return storage.IngestTurnResult{SessionID: "00000000-0000-0000-0000-000000000001"}, nil
+}
+
+// WorkerCorrelation returns correlation restored on asynchronous storage calls.
+func (d *captureDriver) WorkerCorrelation() ([]string, []string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return append([]string(nil), d.requestIDs...), append([]string(nil), d.upstreamIDs...)
 }
 
 // RawTurns returns a copy of every raw turn the server captured.

--- a/ingest/ingest.go
+++ b/ingest/ingest.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/papercomputeco/tapes/pkg/llm"
 	"github.com/papercomputeco/tapes/pkg/llm/provider"
+	tapeslogger "github.com/papercomputeco/tapes/pkg/logger"
 	"github.com/papercomputeco/tapes/pkg/sessions"
 	"github.com/papercomputeco/tapes/pkg/storage"
 	oas "github.com/papercomputeco/tapes/pkg/tapesoapi"
@@ -126,7 +127,7 @@ type TurnPayload struct {
 	RawResponseWithheld bool `json:"raw_response_withheld,omitempty"`
 
 	// Meta is the capture adapter's metadata block. Parsed for the
-	// fields ingest promotes (request_id for raw-turn dedup); the
+	// fields ingest promotes (request IDs and raw-turn dedup); the
 	// verbatim JSON is persisted alongside the raw turn so fields
 	// unknown to this build survive.
 	Meta TurnMeta `json:"meta"`
@@ -147,12 +148,14 @@ type TurnPayload struct {
 
 // TurnMeta mirrors the capture adapter's meta block (tapes-extproc
 // TurnMeta). Every field is optional; adapters that predate a field
-// simply omit it. Ingest only reads RequestID directly (raw-turn
-// dedup) — the rest ride along verbatim in the raw layer and become
-// queryable post-derive.
+// simply omit it. Ingest reads the two request IDs and ThreadID for
+// asynchronous processing; the full block rides along verbatim in the raw
+// layer and becomes queryable post-derive. RequestID is Paper's canonical attempt ID;
+// UpstreamRequestID, when present, is issued independently by the provider.
 type TurnMeta struct {
-	RequestID   string `json:"request_id,omitempty"`
-	ContentType string `json:"content_type,omitempty"`
+	RequestID         string `json:"request_id,omitempty"`
+	UpstreamRequestID string `json:"upstream_request_id,omitempty"`
+	ContentType       string `json:"content_type,omitempty"`
 
 	// ThreadID is the harness sub-thread id resolved by the capture
 	// adapter (extproc headers.ThreadID); "" for main-thread calls.
@@ -907,6 +910,15 @@ func validateReducedResponse(resp *llm.ChatResponse) error {
 	return nil
 }
 
+const maxWorkerCorrelationBytes = 256
+
+func boundedWorkerCorrelation(value string) string {
+	if len(value) > maxWorkerCorrelationBytes {
+		return ""
+	}
+	return value
+}
+
 // processTurn parses a raw turn payload and enqueues it for async DAG storage.
 // Returned errors wrap one of ErrEnvelope / ErrUnprocessable / ErrDownstream so
 // the caller can map to an HTTP status without re-parsing the message.
@@ -939,7 +951,14 @@ func (s *Server) processTurn(turn *TurnPayload, weight int) error {
 		sessHarnessSessionID = turn.Session.HarnessSessionID
 		sessOrgID = turn.Session.OrgID
 	}
-	s.logger.Debug("ingesting turn",
+	requestID := boundedWorkerCorrelation(turn.Meta.RequestID)
+	upstreamRequestID := boundedWorkerCorrelation(turn.Meta.UpstreamRequestID)
+	log := tapeslogger.WithRequestFields(
+		s.logger,
+		requestID,
+		upstreamRequestID,
+	)
+	log.Debug("ingesting turn",
 		"provider", prov.Name(),
 		"agent", turn.AgentName,
 		"model", parsedReq.Model,
@@ -949,17 +968,19 @@ func (s *Server) processTurn(turn *TurnPayload, weight int) error {
 	)
 
 	switch reason := s.workerPool.Admit(worker.Job{
-		Provider:  prov.Name(),
-		AgentName: turn.AgentName,
-		ThreadID:  turn.Meta.ThreadID,
-		Req:       parsedReq,
-		Resp:      &parsedResp,
-		Session:   turn.Session,
-		Weight:    weight,
+		Provider:          prov.Name(),
+		AgentName:         turn.AgentName,
+		ThreadID:          turn.Meta.ThreadID,
+		RequestID:         requestID,
+		UpstreamRequestID: upstreamRequestID,
+		Req:               parsedReq,
+		Resp:              &parsedResp,
+		Session:           turn.Session,
+		Weight:            weight,
 	}); reason {
 	case worker.RejectNone:
 	case worker.RejectByteBudget:
-		s.logger.Error("ingest enqueue failed: worker byte budget exceeded",
+		log.Error("ingest enqueue failed: worker byte budget exceeded",
 			"provider", prov.Name(),
 			"agent", turn.AgentName,
 			"model", parsedReq.Model,
@@ -968,7 +989,7 @@ func (s *Server) processTurn(turn *TurnPayload, weight int) error {
 		s.metrics.SetQueueDepth(s.workerPool.Len())
 		return ErrWorkerByteBudget
 	case worker.RejectQueueFull:
-		s.logger.Error("ingest enqueue failed: worker queue full",
+		log.Error("ingest enqueue failed: worker queue full",
 			"provider", prov.Name(),
 			"agent", turn.AgentName,
 			"model", parsedReq.Model,

--- a/ingest/ingest_test.go
+++ b/ingest/ingest_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"log/slog"
 	"net"
 	"net/http"
 	"strings"
@@ -59,7 +60,10 @@ func reducedResponse(model, text string, usage *llm.Usage) llm.ChatResponse {
 }
 
 func newTestServer() (*ingest.Server, *captureDriver, string) {
-	logger := tapeslogger.NewNoop()
+	return newTestServerWithLogger(tapeslogger.NewNoop())
+}
+
+func newTestServerWithLogger(logger *slog.Logger) (*ingest.Server, *captureDriver, string) {
 	driver := newCaptureDriver()
 
 	s, err := ingest.New(
@@ -214,6 +218,89 @@ var _ = Describe("Ingest Server", func() {
 	})
 
 	Describe("POST /v1/ingest", func() {
+		It("TestTapesIngestWorkerPropagatesRequestIDInJobMetadata", func() {
+			const (
+				requestID         = "d9de5526-b3c2-44d7-b2d0-2c555ef012f2"
+				upstreamRequestID = "provider-request-42"
+			)
+			var logs bytes.Buffer
+			log := slog.New(slog.NewJSONHandler(&logs, nil))
+			correlationServer, correlationDriver, correlationURL := newTestServerWithLogger(log)
+			defer func() { Expect(correlationServer.Close()).To(Succeed()) }()
+
+			payload := ingest.TurnPayload{
+				Provider: "ollama",
+				RawRequest: mustJSON(ollamaRequest{
+					Model:    "llama3",
+					Messages: []ollamaMessage{{Role: "user", Content: "Hello"}},
+				}),
+				Response: reducedResponse("llama3", "Hi", nil),
+				Meta: ingest.TurnMeta{
+					RequestID:         requestID,
+					UpstreamRequestID: upstreamRequestID,
+				},
+				Session: &sessions.IngestEnvelope{
+					HarnessID:        "claude",
+					HarnessSessionID: "correlation-session",
+				},
+			}
+			body, err := json.Marshal(payload)
+			Expect(err).NotTo(HaveOccurred())
+			resp, err := client.Post(correlationURL+"/v1/ingest", "application/json", bytes.NewReader(body))
+			Expect(err).NotTo(HaveOccurred())
+			defer resp.Body.Close()
+			Expect(resp.StatusCode).To(Equal(http.StatusAccepted))
+
+			Eventually(func() []string {
+				requestIDs, _ := correlationDriver.WorkerCorrelation()
+				return requestIDs
+			}).Should(ConsistOf(requestID))
+			_, upstreamIDs := correlationDriver.WorkerCorrelation()
+			Expect(upstreamIDs).To(ConsistOf(upstreamRequestID))
+			Expect(logs.String()).To(ContainSubstring(`"request_id":"` + requestID + `"`))
+			Expect(logs.String()).To(ContainSubstring(`"upstream_request_id":"` + upstreamRequestID + `"`))
+		})
+
+		It("TestRequestAndUpstreamRequestIDsRemainDistinctAndUnlabeled", func() {
+			const (
+				requestID         = "56ae9423-cc87-4a45-bccc-b21752a5783c"
+				upstreamRequestID = "provider-request-99"
+			)
+			payload := ingest.TurnPayload{
+				Provider: "ollama",
+				RawRequest: mustJSON(ollamaRequest{
+					Model:    "llama3",
+					Messages: []ollamaMessage{{Role: "user", Content: "Hello"}},
+				}),
+				Response: reducedResponse("llama3", "Hi", nil),
+				Meta: ingest.TurnMeta{
+					RequestID:         requestID,
+					UpstreamRequestID: upstreamRequestID,
+				},
+				Session: &sessions.IngestEnvelope{
+					HarnessID:        "claude",
+					HarnessSessionID: "label-safety-session",
+				},
+			}
+			body, err := json.Marshal(payload)
+			Expect(err).NotTo(HaveOccurred())
+			resp, err := client.Post(baseURL+"/v1/ingest", "application/json", bytes.NewReader(body))
+			Expect(err).NotTo(HaveOccurred())
+			resp.Body.Close()
+			Expect(resp.StatusCode).To(Equal(http.StatusAccepted))
+
+			families, err := server.Metrics().Registry().Gather()
+			Expect(err).NotTo(HaveOccurred())
+			for _, family := range families {
+				for _, metric := range family.Metric {
+					for _, label := range metric.Label {
+						Expect(label.GetName()).NotTo(BeElementOf("request_id", "upstream_request_id"))
+						Expect(label.GetValue()).NotTo(BeElementOf(requestID, upstreamRequestID))
+					}
+				}
+			}
+		})
+
 		It("accepts a valid ollama turn and captures it into the raw layer", func() {
 			payload := ingest.TurnPayload{
 				Provider:  "ollama",

--- a/pkg/logger/request.go
+++ b/pkg/logger/request.go
@@ -1,0 +1,50 @@
+package logger
+
+import (
+	"context"
+	"log/slog"
+)
+
+type requestContext struct {
+	requestID string
+	logger    *slog.Logger
+}
+
+type requestContextKey struct{}
+
+// WithRequest stores the canonical request ID and its scoped logger in ctx.
+func WithRequest(ctx context.Context, requestID string, log *slog.Logger) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, requestContextKey{}, requestContext{
+		requestID: requestID,
+		logger:    log,
+	})
+}
+
+// RequestIDFromContext returns the canonical request ID stored in ctx.
+func RequestIDFromContext(ctx context.Context) string {
+	request, ok := requestFromContext(ctx)
+	if !ok {
+		return ""
+	}
+	return request.requestID
+}
+
+// RequestLoggerFromContext returns the request-scoped logger stored in ctx.
+func RequestLoggerFromContext(ctx context.Context) *slog.Logger {
+	request, ok := requestFromContext(ctx)
+	if !ok {
+		return nil
+	}
+	return request.logger
+}
+
+func requestFromContext(ctx context.Context) (requestContext, bool) {
+	if ctx == nil {
+		return requestContext{}, false
+	}
+	request, ok := ctx.Value(requestContextKey{}).(requestContext)
+	return request, ok
+}

--- a/pkg/logger/request.go
+++ b/pkg/logger/request.go
@@ -6,8 +6,45 @@ import (
 )
 
 type requestContext struct {
-	requestID string
-	logger    *slog.Logger
+	requestID         string
+	upstreamRequestID string
+	logger            *slog.Logger
+}
+
+// WithRequestMetadata restores correlation copied across an asynchronous
+// boundary and builds a logger whose fields keep Paper and provider IDs
+// distinct.
+func WithRequestMetadata(
+	ctx context.Context,
+	requestID string,
+	upstreamRequestID string,
+	log *slog.Logger,
+) context.Context {
+	log = WithRequestFields(log, requestID, upstreamRequestID)
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, requestContextKey{}, requestContext{
+		requestID:         requestID,
+		upstreamRequestID: upstreamRequestID,
+		logger:            log,
+	})
+}
+
+// WithRequestFields returns a child logger with separate Paper and provider
+// request-ID fields. Empty values are omitted and never substitute for one
+// another.
+func WithRequestFields(log *slog.Logger, requestID, upstreamRequestID string) *slog.Logger {
+	if log == nil {
+		return nil
+	}
+	if requestID != "" {
+		log = log.With("request_id", requestID)
+	}
+	if upstreamRequestID != "" {
+		log = log.With("upstream_request_id", upstreamRequestID)
+	}
+	return log
 }
 
 type requestContextKey struct{}
@@ -30,6 +67,16 @@ func RequestIDFromContext(ctx context.Context) string {
 		return ""
 	}
 	return request.requestID
+}
+
+// UpstreamRequestIDFromContext returns the provider-issued request ID stored
+// in ctx. It is never substituted for a missing Paper request ID.
+func UpstreamRequestIDFromContext(ctx context.Context) string {
+	request, ok := requestFromContext(ctx)
+	if !ok {
+		return ""
+	}
+	return request.upstreamRequestID
 }
 
 // RequestLoggerFromContext returns the request-scoped logger stored in ctx.

--- a/pkg/logger/request_test.go
+++ b/pkg/logger/request_test.go
@@ -1,7 +1,9 @@
 package logger_test
 
 import (
+	"bytes"
 	"context"
+	"log/slog"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -21,5 +23,21 @@ var _ = Describe("request logging context", func() {
 	It("returns empty values when no request scope is present", func() {
 		Expect(logger.RequestIDFromContext(context.Background())).To(BeEmpty())
 		Expect(logger.RequestLoggerFromContext(context.Background())).To(BeNil())
+	})
+
+	It("keeps provider correlation separate from a missing Paper request ID", func() {
+		var logs bytes.Buffer
+		ctx := logger.WithRequestMetadata(
+			context.Background(),
+			"",
+			"provider-request-7",
+			slog.New(slog.NewJSONHandler(&logs, nil)),
+		)
+
+		Expect(logger.RequestIDFromContext(ctx)).To(BeEmpty())
+		Expect(logger.UpstreamRequestIDFromContext(ctx)).To(Equal("provider-request-7"))
+		logger.RequestLoggerFromContext(ctx).Info("provider-only correlation")
+		Expect(logs.String()).To(ContainSubstring(`"upstream_request_id":"provider-request-7"`))
+		Expect(logs.String()).NotTo(ContainSubstring(`"request_id"`))
 	})
 })

--- a/pkg/logger/request_test.go
+++ b/pkg/logger/request_test.go
@@ -1,0 +1,25 @@
+package logger_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/papercomputeco/tapes/pkg/logger"
+)
+
+var _ = Describe("request logging context", func() {
+	It("stores and retrieves one request ID and its scoped logger", func() {
+		requestLog := logger.NewNoop()
+		ctx := logger.WithRequest(context.Background(), "request-123", requestLog)
+
+		Expect(logger.RequestIDFromContext(ctx)).To(Equal("request-123"))
+		Expect(logger.RequestLoggerFromContext(ctx)).To(BeIdenticalTo(requestLog))
+	})
+
+	It("returns empty values when no request scope is present", func() {
+		Expect(logger.RequestIDFromContext(context.Background())).To(BeEmpty())
+		Expect(logger.RequestLoggerFromContext(context.Background())).To(BeNil())
+	})
+})

--- a/proxy/worker/pool.go
+++ b/proxy/worker/pool.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/papercomputeco/tapes/pkg/derive"
 	"github.com/papercomputeco/tapes/pkg/llm"
+	tapeslogger "github.com/papercomputeco/tapes/pkg/logger"
 	"github.com/papercomputeco/tapes/pkg/merkle"
 	"github.com/papercomputeco/tapes/pkg/sessions"
 	"github.com/papercomputeco/tapes/pkg/storage"
@@ -52,8 +53,13 @@ type Job struct {
 	// the main thread), captured at the wire and stamped onto the
 	// turn's nodes as non-hashed metadata.
 	ThreadID string
-	Req      *llm.ChatRequest
-	Resp     *llm.ChatResponse
+	// RequestID is Paper's canonical identifier for the captured HTTP attempt.
+	// UpstreamRequestID is the provider's independent identifier for its side
+	// of that attempt; it must never replace RequestID when the latter is empty.
+	RequestID         string
+	UpstreamRequestID string
+	Req               *llm.ChatRequest
+	Resp              *llm.ChatResponse
 
 	// Weight is the estimated bytes this job retains live (its parsed body)
 	// while queued and processed; the pool holds it against the byte budget
@@ -163,24 +169,24 @@ func (p *Pool) Enqueue(job Job) bool {
 // until the job finishes processing (released in worker). RejectNone means the
 // job was enqueued; the other reasons name the ceiling that declined it.
 func (p *Pool) Admit(job Job) RejectReason {
+	log := tapeslogger.WithRequestFields(p.logger, job.RequestID, job.UpstreamRequestID)
 	if !p.reserve(job.Weight) {
-		p.logger.Error("job not queued, byte budget exceeded, job dropped",
+		log.Error("job not queued, byte budget exceeded, job dropped",
 			"provider", job.Provider,
 			"model", job.Req.Model,
 		)
 		return RejectByteBudget
 	}
-
 	select {
 	case p.queue <- job:
-		p.logger.Debug("job queued",
+		log.Debug("job queued",
 			"provider", job.Provider,
 			"model", job.Req.Model,
 		)
 		return RejectNone
 	default:
 		p.release(job.Weight)
-		p.logger.Error("job not queued, queue full, job dropped",
+		log.Error("job not queued, queue full, job dropped",
 			"provider", job.Provider,
 			"model", job.Req.Model,
 		)
@@ -249,11 +255,17 @@ func (p *Pool) worker(id uint) {
 // deriver's input), and ensures the turn's sessions row exists so the
 // deriver can resolve it and attach the turn's spans.
 func (p *Pool) processJob(job Job) {
-	ctx := context.Background()
+	ctx := tapeslogger.WithRequestMetadata(
+		context.Background(),
+		job.RequestID,
+		job.UpstreamRequestID,
+		p.logger,
+	)
+	log := tapeslogger.RequestLoggerFromContext(ctx)
 
 	chain := buildTurnChain(job, p.config.Project)
 	if len(chain) == 0 {
-		p.logger.Error("capture skipped: turn produced no nodes",
+		log.Error("capture skipped: turn produced no nodes",
 			"provider", job.Provider,
 		)
 		return
@@ -269,7 +281,9 @@ func (p *Pool) processJob(job Job) {
 // capture inserts the row at ~capture time, so the deriver's
 // received_at fallback is accurate.
 type rawTurnMeta struct {
-	ThreadID string `json:"thread_id,omitempty"`
+	ThreadID          string `json:"thread_id,omitempty"`
+	RequestID         string `json:"request_id,omitempty"`
+	UpstreamRequestID string `json:"upstream_request_id,omitempty"`
 }
 
 // persistRawTurn appends one captured turn to the immutable raw-turn
@@ -286,6 +300,7 @@ type rawTurnMeta struct {
 // Failures are logged, never propagated: a raw-layer outage must not
 // take down capture.
 func (p *Pool) persistRawTurn(ctx context.Context, job Job, chain []*merkle.Node) {
+	log := tapeslogger.RequestLoggerFromContext(ctx)
 	rawStore, ok := p.config.Driver.(storage.RawTurnStore)
 	if !ok || len(job.RawRequest) == 0 {
 		return
@@ -296,32 +311,40 @@ func (p *Pool) persistRawTurn(ctx context.Context, job Job, chain []*merkle.Node
 
 	envelope, harnessSessionID, err := sessions.ResolveHarnessSessionID(job.Session, root.Hash)
 	if err != nil {
-		p.logger.Error("raw turn skipped: resolve harness_session_id",
+		log.Error("raw turn skipped: resolve harness_session_id",
 			"provider", job.Provider, "error", err)
 		return
 	}
 
 	response, err := json.Marshal(job.Resp)
 	if err != nil {
-		p.logger.Error("raw turn skipped: marshal response",
+		log.Error("raw turn skipped: marshal response",
 			"provider", job.Provider, "error", err)
 		return
 	}
 
-	meta, err := json.Marshal(rawTurnMeta{ThreadID: job.ThreadID})
+	meta, err := json.Marshal(rawTurnMeta{
+		ThreadID:          job.ThreadID,
+		RequestID:         job.RequestID,
+		UpstreamRequestID: job.UpstreamRequestID,
+	})
 	if err != nil {
-		p.logger.Error("raw turn skipped: marshal meta",
+		log.Error("raw turn skipped: marshal meta",
 			"provider", job.Provider, "error", err)
 		return
 	}
 
 	sessionJSON, err := json.Marshal(envelope)
 	if err != nil {
-		p.logger.Error("raw turn skipped: marshal session envelope",
+		log.Error("raw turn skipped: marshal session envelope",
 			"provider", job.Provider, "error", err)
 		return
 	}
 
+	requestID := job.RequestID
+	if requestID == "" {
+		requestID = head.Hash
+	}
 	if _, err := rawStore.PutRawTurn(ctx, storage.RawTurnRecord{
 		OrgID:            envelope.OrgID,
 		Source:           storage.RawTurnSourceWire,
@@ -329,16 +352,16 @@ func (p *Pool) persistRawTurn(ctx context.Context, job Job, chain []*merkle.Node
 		AgentName:        job.AgentName,
 		HarnessID:        envelope.HarnessIDOrUnknown(),
 		HarnessSessionID: harnessSessionID,
-		// The leaf (response) node hash is content-addressed and unique
-		// per turn, so it both dedupes an identical re-send and ties the
-		// raw row back to the turn's Merkle identity.
-		RequestID:       head.Hash,
+		// A canonical request ID wins when the capture path supplied one.
+		// The leaf hash remains the legacy local-proxy fallback: it dedupes
+		// identical re-sends without borrowing a provider-issued ID.
+		RequestID:       requestID,
 		RawRequest:      job.RawRequest,
 		Response:        response,
 		Meta:            meta,
 		SessionEnvelope: sessionJSON,
 	}); err != nil {
-		p.logger.Error("raw turn persist failed",
+		log.Error("raw turn persist failed",
 			"provider", job.Provider,
 			"harness_session_id", harnessSessionID,
 			"error", err,
@@ -356,6 +379,7 @@ func (p *Pool) persistRawTurn(ctx context.Context, job Job, chain []*merkle.Node
 // Drivers without the SessionIngester capability (the in-memory test
 // driver) have no sessions surface, so this is a no-op for them.
 func (p *Pool) ingestSession(ctx context.Context, job Job, chain []*merkle.Node) {
+	log := tapeslogger.RequestLoggerFromContext(ctx)
 	ingester, ok := p.config.Driver.(storage.SessionIngester)
 	if !ok || job.Session == nil {
 		return
@@ -366,7 +390,7 @@ func (p *Pool) ingestSession(ctx context.Context, job Job, chain []*merkle.Node)
 		Nodes:        chain,
 		DerivedTitle: derive.SessionTitle(chain[len(chain)-1].Kind, job.Resp),
 	}); err != nil {
-		p.logger.Error("session ingest failed",
+		log.Error("session ingest failed",
 			"provider", job.Provider,
 			"error", err,
 		)


### PR DESCRIPTION
## Summary

- Preserve canonical request IDs through consolidated ext-proc capture and distinguish missing-header fallbacks.
- Install early Tapes API middleware that validates or generates the request ID and exposes it on the response and request context.
- Carry bounded `request_id` and provider `upstream_request_id` metadata independently across asynchronous ingest and worker execution.
- Keep both identifiers out of Prometheus labels and Loki stream labels.

## How it works

The API establishes request-scoped correlation before handlers run. Ingest copies the Paper and provider identifiers into bounded job metadata, and workers restore both fields into their context and structured logger without allowing the provider ID to replace the Paper ID.

## Test plan

- [x] Contract fixture parity
- [x] Full consolidated ext-proc suite
- [x] Ext-proc image build
- [x] Full E2E suite
- [x] Cross-platform binary build
- [x] Focused API, logger, ingest, and worker correlation suites

Fixes PCC-1177
