### PR TITLE
✨ feat: /v1/stats accepts an auth_subject filter

### DIFF
--- a/api/CONTRACT
+++ b/api/CONTRACT
@@ -13,4 +13,4 @@
 #
 # api/openapi_seal_test.go recompiles and compares. If it fails, it prints the
 # value to write here. Bump it in the same change that moved the contract.
-sha256:26755fe576fbd4a9eb57639472a00e8ca1f9de7be1e27296bd85975add46e9c8
+sha256:2a36f0b39cca676a7b877bcde488967c227b3ece431bc84d2c3329a8a688a97e

--- a/api/openapi_routes.go
+++ b/api/openapi_routes.go
@@ -47,12 +47,18 @@ func (s *Server) mountSessions(router *oasfiber.Router) {
 			Description("Returns counts plus cost / token / duration / tool-call / completed-count "+
 				"totals for the window. The numbers are span-grain trace rollup sums (delta-only usage, "+
 				"agent time = sum of trace durations) so they agree with the session and trace views; "+
-				"turn_count counts traces. Filter the window with since/until.").
+				"turn_count counts traces. Filter the window with since/until, and narrow every total "+
+				"to one user with auth_subject — the same subject the /v1/sessions filter takes, so a "+
+				"personal surface can show totals that match the rows beside them.").
 			Tag("sessions").
 			QueryParam("since", oas.String(oas.Format("date-time")),
 				oas.ParamDescription("Only include records at or after this RFC3339 timestamp")).
 			QueryParam("until", oas.String(oas.Format("date-time")),
 				oas.ParamDescription("Only include records before or at this RFC3339 timestamp")).
+			QueryParam("auth_subject", oas.String(),
+				oas.ParamDescription("Narrow every total to sessions captured for this gateway-stamped "+
+					"JWT subject (exact match). Omitted, the totals are org-wide. A subject with no "+
+					"sessions in the window aggregates to zeros, not an error")).
 			JSONResponse(200, "Aggregate stats for the window", s.schema(StatsResponse{})).
 			JSONResponse(400, "Invalid query parameters", s.errorSchema()).
 			JSONResponse(500, "Failed to compute stats", s.errorSchema()))

--- a/api/v1_handlers.go
+++ b/api/v1_handlers.go
@@ -51,7 +51,15 @@ func (s *Server) handleStats(c *fiber.Ctx) error {
 		s.logger.Error("stats unavailable: driver is not a SpanStatsReader")
 		return c.Status(fiber.StatusInternalServerError).JSON(llm.ErrorResponse{Error: "failed to compute stats"})
 	}
-	stats, err := reader.AggregateSpanStats(c.Context(), singleTenantOrgID, since, until)
+	// auth_subject is a caller-supplied filter, not an identity claim: it
+	// narrows the totals within this tenant and grants nothing. The verified
+	// subject is stamped at ingest from the JWT (x-paper-auth-subject); this
+	// only chooses which of those rows to add up. Same parameter, same
+	// meaning, as the /v1/sessions filter — a personal surface that scopes
+	// its rows and its totals passes the one value to both.
+	//
+	// Absent, it is empty and every total stays org-wide.
+	stats, err := reader.AggregateSpanStats(c.Context(), singleTenantOrgID, since, until, c.Query("auth_subject"))
 	if err != nil {
 		s.logger.Error("aggregate span stats", "error", err)
 		return c.Status(fiber.StatusInternalServerError).JSON(llm.ErrorResponse{Error: "failed to compute stats"})
@@ -69,8 +77,9 @@ func (s *Server) handleStats(c *fiber.Ctx) error {
 }
 
 // parseStatsWindow reads the optional since/until time window from query
-// params. /v1/stats is a whole-window aggregate: it has no filter or
-// pagination parameters, only the time bounds.
+// params. /v1/stats has no pagination — it is one aggregate row — so the time
+// bounds and the auth_subject filter are the whole of its input; the subject
+// needs no parsing and is read at the call site.
 //
 // Validation errors are returned as plain Go errors so the calling handler
 // can map them to a 400 Bad Request response, instead of letting them

--- a/api/v1_handlers_test.go
+++ b/api/v1_handlers_test.go
@@ -25,19 +25,21 @@ import (
 type statsStubDriver struct {
 	storage.Driver
 
-	stats     storage.SpanStats
-	statsErr  error
-	calls     int
-	lastOrg   string
-	lastSince *time.Time
-	lastUntil *time.Time
+	stats       storage.SpanStats
+	statsErr    error
+	calls       int
+	lastOrg     string
+	lastSince   *time.Time
+	lastUntil   *time.Time
+	lastSubject string
 }
 
-func (d *statsStubDriver) AggregateSpanStats(_ context.Context, orgID string, since, until *time.Time) (storage.SpanStats, error) {
+func (d *statsStubDriver) AggregateSpanStats(_ context.Context, orgID string, since, until *time.Time, authSubject string) (storage.SpanStats, error) {
 	d.calls++
 	d.lastOrg = orgID
 	d.lastSince = since
 	d.lastUntil = until
+	d.lastSubject = authSubject
 	return d.stats, d.statsErr
 }
 
@@ -87,6 +89,64 @@ var _ = Describe("v1 session handlers", func() {
 			Expect(drv.lastUntil).NotTo(BeNil())
 			Expect(drv.lastSince.UTC()).To(Equal(time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)))
 			Expect(drv.lastUntil.UTC()).To(Equal(time.Date(2026, 4, 2, 0, 0, 0, 0, time.UTC)))
+		})
+
+		It("threads auth_subject through to the reader", func() {
+			drv := &statsStubDriver{Driver: inmemory.NewDriver()}
+			server := newStatsServer(drv)
+
+			_ = decodeStats(server, "/v1/stats?auth_subject=user_01HXYZ")
+
+			Expect(drv.calls).To(Equal(1))
+			Expect(drv.lastSubject).To(Equal("user_01HXYZ"))
+		})
+
+		It("aggregates org-wide when auth_subject is absent", func() {
+			// The parameter is additive: every caller that never sends it —
+			// which is every caller that predates it — must keep getting the
+			// org-wide totals it always got.
+			drv := &statsStubDriver{Driver: inmemory.NewDriver()}
+			server := newStatsServer(drv)
+
+			_ = decodeStats(server, "/v1/stats?since=2026-04-01T00:00:00Z")
+
+			Expect(drv.calls).To(Equal(1))
+			Expect(drv.lastSubject).To(BeEmpty())
+		})
+
+		It("carries the subject alongside the window rather than instead of it", func() {
+			// The two narrow together. A handler that read the subject in
+			// place of the window (or dropped one when both are present)
+			// would report a lifetime total on a windowed surface.
+			drv := &statsStubDriver{Driver: inmemory.NewDriver()}
+			server := newStatsServer(drv)
+
+			_ = decodeStats(server,
+				"/v1/stats?since=2026-04-01T00:00:00Z&until=2026-04-02T00:00:00Z&auth_subject=user_both")
+
+			Expect(drv.lastSubject).To(Equal("user_both"))
+			Expect(drv.lastSince).NotTo(BeNil())
+			Expect(drv.lastUntil).NotTo(BeNil())
+			Expect(drv.lastSince.UTC()).To(Equal(time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)))
+			Expect(drv.lastUntil.UTC()).To(Equal(time.Date(2026, 4, 2, 0, 0, 0, 0, time.UTC)))
+		})
+
+		It("returns zeros for a subject with nothing to aggregate, not an error", func() {
+			// A tray opened by a user who has never run a session is the
+			// ordinary case, not a failure: the empty aggregate is a 200 with
+			// zeros. Erroring here would make a new user's tray look broken.
+			drv := &statsStubDriver{Driver: inmemory.NewDriver()}
+			body := decodeStats(newStatsServer(drv), "/v1/stats?auth_subject=user_with_no_sessions")
+
+			Expect(drv.lastSubject).To(Equal("user_with_no_sessions"))
+			Expect(body.SessionCount).To(BeZero())
+			Expect(body.TurnCount).To(BeZero())
+			Expect(body.CompletedCount).To(BeZero())
+			Expect(body.TotalCost).To(BeZero())
+			Expect(body.InputTokens).To(BeZero())
+			Expect(body.OutputTokens).To(BeZero())
+			Expect(body.TotalDurationMs).To(BeZero())
+			Expect(body.ToolCalls).To(BeZero())
 		})
 
 		It("returns zeros across every field for an empty aggregate", func() {

--- a/pkg/storage/postgres/gensqlc/spans.sql.go
+++ b/pkg/storage/postgres/gensqlc/spans.sql.go
@@ -22,6 +22,7 @@ WITH matched AS (
     WHERE t.org_id = $1
       AND ($2::timestamptz IS NULL OR t.started_at >= $2::timestamptz)
       AND ($3::timestamptz IS NULL OR t.started_at < $3::timestamptz)
+      AND ($4::text IS NULL OR s.auth_subject = $4::text)
 )
 SELECT
     COUNT(*)::bigint                                        AS turn_count,
@@ -40,14 +41,24 @@ SELECT
        AND sp.kind = 'tool'
        AND ($2::timestamptz IS NULL OR sp.started_at >= $2::timestamptz)
        AND ($3::timestamptz IS NULL OR sp.started_at < $3::timestamptz)
+       -- Uncorrelated on purpose: the subject's session ids depend only on the
+       -- parameter, so this is one hashed subplan (index-only on
+       -- sessions_org_subject_id_idx) rather than a lookup per tool span. A
+       -- correlated EXISTS here is the same O(spans) probe the comment above
+       -- says times out on a wide window.
+       AND ($4::text IS NULL
+            OR sp.session_id IN (SELECT s2.id FROM sessions s2
+                                 WHERE s2.org_id = $1
+                                   AND s2.auth_subject = $4::text))
     )::bigint                                               AS tool_calls
 FROM matched
 `
 
 type AggregateSpanStatsParams struct {
-	OrgID       pgtype.UUID
-	SinceFilter pgtype.Timestamptz
-	UntilFilter pgtype.Timestamptz
+	OrgID             pgtype.UUID
+	SinceFilter       pgtype.Timestamptz
+	UntilFilter       pgtype.Timestamptz
+	AuthSubjectFilter pgtype.Text
 }
 
 type AggregateSpanStatsRow struct {
@@ -79,8 +90,24 @@ type AggregateSpanStatsRow struct {
 // doesn't count as completed) rather than a correlated EXISTS per matched
 // trace — the per-row subquery is O(traces) index lookups and is the part
 // that times out on a wide (30d) window at scale.
+//
+// auth_subject_filter narrows every total to one gateway-stamped subject.
+// Attribution lives on sessions and nowhere else — neither projection table
+// carries a subject — so both legs reach it through session_id, and both must:
+// a filter the tool_calls subquery did not apply would report one user's turns
+// beside the whole org's tool volume.
+//
+// Filtering also tightens the LEFT JOIN to an inner match, and deliberately: a
+// trace whose session row is missing has no subject, so it belongs to no one
+// and cannot match. `s.auth_subject = @filter` is NULL for those rows, which
+// drops them. Unfiltered they still count, exactly as before.
 func (q *Queries) AggregateSpanStats(ctx context.Context, arg AggregateSpanStatsParams) (AggregateSpanStatsRow, error) {
-	row := q.db.QueryRow(ctx, aggregateSpanStats, arg.OrgID, arg.SinceFilter, arg.UntilFilter)
+	row := q.db.QueryRow(ctx, aggregateSpanStats,
+		arg.OrgID,
+		arg.SinceFilter,
+		arg.UntilFilter,
+		arg.AuthSubjectFilter,
+	)
 	var i AggregateSpanStatsRow
 	err := row.Scan(
 		&i.TurnCount,

--- a/pkg/storage/postgres/queries/spans.sql
+++ b/pkg/storage/postgres/queries/spans.sql
@@ -277,6 +277,17 @@ WHERE sessions.id = f.id;
 -- doesn't count as completed) rather than a correlated EXISTS per matched
 -- trace — the per-row subquery is O(traces) index lookups and is the part
 -- that times out on a wide (30d) window at scale.
+--
+-- auth_subject_filter narrows every total to one gateway-stamped subject.
+-- Attribution lives on sessions and nowhere else — neither projection table
+-- carries a subject — so both legs reach it through session_id, and both must:
+-- a filter the tool_calls subquery did not apply would report one user's turns
+-- beside the whole org's tool volume.
+--
+-- Filtering also tightens the LEFT JOIN to an inner match, and deliberately: a
+-- trace whose session row is missing has no subject, so it belongs to no one
+-- and cannot match. `s.auth_subject = @filter` is NULL for those rows, which
+-- drops them. Unfiltered they still count, exactly as before.
 WITH matched AS (
     SELECT t.org_id, t.trace_id, t.session_id, t.duration_ns,
            t.total_input_tokens, t.total_output_tokens,
@@ -287,6 +298,7 @@ WITH matched AS (
     WHERE t.org_id = sqlc.arg(org_id)
       AND (sqlc.narg(since_filter)::timestamptz IS NULL OR t.started_at >= sqlc.narg(since_filter)::timestamptz)
       AND (sqlc.narg(until_filter)::timestamptz IS NULL OR t.started_at < sqlc.narg(until_filter)::timestamptz)
+      AND (sqlc.narg(auth_subject_filter)::text IS NULL OR s.auth_subject = sqlc.narg(auth_subject_filter)::text)
 )
 SELECT
     COUNT(*)::bigint                                        AS turn_count,
@@ -305,6 +317,15 @@ SELECT
        AND sp.kind = 'tool'
        AND (sqlc.narg(since_filter)::timestamptz IS NULL OR sp.started_at >= sqlc.narg(since_filter)::timestamptz)
        AND (sqlc.narg(until_filter)::timestamptz IS NULL OR sp.started_at < sqlc.narg(until_filter)::timestamptz)
+       -- Uncorrelated on purpose: the subject's session ids depend only on the
+       -- parameter, so this is one hashed subplan (index-only on
+       -- sessions_org_subject_id_idx) rather than a lookup per tool span. A
+       -- correlated EXISTS here is the same O(spans) probe the comment above
+       -- says times out on a wide window.
+       AND (sqlc.narg(auth_subject_filter)::text IS NULL
+            OR sp.session_id IN (SELECT s2.id FROM sessions s2
+                                 WHERE s2.org_id = sqlc.arg(org_id)
+                                   AND s2.auth_subject = sqlc.narg(auth_subject_filter)::text))
     )::bigint                                               AS tool_calls
 FROM matched;
 

--- a/pkg/storage/postgres/span_stats_test.go
+++ b/pkg/storage/postgres/span_stats_test.go
@@ -1,0 +1,283 @@
+package postgres_test
+
+// The /v1/stats aggregate, and its subject filter.
+//
+// Attribution lives on sessions; the projection tables the aggregate reads
+// carry only a session_id. So "scope the stats to a user" is a join away from
+// every total, and the risk this file exists for is a filter that reaches some
+// of them: turn and token sums narrowed while tool_calls — computed by its own
+// subquery, over a different table — stays org-wide. A response like that does
+// not look wrong, it just reports one user's work beside everyone's tool
+// volume. Each spec below asserts every field, for that reason.
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/papercomputeco/tapes/pkg/sessions"
+	"github.com/papercomputeco/tapes/pkg/storage"
+	"github.com/papercomputeco/tapes/pkg/storage/postgres"
+)
+
+var _ = Describe("Driver.AggregateSpanStats", func() {
+	var (
+		driver   storage.Driver
+		pgDriver *postgres.Driver
+		ingester storage.SessionIngester
+		ctx      context.Context
+		orgID    string
+	)
+
+	// One instant for everything, so the specs are about attribution and not
+	// about the window. The window has its own coverage.
+	base := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		var err error
+		driver, err = postgres.NewDriver(ctx, testPostgresDSN)
+		Expect(err).NotTo(HaveOccurred())
+
+		var ok bool
+		pgDriver, ok = driver.(*postgres.Driver)
+		Expect(ok).To(BeTrue())
+		ingester, ok = driver.(storage.SessionIngester)
+		Expect(ok).To(BeTrue(), "postgres driver must satisfy SessionIngester")
+
+		// A fresh org per spec isolates these rows without truncating tables
+		// other suites are using: every read here is org-scoped anyway.
+		orgID = newTestOrgID()
+	})
+
+	AfterEach(func() {
+		if driver != nil {
+			driver.Close()
+		}
+	})
+
+	// seedSubjectSession ingests a session attributed to authSubject and
+	// returns the tapes-minted session id. Ingest is what stamps
+	// sessions.auth_subject from the gateway-verified JWT header, so going
+	// through it is the point: the filter must match what capture actually
+	// writes, not what a test inserted by hand.
+	seedSubjectSession := func(authSubject, harnessSessionID string) string {
+		res, err := ingester.IngestTurn(ctx, storage.IngestTurnRequest{
+			Session: &sessions.IngestEnvelope{
+				OrgID:            orgID,
+				AuthSubject:      authSubject,
+				HarnessID:        "claude",
+				HarnessSessionID: harnessSessionID,
+			},
+			Nodes: sessionFixture("stats " + harnessSessionID),
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.SessionID).NotTo(BeEmpty())
+		return res.SessionID
+	}
+
+	markCompleted := func(sessionID string) {
+		_, err := pgDriver.DB().Exec(ctx,
+			"UPDATE sessions SET derived_status = 'completed' WHERE id = $1", mustUUID(sessionID))
+		Expect(err).NotTo(HaveOccurred())
+	}
+
+	// insertTurn writes one projection row directly. The deriver owns these
+	// in production; writing them here lets a spec state the exact totals it
+	// expects instead of reverse-engineering them from a fixture.
+	insertTurn := func(traceID, sessionID string, in, out int64, costUSD float64, dur time.Duration) {
+		var sid any
+		if sessionID == "" {
+			sid = nil // an unattributed trace: no session row, so no subject
+		} else {
+			sid = mustUUID(sessionID)
+		}
+		_, err := pgDriver.DB().Exec(ctx, `
+			INSERT INTO span_turns_20260615
+			    (org_id, trace_id, session_id, started_at, duration_ns,
+			     total_input_tokens, total_output_tokens, total_cost_usd)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+			mustUUID(orgID), traceID, sid, base, dur.Nanoseconds(), in, out, costUSD)
+		Expect(err).NotTo(HaveOccurred())
+	}
+
+	insertToolSpan := func(traceID, spanID, sessionID string) {
+		var sid any
+		if sessionID == "" {
+			sid = nil
+		} else {
+			sid = mustUUID(sessionID)
+		}
+		_, err := pgDriver.DB().Exec(ctx, `
+			INSERT INTO spans_20260615 (org_id, trace_id, span_id, session_id, kind, started_at)
+			VALUES ($1, $2, $3, $4, 'tool', $5)`,
+			mustUUID(orgID), traceID, spanID, sid, base)
+		Expect(err).NotTo(HaveOccurred())
+	}
+
+	// Two users in one org. alice has one completed session — one trace, one
+	// tool call; bob has two traces on a single session and two tool calls,
+	// and is deliberately not completed, so completed_count can distinguish
+	// them rather than agreeing by coincidence.
+	var aliceSession, bobSession string
+
+	BeforeEach(func() {
+		aliceSession = seedSubjectSession("user_alice", "alice-1")
+		bobSession = seedSubjectSession("user_bob", "bob-1")
+		markCompleted(aliceSession)
+
+		insertTurn("trace-alice-1", aliceSession, 100, 10, 1.5, 2*time.Second)
+		insertToolSpan("trace-alice-1", "span-alice-tool-1", aliceSession)
+
+		insertTurn("trace-bob-1", bobSession, 200, 20, 2.5, 3*time.Second)
+		insertTurn("trace-bob-2", bobSession, 400, 40, 4.0, 5*time.Second)
+		insertToolSpan("trace-bob-1", "span-bob-tool-1", bobSession)
+		insertToolSpan("trace-bob-2", "span-bob-tool-2", bobSession)
+	})
+
+	It("sums both subjects when no subject is given", func() {
+		stats, err := pgDriver.AggregateSpanStats(ctx, orgID, nil, nil, "")
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(stats.TurnCount).To(Equal(3))
+		Expect(stats.SessionCount).To(Equal(2))
+		Expect(stats.CompletedCount).To(Equal(1))
+		Expect(stats.InputTokens).To(Equal(int64(700)))
+		Expect(stats.OutputTokens).To(Equal(int64(70)))
+		Expect(stats.TotalCostUSD).To(BeNumerically("~", 8.0, 0.0001))
+		Expect(stats.TotalDurationNS).To(Equal((10 * time.Second).Nanoseconds()))
+		Expect(stats.ToolCalls).To(Equal(3))
+	})
+
+	It("narrows every total to the named subject", func() {
+		stats, err := pgDriver.AggregateSpanStats(ctx, orgID, nil, nil, "user_alice")
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(stats.TurnCount).To(Equal(1))
+		Expect(stats.SessionCount).To(Equal(1))
+		Expect(stats.CompletedCount).To(Equal(1))
+		Expect(stats.InputTokens).To(Equal(int64(100)))
+		Expect(stats.OutputTokens).To(Equal(int64(10)))
+		Expect(stats.TotalCostUSD).To(BeNumerically("~", 1.5, 0.0001))
+		Expect(stats.TotalDurationNS).To(Equal((2 * time.Second).Nanoseconds()))
+		// The one that a partial implementation gets wrong: tool_calls is a
+		// separate subquery over a separate table, and org-wide it is 3.
+		Expect(stats.ToolCalls).To(Equal(1))
+	})
+
+	It("gives the other subject its own totals, not the remainder", func() {
+		stats, err := pgDriver.AggregateSpanStats(ctx, orgID, nil, nil, "user_bob")
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(stats.TurnCount).To(Equal(2))
+		Expect(stats.SessionCount).To(Equal(1))
+		// bob's session was never marked completed: a filter that leaked
+		// alice's session into the completed count would show 1 here.
+		Expect(stats.CompletedCount).To(BeZero())
+		Expect(stats.InputTokens).To(Equal(int64(600)))
+		Expect(stats.OutputTokens).To(Equal(int64(60)))
+		Expect(stats.TotalCostUSD).To(BeNumerically("~", 6.5, 0.0001))
+		Expect(stats.TotalDurationNS).To(Equal((8 * time.Second).Nanoseconds()))
+		Expect(stats.ToolCalls).To(Equal(2))
+	})
+
+	It("returns zeros for a subject with no sessions, not an error", func() {
+		// The new user's tray. Zeros are the honest answer and a 200; an
+		// error here would read as a broken surface.
+		stats, err := pgDriver.AggregateSpanStats(ctx, orgID, nil, nil, "user_nobody")
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(stats).To(Equal(storage.SpanStats{}))
+	})
+
+	It("treats a blank-looking subject as a subject, not as absent", func() {
+		// Widening to org-wide totals on a personal surface is the bug this
+		// filter exists to fix, so a subject that trims to nothing must
+		// aggregate to zeros rather than to everyone.
+		stats, err := pgDriver.AggregateSpanStats(ctx, orgID, nil, nil, "   ")
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(stats).To(Equal(storage.SpanStats{}))
+	})
+
+	It("counts an unattributed trace org-wide but for no subject", func() {
+		// A trace with no session row has no subject, so it belongs to
+		// nobody: it keeps counting in the org-wide totals it has always
+		// counted in, and joins no user's. The filter tightening the LEFT
+		// JOIN to an inner match is what makes the second half true.
+		insertTurn("trace-orphan", "", 1_000, 100, 9.0, 7*time.Second)
+
+		orgWide, err := pgDriver.AggregateSpanStats(ctx, orgID, nil, nil, "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(orgWide.TurnCount).To(Equal(4))
+		Expect(orgWide.InputTokens).To(Equal(int64(1_700)))
+
+		alice, err := pgDriver.AggregateSpanStats(ctx, orgID, nil, nil, "user_alice")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(alice.TurnCount).To(Equal(1))
+		Expect(alice.InputTokens).To(Equal(int64(100)))
+	})
+
+	It("applies the subject and the window together", func() {
+		// Each filter must survive the other. bob gets a second session far
+		// outside the window; scoping to bob alone counts it, scoping to bob
+		// within the window must not.
+		outside := base.Add(-30 * 24 * time.Hour)
+		late := seedSubjectSession("user_bob", "bob-2")
+		_, err := pgDriver.DB().Exec(ctx, `
+			INSERT INTO span_turns_20260615
+			    (org_id, trace_id, session_id, started_at, duration_ns,
+			     total_input_tokens, total_output_tokens, total_cost_usd)
+			VALUES ($1, 'trace-bob-old', $2, $3, 0, 999, 99, 9.0)`,
+			mustUUID(orgID), mustUUID(late), outside)
+		Expect(err).NotTo(HaveOccurred())
+
+		unwindowed, err := pgDriver.AggregateSpanStats(ctx, orgID, nil, nil, "user_bob")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(unwindowed.TurnCount).To(Equal(3))
+
+		since := base.Add(-time.Hour)
+		until := base.Add(time.Hour)
+		windowed, err := pgDriver.AggregateSpanStats(ctx, orgID, &since, &until, "user_bob")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(windowed.TurnCount).To(Equal(2))
+		Expect(windowed.InputTokens).To(Equal(int64(600)))
+	})
+
+	It("keeps subjects from other orgs out of a subject's totals", func() {
+		// auth_subject is unique to a person, not to a person within an org,
+		// so a filter that forgot the org scope would still look right on a
+		// single-org fixture. Give another org the same subject name.
+		otherOrg := newTestOrgID()
+		res, err := ingester.IngestTurn(ctx, storage.IngestTurnRequest{
+			Session: &sessions.IngestEnvelope{
+				OrgID:            otherOrg,
+				AuthSubject:      "user_alice",
+				HarnessID:        "claude",
+				HarnessSessionID: "alice-elsewhere",
+			},
+			Nodes: sessionFixture("other org"),
+		})
+		Expect(err).NotTo(HaveOccurred())
+		_, err = pgDriver.DB().Exec(ctx, `
+			INSERT INTO span_turns_20260615
+			    (org_id, trace_id, session_id, started_at, duration_ns,
+			     total_input_tokens, total_output_tokens, total_cost_usd)
+			VALUES ($1, 'trace-alice-elsewhere', $2, $3, 0, 5000, 500, 50.0)`,
+			mustUUID(otherOrg), mustUUID(res.SessionID), base)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = pgDriver.DB().Exec(ctx, `
+			INSERT INTO spans_20260615 (org_id, trace_id, span_id, session_id, kind, started_at)
+			VALUES ($1, 'trace-alice-elsewhere', 'span-elsewhere', $2, 'tool', $3)`,
+			mustUUID(otherOrg), mustUUID(res.SessionID), base)
+		Expect(err).NotTo(HaveOccurred())
+
+		stats, err := pgDriver.AggregateSpanStats(ctx, orgID, nil, nil, "user_alice")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(stats.TurnCount).To(Equal(1))
+		Expect(stats.InputTokens).To(Equal(int64(100)))
+		Expect(stats.ToolCalls).To(Equal(1))
+	})
+})

--- a/pkg/storage/postgres/spans.go
+++ b/pkg/storage/postgres/spans.go
@@ -629,9 +629,9 @@ func (d *Driver) GetSpanRecord(ctx context.Context, orgID, traceID, spanID strin
 }
 
 // AggregateSpanStats sums the trace-grain rollups over a time window —
-// the span-layer aggregate behind /v1/stats. Implements
-// storage.SpanStatsReader.
-func (d *Driver) AggregateSpanStats(ctx context.Context, orgID string, since, until *time.Time) (storage.SpanStats, error) {
+// the span-layer aggregate behind /v1/stats. A non-empty authSubject narrows
+// every total to that subject's sessions. Implements storage.SpanStatsReader.
+func (d *Driver) AggregateSpanStats(ctx context.Context, orgID string, since, until *time.Time, authSubject string) (storage.SpanStats, error) {
 	if d == nil || d.conn == nil {
 		return storage.SpanStats{}, errors.New("postgres driver not open")
 	}
@@ -643,6 +643,12 @@ func (d *Driver) AggregateSpanStats(ctx context.Context, orgID string, since, un
 		OrgID:       org,
 		SinceFilter: nullTimePtr(since),
 		UntilFilter: nullTimePtr(until),
+		// Deliberately not nullStringValue: that treats whitespace as absent,
+		// and absent here means org-wide. A caller who sends a blank-looking
+		// subject should get zeros — "nobody by that name" — rather than
+		// silently widening to every user's totals on a personal surface.
+		// `!= ""` is also exactly how the /v1/sessions filter decides.
+		AuthSubjectFilter: pgtype.Text{String: authSubject, Valid: authSubject != ""},
 	})
 	if err != nil {
 		return storage.SpanStats{}, fmt.Errorf("aggregate span stats: %w", err)

--- a/pkg/storage/span_model.go
+++ b/pkg/storage/span_model.go
@@ -135,6 +135,13 @@ type SpanStats struct {
 }
 
 // SpanStatsReader is the capability interface for span-layer stats.
+//
+// authSubject narrows every total in the returned SpanStats to sessions
+// captured for one gateway-stamped JWT subject; empty means the whole org, the
+// only behavior there used to be. It is a filter and not an authorization
+// boundary — the caller has already been scoped to a tenant, and this only
+// chooses which of that tenant's rows to add up, the same way the auth_subject
+// filter on ListSessionRecords does.
 type SpanStatsReader interface {
-	AggregateSpanStats(ctx context.Context, orgID string, since, until *time.Time) (SpanStats, error)
+	AggregateSpanStats(ctx context.Context, orgID string, since, until *time.Time, authSubject string) (SpanStats, error)
 }


### PR DESCRIPTION
Adds an optional `auth_subject` query parameter to `GET /v1/stats`, filtering every aggregate to sessions ingested under that gateway-verified subject. Absent or empty → unchanged org-wide behavior; present → exact match; no match → zeros, not an error.

Why `auth_subject` and not `subject`: the sessions list API already filters on `auth_subject`, and existing consumers already append `auth_subject=` to stats URLs expecting it to take effect — one vocabulary for one concept.

- All eight aggregates honor the filter, including `tool_calls`, which lives in a separate subquery with no session join — handled with an uncorrelated semi-join (one hashed subplan over the existing `(org_id, auth_subject, id)` index) rather than a per-span correlated probe.
- Deliberate semantic edge: filtering tightens the trace→session LEFT JOIN to an inner match — an unattributed trace has no subject, so it counts for nobody under a filter; unfiltered behavior is byte-identical.
- Whitespace subjects are preserved, not trimmed to NULL: a blank-looking subject means "nobody by that name," never a silent widening to the org.
- Contract seal bumped in the same commit; sqlc output matches the pinned generator; 12 new specs; mutation-testing the `tool_calls` clause reproduces the org-wide leak this exists to prevent.

Heads-up @yeazelm  diff is confined to the `/v1/stats` surface (9 files); the one shared edit is the `SpanStatsReader` interface signature (postgres driver + test stub). No release cut — riding the next scheduled one.

Note for CI: the DB suite ran locally against `pgvector/pgvector:pg17` (the pinned ECR Public image 403'd locally); `pkg/spanembed` has a pre-existing first-run flake that reproduces on unmodified main.

related to PCC-1192

🤖 Generated with [Claude Code](https://claude.com/claude-code)