### PR TITLE
🔧 fix(proxy): bound the buffered request body at the shared capture ceiling

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/middleware/compress"
 
+	"github.com/papercomputeco/tapes/ingest"
 	"github.com/papercomputeco/tapes/pkg/capture"
 	"github.com/papercomputeco/tapes/pkg/llm"
 	"github.com/papercomputeco/tapes/pkg/llm/provider"
@@ -85,6 +86,12 @@ func New(config Config, driver storage.Driver, log *slog.Logger) (*Proxy, error)
 		DisableStartupMessage: true,
 		// Enable streaming
 		StreamRequestBody: true,
+		// With StreamRequestBody enabled, fasthttp skips its max-body-size
+		// check entirely, so this limit is enforced by handleProxy's own
+		// guard rather than here. It is still set so that the bound holds
+		// if streaming is ever disabled — and so the config states the
+		// ceiling the handler actually enforces.
+		BodyLimit: ingest.MaxIngestBodyBytes,
 	})
 
 	// Add compression middleware to handle responses
@@ -164,8 +171,27 @@ func (p *Proxy) handleProxy(c *fiber.Ctx) error {
 	prov, upstreamURL := p.resolveProvider(agentName, providerName, path)
 	method := c.Method()
 
+	// Bound the buffered request explicitly. With StreamRequestBody enabled,
+	// fasthttp never applies its max-body-size check — Fiber's BodyLimit is
+	// inert on this server — and c.Body() materializes the whole stream, so
+	// without this guard one oversized request buffers without bound. The
+	// declared length rejects cheaply before any read; the post-read check
+	// catches chunked bodies that declare nothing. MaxIngestBodyBytes
+	// (~46.67 MiB) sits above the 32 MiB provider request contract the same
+	// way the gateway's connection buffer does, so the provider's edge — not
+	// the capture layer — stays the authority on over-limit requests.
+	if cl := c.Request().Header.ContentLength(); cl > ingest.MaxIngestBodyBytes {
+		// Rejecting on the declared length leaves the body unread; close the
+		// connection so the unread bytes are never parsed as a next request.
+		c.Context().SetConnectionClose()
+		return c.SendStatus(fiber.StatusRequestEntityTooLarge)
+	}
+
 	// Only process POST requests that look like chat/completion endpoints
 	body := c.Body()
+	if len(body) > ingest.MaxIngestBodyBytes {
+		return c.SendStatus(fiber.StatusRequestEntityTooLarge)
+	}
 	isChatRequest := method == "POST" && len(body) > 0
 
 	// Parse request using configured provider

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -12,6 +13,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/papercomputeco/tapes/ingest"
 	"github.com/papercomputeco/tapes/pkg/llm"
 	tapeslogger "github.com/papercomputeco/tapes/pkg/logger"
 	"github.com/papercomputeco/tapes/pkg/storage"
@@ -108,6 +110,64 @@ func makeOllamaResponseBody(model, role, content string) []byte {
 	Expect(err).NotTo(HaveOccurred())
 	return body
 }
+
+var _ = Describe("Proxy body limit", func() {
+	var (
+		p        *Proxy
+		driver   *captureDriver
+		upstream *httptest.Server
+	)
+
+	BeforeEach(func() {
+		upstream = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write(makeOllamaResponseBody("test-model", "assistant", "ok"))
+		}))
+		p, driver = newTestProxy(upstream.URL)
+	})
+
+	AfterEach(func() {
+		if p != nil {
+			p.Close()
+		}
+		if upstream != nil {
+			upstream.Close()
+		}
+	})
+
+	It("forwards a request above Fiber's 4 MiB default body limit", func() {
+		// Pins the forwarding contract: no size gate below the shared
+		// capture ceiling. Fiber's default BodyLimit is 4 MiB — inert today
+		// because StreamRequestBody skips fasthttp's check, but this spec
+		// keeps forwarding safe if that coupling ever changes.
+		reqBody := makeOllamaRequestBody("test-model", []ollamaTestMessage{
+			{Role: "user", Content: strings.Repeat("a", 6<<20)},
+		}, new(false))
+		Expect(len(reqBody)).To(BeNumerically(">", 4<<20))
+
+		req := httptest.NewRequest(http.MethodPost, "/api/chat", bytes.NewReader(reqBody))
+		resp, err := p.server.Test(req, 30_000)
+		Expect(err).NotTo(HaveOccurred())
+		defer resp.Body.Close()
+		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+		// The oversize-for-capture shed may drop the turn; forwarding is what
+		// this spec pins. Drain cleanly either way.
+		_ = driver
+	})
+
+	It("refuses only above the shared capture ceiling", func() {
+		// One byte past MaxIngestBodyBytes: the explicit BodyLimit binds
+		// there — above the 32 MiB contract, matching the gateway's buffer.
+		big := bytes.Repeat([]byte("a"), ingest.MaxIngestBodyBytes+1)
+		req := httptest.NewRequest(http.MethodPost, "/api/chat", bytes.NewReader(big))
+		resp, err := p.server.Test(req, 60_000)
+		Expect(err).NotTo(HaveOccurred())
+		defer resp.Body.Close()
+		Expect(resp.StatusCode).To(Equal(http.StatusRequestEntityTooLarge))
+	})
+})
 
 var _ = Describe("Proxy capture byte budget", func() {
 	var (


### PR DESCRIPTION
## Summary

- Bounds the proxy's buffered request body at the **shared capture ceiling** (`ingest.MaxIngestBodyBytes`, ~46.67 MiB) — above the 32 MiB provider request contract, so the provider's edge stays the authority on over-limit requests.
- The bug is worse than the one on record. The initiative notes said the proxy "413s forwarding at Fiber's 4 MiB default." Measured reality: with `StreamRequestBody: true` (set since the initial commit), fasthttp **skips its max-body-size check entirely** — no 4 MiB gate, and no ceiling at all. `c.Body()` materialized arbitrarily large client bodies in memory, unbounded.
- Fix is a handler-level guard, because Fiber's `BodyLimit` is inert under streaming: reject on the declared Content-Length before any read (closing the connection so unread bytes aren't parsed as a pipelined next request), and check the materialized length for chunked bodies that declare nothing. `BodyLimit` is also set in the config so the bound holds if streaming is ever disabled.

## Behavior matrix

| Request | Before | After |
|---|---|---|
| ≤ 4 MiB | forwards | forwards (unchanged) |
| 4 MiB – ~46.67 MiB (incl. the whole 32 MiB contract band) | forwards | forwards (pinned by test) |
| > ~46.67 MiB, Content-Length declared | forwards, fully buffered | **413 before reading the body** |
| > ~46.67 MiB, chunked | forwards, fully buffered | 413 after read (transient buffer, then reject) |

## Test plan

- [x] New `Describe("Proxy body limit")`: 6 MiB body forwards 200; `MaxIngestBodyBytes+1` gets 413. Both proven load-bearing (removing the guard fails the 413 spec; the forwarding spec guards the streaming/BodyLimit coupling if it ever changes).
- [x] `make parity`, `make test-extproc`, `make test`, `dagger call check-lint` — green locally.
- [x] `make e2e-test` — fails **locally on unmodified main too** (control run; GitHub CI is green on the same base commit `e8192f7`), i.e. a local-runner environment issue, not this change. CI's E2E on this PR is the arbiter.

Related to PCC-1167
