### PR TITLE
🔧 fix(api): sum /v1/stats tool calls from turn rollups

### DIFF
--- a/api/v1_handlers.go
+++ b/api/v1_handlers.go
@@ -24,6 +24,9 @@ import (
 //     JSON consumer's 2^53 safe-integer range (~104 cumulative days), and
 //     sub-ms precision is meaningless for an aggregate agent-time figure.
 //   - TurnCount counts traces (user-visible turns).
+//   - ToolCalls is the SUM of the turn rollups' tool span counts,
+//     windowed on the turn's started_at like every other figure here
+//     rather than on each tool span's own timestamp (PCC-936).
 //   - CompletedCount counts distinct sessions whose denormalized
 //     derived_status is 'completed' (chain-aware, PCC-515).
 type StatsResponse struct {

--- a/migrations/1781510000_span_turns_tool_calls.down.sql
+++ b/migrations/1781510000_span_turns_tool_calls.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE span_turns_20260615
+    DROP COLUMN IF EXISTS tool_calls;

--- a/migrations/1781510000_span_turns_tool_calls.up.sql
+++ b/migrations/1781510000_span_turns_tool_calls.up.sql
@@ -1,0 +1,42 @@
+-- Adds a per-turn tool_calls rollup to span_turns so /v1/stats can sum it
+-- from the narrow turn table instead of counting kind='tool' rows in the
+-- wide spans table on every request (PCC-936).
+--
+-- The spans count was the aggregate's dominant cost: ~20x the row volume of
+-- span_turns, rows carrying input/output/usage JSONB payloads, and in-place
+-- re-derive rewrites clearing visibility-map bits so the (org_id, kind,
+-- started_at) index degrades into random heap fetches on a cold cache.
+--
+-- The deriver folds the count at emit time (pkg/derive SpanTurn.ToolCalls),
+-- the same single-writer path as every other turn total. The backfill below
+-- covers rows derived before the column existed; the count also self-heals
+-- on any later re-derive of a session.
+--
+-- Rolling-deploy window: a pre-change derive worker still running after this
+-- migration writes turns without tool_calls, which land as the 0 default and
+-- undercount /v1/stats until that session re-derives. Those rows carry a
+-- content_hash computed without the column, so the next new-code derive pass
+-- rewrites them — but a session that never derives again stays wrong. The
+-- backfill UPDATE is therefore deliberately idempotent (the IS DISTINCT FROM
+-- guard makes re-runs touch only wrong rows): after every worker is on the
+-- new binary, re-run it verbatim, or run `tapes dev rederive`, to close the
+-- window.
+--
+-- Attribution note: /v1/stats previously windowed tool calls on the tool
+-- span's own started_at. Summing turn rollups windows them on the turn's
+-- started_at instead, matching how every other stats figure is attributed.
+
+ALTER TABLE span_turns_20260615
+    ADD COLUMN IF NOT EXISTS tool_calls BIGINT NOT NULL DEFAULT 0;
+
+UPDATE span_turns_20260615 t
+SET tool_calls = counted.n
+FROM (
+    SELECT org_id, trace_id, COUNT(*) AS n
+    FROM spans_20260615
+    WHERE kind = 'tool'
+    GROUP BY org_id, trace_id
+) counted
+WHERE t.org_id = counted.org_id
+  AND t.trace_id = counted.trace_id
+  AND t.tool_calls IS DISTINCT FROM counted.n;

--- a/pkg/derive/spans.go
+++ b/pkg/derive/spans.go
@@ -140,6 +140,11 @@ type SpanTurn struct {
 	// re-derive reprices history when the table updates.
 	TotalCostUSD float64
 
+	// ToolCalls counts the trace's tool spans, folded at derive time so
+	// /v1/stats can sum turn rollups instead of scanning the wide spans
+	// table per request (PCC-936).
+	ToolCalls int
+
 	Spans []*Span
 	Links []*SpanLink
 }
@@ -833,6 +838,7 @@ func (em *spanEmitter) finish() {
 				byKind[s.CallKind]++
 			}
 			if s.Kind == SpanKindTool {
+				turn.ToolCalls++
 				toolsBySession[turn.Session] = append(toolsBySession[turn.Session], s)
 			}
 			if s.Kind == SpanKindLLM && s.Usage != nil {

--- a/pkg/derive/spans_corpus_test.go
+++ b/pkg/derive/spans_corpus_test.go
@@ -94,6 +94,27 @@ var _ = Describe("span emit over the corpus (cb9a87e5)", func() {
 
 		expectTurnPreviews(spans)
 	})
+
+	It("folds per-turn tool call counts into the trace rollup", func() {
+		set, _ := deriveAdvanced()
+		spans := derive.EmitSpans(set)
+
+		total := 0
+		for _, turn := range spans.Turns {
+			want := 0
+			for _, s := range turn.Spans {
+				if s.Kind == derive.SpanKindTool {
+					want++
+				}
+			}
+			Expect(turn.ToolCalls).To(Equal(want),
+				"turn %s tool rollup disagrees with its spans", turn.TraceID)
+			total += turn.ToolCalls
+		}
+		// Pinned: one tool span per tool_use in the corpus (matches
+		// the SpanKinds gate above).
+		Expect(total).To(Equal(97))
+	})
 })
 
 // expectTurnPreviews pins the derive-time turn-card folds: the header

--- a/pkg/storage/postgres/change_feed.go
+++ b/pkg/storage/postgres/change_feed.go
@@ -259,6 +259,7 @@ func spanTurnContentHash(p gensqlc.UpsertSpanTurnParams) string {
 		i64(p.CacheReadTokens).
 		i64(p.CacheCreationTokens).
 		numeric(p.TotalCostUsd).
+		i64(p.ToolCalls).
 		str(p.Source).
 		str(p.Fidelity).
 		sum()

--- a/pkg/storage/postgres/change_feed_test.go
+++ b/pkg/storage/postgres/change_feed_test.go
@@ -91,6 +91,15 @@ var _ = Describe("content hashing", func() {
 		Expect(postgres.SpanTurnContentHashForTest(a)).NotTo(Equal(postgres.SpanTurnContentHashForTest(b)))
 	})
 
+	It("changes when only tool_calls changes", func() {
+		// The stats aggregate reads the rollup, so a corrected tool
+		// count is a change a consumer must see.
+		a := postgres.NewSpanTurnParamsForTest(pgtype.UUID{}, "t1", pgtype.UUID{}, "hello", 1, postgres.FidelityRaw)
+		b := postgres.NewSpanTurnParamsForTest(pgtype.UUID{}, "t1", pgtype.UUID{}, "hello", 1, postgres.FidelityRaw)
+		b.ToolCalls = 4
+		Expect(postgres.SpanTurnContentHashForTest(a)).NotTo(Equal(postgres.SpanTurnContentHashForTest(b)))
+	})
+
 	It("changes when only fidelity changes", func() {
 		// A row whose bytes went from stored to dropped has changed in the
 		// only way a fidelity-tracking consumer cares about, even though

--- a/pkg/storage/postgres/gensqlc/models.go
+++ b/pkg/storage/postgres/gensqlc/models.go
@@ -154,6 +154,7 @@ type SpanTurns20260615 struct {
 	ContentHash         string
 	DeriveSeq           int64
 	Fidelity            string
+	ToolCalls           int64
 }
 
 // Derived span projection schema version 2026-06-15.

--- a/pkg/storage/postgres/gensqlc/spans.sql.go
+++ b/pkg/storage/postgres/gensqlc/spans.sql.go
@@ -16,6 +16,7 @@ WITH matched AS (
     SELECT t.org_id, t.trace_id, t.session_id, t.duration_ns,
            t.total_input_tokens, t.total_output_tokens,
            t.cache_read_tokens, t.cache_creation_tokens, t.total_cost_usd,
+           t.tool_calls,
            s.derived_status
     FROM span_turns_20260615 t
     LEFT JOIN sessions s ON s.id = t.session_id
@@ -36,21 +37,7 @@ SELECT
     COALESCE(SUM(cache_read_tokens), 0)::bigint             AS cache_read_tokens,
     COALESCE(SUM(duration_ns), 0)::bigint                   AS total_duration_ns,
     COALESCE(SUM(total_cost_usd), 0)::numeric               AS total_cost_usd,
-    (SELECT COUNT(*) FROM spans_20260615 sp
-     WHERE sp.org_id = $1
-       AND sp.kind = 'tool'
-       AND ($2::timestamptz IS NULL OR sp.started_at >= $2::timestamptz)
-       AND ($3::timestamptz IS NULL OR sp.started_at < $3::timestamptz)
-       -- Uncorrelated on purpose: the subject's session ids depend only on the
-       -- parameter, so this is one hashed subplan (index-only on
-       -- sessions_org_subject_id_idx) rather than a lookup per tool span. A
-       -- correlated EXISTS here is the same O(spans) probe the comment above
-       -- says times out on a wide window.
-       AND ($4::text IS NULL
-            OR sp.session_id IN (SELECT s2.id FROM sessions s2
-                                 WHERE s2.org_id = $1
-                                   AND s2.auth_subject = $4::text))
-    )::bigint                                               AS tool_calls
+    COALESCE(SUM(tool_calls), 0)::bigint                    AS tool_calls
 FROM matched
 `
 
@@ -83,7 +70,12 @@ type AggregateSpanStatsRow struct {
 //	total_duration_ns = SUM of trace durations — agent time, not the
 //	                    wall-clock MAX-MIN window (idle time between
 //	                    turns no longer counts)
-//	tool_calls        = tool spans_20260615 started in the window
+//	tool_calls        = SUM of the turn rollups' tool span counts,
+//	                    windowed on the turn's started_at like every
+//	                    other figure here. Counting kind='tool' rows in
+//	                    spans_20260615 per request was the aggregate's
+//	                    dominant cost: ~20x the rows, wide JSONB
+//	                    payloads, and cold heap fetches (PCC-936)
 //
 // completed_count joins sessions once (LEFT JOIN, so a trace whose
 // session identity is missing keeps its turn/token totals and simply
@@ -93,9 +85,9 @@ type AggregateSpanStatsRow struct {
 //
 // auth_subject_filter narrows every total to one gateway-stamped subject.
 // Attribution lives on sessions and nowhere else — neither projection table
-// carries a subject — so both legs reach it through session_id, and both must:
-// a filter the tool_calls subquery did not apply would report one user's turns
-// beside the whole org's tool volume.
+// carries a subject — so it is reached through session_id, once, in the
+// matched CTE. Every figure including tool_calls comes from that CTE, so
+// one predicate scopes them all.
 //
 // Filtering also tightens the LEFT JOIN to an inner match, and deliberately: a
 // trace whose session row is missing has no subject, so it belongs to no one
@@ -228,7 +220,7 @@ func (q *Queries) GetSpan(ctx context.Context, arg GetSpanParams) (Spans20260615
 }
 
 const getSpanTurn = `-- name: GetSpanTurn :one
-SELECT org_id, trace_id, session_id, user_prompt, synthetic, status, started_at, ended_at, duration_ns, total_input_tokens, total_output_tokens, total_cost_usd, main_input_tokens, main_output_tokens, cache_read_tokens, cache_creation_tokens, response_preview, source, content_hash, derive_seq, fidelity FROM span_turns_20260615
+SELECT org_id, trace_id, session_id, user_prompt, synthetic, status, started_at, ended_at, duration_ns, total_input_tokens, total_output_tokens, total_cost_usd, main_input_tokens, main_output_tokens, cache_read_tokens, cache_creation_tokens, response_preview, source, content_hash, derive_seq, fidelity, tool_calls FROM span_turns_20260615
 WHERE org_id = $1 AND trace_id = $2
 `
 
@@ -262,6 +254,7 @@ func (q *Queries) GetSpanTurn(ctx context.Context, arg GetSpanTurnParams) (SpanT
 		&i.ContentHash,
 		&i.DeriveSeq,
 		&i.Fidelity,
+		&i.ToolCalls,
 	)
 	return i, err
 }
@@ -473,7 +466,7 @@ func (q *Queries) ListSpanLinksByTrace(ctx context.Context, arg ListSpanLinksByT
 }
 
 const listSpanTurns = `-- name: ListSpanTurns :many
-SELECT org_id, trace_id, session_id, user_prompt, synthetic, status, started_at, ended_at, duration_ns, total_input_tokens, total_output_tokens, total_cost_usd, main_input_tokens, main_output_tokens, cache_read_tokens, cache_creation_tokens, response_preview, source, content_hash, derive_seq, fidelity FROM span_turns_20260615
+SELECT org_id, trace_id, session_id, user_prompt, synthetic, status, started_at, ended_at, duration_ns, total_input_tokens, total_output_tokens, total_cost_usd, main_input_tokens, main_output_tokens, cache_read_tokens, cache_creation_tokens, response_preview, source, content_hash, derive_seq, fidelity, tool_calls FROM span_turns_20260615
 WHERE org_id = $1
   AND ($3::timestamptz IS NULL
        OR (started_at, trace_id) < ($3::timestamptz, $4::text))
@@ -524,6 +517,7 @@ func (q *Queries) ListSpanTurns(ctx context.Context, arg ListSpanTurnsParams) ([
 			&i.ContentHash,
 			&i.DeriveSeq,
 			&i.Fidelity,
+			&i.ToolCalls,
 		); err != nil {
 			return nil, err
 		}
@@ -537,7 +531,7 @@ func (q *Queries) ListSpanTurns(ctx context.Context, arg ListSpanTurnsParams) ([
 
 const listSpanTurnsBySession = `-- name: ListSpanTurnsBySession :many
 
-SELECT org_id, trace_id, session_id, user_prompt, synthetic, status, started_at, ended_at, duration_ns, total_input_tokens, total_output_tokens, total_cost_usd, main_input_tokens, main_output_tokens, cache_read_tokens, cache_creation_tokens, response_preview, source, content_hash, derive_seq, fidelity FROM span_turns_20260615
+SELECT org_id, trace_id, session_id, user_prompt, synthetic, status, started_at, ended_at, duration_ns, total_input_tokens, total_output_tokens, total_cost_usd, main_input_tokens, main_output_tokens, cache_read_tokens, cache_creation_tokens, response_preview, source, content_hash, derive_seq, fidelity, tool_calls FROM span_turns_20260615
 WHERE session_id = $1
 ORDER BY started_at ASC, trace_id ASC
 `
@@ -574,6 +568,7 @@ func (q *Queries) ListSpanTurnsBySession(ctx context.Context, sessionID pgtype.U
 			&i.ContentHash,
 			&i.DeriveSeq,
 			&i.Fidelity,
+			&i.ToolCalls,
 		); err != nil {
 			return nil, err
 		}
@@ -1026,7 +1021,7 @@ INSERT INTO span_turns_20260615 (
     total_input_tokens, total_output_tokens,
     main_input_tokens, main_output_tokens,
     cache_read_tokens, cache_creation_tokens,
-    total_cost_usd, source,
+    total_cost_usd, source, tool_calls,
     content_hash, derive_seq, fidelity
 ) VALUES (
     $1, $2, $3, $4, $5, $6, $7,
@@ -1034,8 +1029,8 @@ INSERT INTO span_turns_20260615 (
     $11, $12,
     $13, $14,
     $15, $16,
-    $17, $18,
-    $19, $20, $21
+    $17, $18, $19,
+    $20, $21, $22
 )
 ON CONFLICT (org_id, trace_id) DO UPDATE SET
     session_id            = COALESCE(span_turns_20260615.session_id, EXCLUDED.session_id),
@@ -1054,6 +1049,7 @@ ON CONFLICT (org_id, trace_id) DO UPDATE SET
     cache_creation_tokens = EXCLUDED.cache_creation_tokens,
     total_cost_usd        = EXCLUDED.total_cost_usd,
     source                = EXCLUDED.source,
+    tool_calls            = EXCLUDED.tool_calls,
     content_hash          = EXCLUDED.content_hash,
     fidelity              = EXCLUDED.fidelity,
     -- Advance the cursor ONLY when the content actually changed. A derive
@@ -1087,6 +1083,7 @@ type UpsertSpanTurnParams struct {
 	CacheCreationTokens int64
 	TotalCostUsd        pgtype.Numeric
 	Source              string
+	ToolCalls           int64
 	ContentHash         string
 	DeriveSeq           int64
 	Fidelity            string
@@ -1115,6 +1112,7 @@ func (q *Queries) UpsertSpanTurn(ctx context.Context, arg UpsertSpanTurnParams) 
 		arg.CacheCreationTokens,
 		arg.TotalCostUsd,
 		arg.Source,
+		arg.ToolCalls,
 		arg.ContentHash,
 		arg.DeriveSeq,
 		arg.Fidelity,

--- a/pkg/storage/postgres/queries/spans.sql
+++ b/pkg/storage/postgres/queries/spans.sql
@@ -9,7 +9,7 @@ INSERT INTO span_turns_20260615 (
     total_input_tokens, total_output_tokens,
     main_input_tokens, main_output_tokens,
     cache_read_tokens, cache_creation_tokens,
-    total_cost_usd, source,
+    total_cost_usd, source, tool_calls,
     content_hash, derive_seq, fidelity
 ) VALUES (
     $1, $2, $3, $4, $5, $6, $7,
@@ -17,8 +17,8 @@ INSERT INTO span_turns_20260615 (
     $11, $12,
     $13, $14,
     $15, $16,
-    $17, $18,
-    $19, $20, $21
+    $17, $18, $19,
+    $20, $21, $22
 )
 ON CONFLICT (org_id, trace_id) DO UPDATE SET
     session_id            = COALESCE(span_turns_20260615.session_id, EXCLUDED.session_id),
@@ -37,6 +37,7 @@ ON CONFLICT (org_id, trace_id) DO UPDATE SET
     cache_creation_tokens = EXCLUDED.cache_creation_tokens,
     total_cost_usd        = EXCLUDED.total_cost_usd,
     source                = EXCLUDED.source,
+    tool_calls            = EXCLUDED.tool_calls,
     content_hash          = EXCLUDED.content_hash,
     fidelity              = EXCLUDED.fidelity,
     -- Advance the cursor ONLY when the content actually changed. A derive
@@ -271,7 +272,12 @@ WHERE sessions.id = f.id;
 --   total_duration_ns = SUM of trace durations — agent time, not the
 --                       wall-clock MAX-MIN window (idle time between
 --                       turns no longer counts)
---   tool_calls        = tool spans_20260615 started in the window
+--   tool_calls        = SUM of the turn rollups' tool span counts,
+--                       windowed on the turn's started_at like every
+--                       other figure here. Counting kind='tool' rows in
+--                       spans_20260615 per request was the aggregate's
+--                       dominant cost: ~20x the rows, wide JSONB
+--                       payloads, and cold heap fetches (PCC-936)
 -- completed_count joins sessions once (LEFT JOIN, so a trace whose
 -- session identity is missing keeps its turn/token totals and simply
 -- doesn't count as completed) rather than a correlated EXISTS per matched
@@ -280,9 +286,9 @@ WHERE sessions.id = f.id;
 --
 -- auth_subject_filter narrows every total to one gateway-stamped subject.
 -- Attribution lives on sessions and nowhere else — neither projection table
--- carries a subject — so both legs reach it through session_id, and both must:
--- a filter the tool_calls subquery did not apply would report one user's turns
--- beside the whole org's tool volume.
+-- carries a subject — so it is reached through session_id, once, in the
+-- matched CTE. Every figure including tool_calls comes from that CTE, so
+-- one predicate scopes them all.
 --
 -- Filtering also tightens the LEFT JOIN to an inner match, and deliberately: a
 -- trace whose session row is missing has no subject, so it belongs to no one
@@ -292,6 +298,7 @@ WITH matched AS (
     SELECT t.org_id, t.trace_id, t.session_id, t.duration_ns,
            t.total_input_tokens, t.total_output_tokens,
            t.cache_read_tokens, t.cache_creation_tokens, t.total_cost_usd,
+           t.tool_calls,
            s.derived_status
     FROM span_turns_20260615 t
     LEFT JOIN sessions s ON s.id = t.session_id
@@ -312,21 +319,7 @@ SELECT
     COALESCE(SUM(cache_read_tokens), 0)::bigint             AS cache_read_tokens,
     COALESCE(SUM(duration_ns), 0)::bigint                   AS total_duration_ns,
     COALESCE(SUM(total_cost_usd), 0)::numeric               AS total_cost_usd,
-    (SELECT COUNT(*) FROM spans_20260615 sp
-     WHERE sp.org_id = sqlc.arg(org_id)
-       AND sp.kind = 'tool'
-       AND (sqlc.narg(since_filter)::timestamptz IS NULL OR sp.started_at >= sqlc.narg(since_filter)::timestamptz)
-       AND (sqlc.narg(until_filter)::timestamptz IS NULL OR sp.started_at < sqlc.narg(until_filter)::timestamptz)
-       -- Uncorrelated on purpose: the subject's session ids depend only on the
-       -- parameter, so this is one hashed subplan (index-only on
-       -- sessions_org_subject_id_idx) rather than a lookup per tool span. A
-       -- correlated EXISTS here is the same O(spans) probe the comment above
-       -- says times out on a wide window.
-       AND (sqlc.narg(auth_subject_filter)::text IS NULL
-            OR sp.session_id IN (SELECT s2.id FROM sessions s2
-                                 WHERE s2.org_id = sqlc.arg(org_id)
-                                   AND s2.auth_subject = sqlc.narg(auth_subject_filter)::text))
-    )::bigint                                               AS tool_calls
+    COALESCE(SUM(tool_calls), 0)::bigint                    AS tool_calls
 FROM matched;
 
 -- name: ListChangedSpanTurns :many

--- a/pkg/storage/postgres/span_stats_rollup_test.go
+++ b/pkg/storage/postgres/span_stats_rollup_test.go
@@ -1,0 +1,57 @@
+package postgres_test
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/papercomputeco/tapes/pkg/storage/postgres"
+)
+
+var _ = Describe("span stats aggregate [postgres]", func() {
+	var (
+		ctx    context.Context
+		driver *postgres.Driver
+		orgID  pgtype.UUID
+	)
+
+	const orgKey = "00000000-0000-4000-8000-0000000057a7"
+
+	BeforeEach(func() {
+		ctx = context.Background()
+
+		var err error
+		driver, err = postgres.NewDriver(ctx, testPostgresDSN)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(driver.Close)
+
+		_, err = driver.DB().Exec(ctx, "TRUNCATE TABLE span_turns_20260615 CASCADE")
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(orgID.Scan(orgKey)).To(Succeed())
+	})
+
+	It("sums tool calls from the turn rollups, not the spans table", func() {
+		// Two turns whose rollups carry tool counts, with no rows in
+		// spans_20260615 at all. The aggregate must believe the rollup:
+		// scanning the wide spans table per request is what made
+		// /v1/stats slow (PCC-936).
+		seq, err := driver.NextDeriveSeqForTest(ctx)
+		Expect(err).NotTo(HaveOccurred())
+
+		a := postgres.NewSpanTurnParamsForTest(orgID, "trace-tools-a", pgtype.UUID{}, "first", seq, postgres.FidelityRaw)
+		a.ToolCalls = 3
+		Expect(driver.SpanTurnUpsertForTest(ctx, a)).To(Succeed())
+
+		b := postgres.NewSpanTurnParamsForTest(orgID, "trace-tools-b", pgtype.UUID{}, "second", seq, postgres.FidelityRaw)
+		b.ToolCalls = 2
+		Expect(driver.SpanTurnUpsertForTest(ctx, b)).To(Succeed())
+
+		stats, err := driver.AggregateSpanStats(ctx, orgKey, nil, nil, "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(stats.TurnCount).To(Equal(2))
+		Expect(stats.ToolCalls).To(Equal(5))
+	})
+})

--- a/pkg/storage/postgres/span_stats_test.go
+++ b/pkg/storage/postgres/span_stats_test.go
@@ -2,13 +2,12 @@ package postgres_test
 
 // The /v1/stats aggregate, and its subject filter.
 //
-// Attribution lives on sessions; the projection tables the aggregate reads
-// carry only a session_id. So "scope the stats to a user" is a join away from
-// every total, and the risk this file exists for is a filter that reaches some
-// of them: turn and token sums narrowed while tool_calls — computed by its own
-// subquery, over a different table — stays org-wide. A response like that does
-// not look wrong, it just reports one user's work beside everyone's tool
-// volume. Each spec below asserts every field, for that reason.
+// Attribution lives on sessions; the projection table the aggregate reads
+// carries only a session_id. So "scope the stats to a user" is a join away
+// from every total, and the risk this file exists for is a filter that
+// reaches some of them but not others. Every figure, tool_calls included,
+// now comes from the turn rollups in one CTE (PCC-936), so one predicate
+// scopes them all — and each spec below asserts every field to pin that.
 
 import (
 	"context"
@@ -87,7 +86,7 @@ var _ = Describe("Driver.AggregateSpanStats", func() {
 	// insertTurn writes one projection row directly. The deriver owns these
 	// in production; writing them here lets a spec state the exact totals it
 	// expects instead of reverse-engineering them from a fixture.
-	insertTurn := func(traceID, sessionID string, in, out int64, costUSD float64, dur time.Duration) {
+	insertTurn := func(traceID, sessionID string, in, out int64, costUSD float64, dur time.Duration, toolCalls int) {
 		var sid any
 		if sessionID == "" {
 			sid = nil // an unattributed trace: no session row, so no subject
@@ -97,9 +96,9 @@ var _ = Describe("Driver.AggregateSpanStats", func() {
 		_, err := pgDriver.DB().Exec(ctx, `
 			INSERT INTO span_turns_20260615
 			    (org_id, trace_id, session_id, started_at, duration_ns,
-			     total_input_tokens, total_output_tokens, total_cost_usd)
-			VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
-			mustUUID(orgID), traceID, sid, base, dur.Nanoseconds(), in, out, costUSD)
+			     total_input_tokens, total_output_tokens, total_cost_usd, tool_calls)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+			mustUUID(orgID), traceID, sid, base, dur.Nanoseconds(), in, out, costUSD, toolCalls)
 		Expect(err).NotTo(HaveOccurred())
 	}
 
@@ -128,11 +127,11 @@ var _ = Describe("Driver.AggregateSpanStats", func() {
 		bobSession = seedSubjectSession("user_bob", "bob-1")
 		markCompleted(aliceSession)
 
-		insertTurn("trace-alice-1", aliceSession, 100, 10, 1.5, 2*time.Second)
+		insertTurn("trace-alice-1", aliceSession, 100, 10, 1.5, 2*time.Second, 1)
 		insertToolSpan("trace-alice-1", "span-alice-tool-1", aliceSession)
 
-		insertTurn("trace-bob-1", bobSession, 200, 20, 2.5, 3*time.Second)
-		insertTurn("trace-bob-2", bobSession, 400, 40, 4.0, 5*time.Second)
+		insertTurn("trace-bob-1", bobSession, 200, 20, 2.5, 3*time.Second, 1)
+		insertTurn("trace-bob-2", bobSession, 400, 40, 4.0, 5*time.Second, 1)
 		insertToolSpan("trace-bob-1", "span-bob-tool-1", bobSession)
 		insertToolSpan("trace-bob-2", "span-bob-tool-2", bobSession)
 	})
@@ -162,8 +161,8 @@ var _ = Describe("Driver.AggregateSpanStats", func() {
 		Expect(stats.OutputTokens).To(Equal(int64(10)))
 		Expect(stats.TotalCostUSD).To(BeNumerically("~", 1.5, 0.0001))
 		Expect(stats.TotalDurationNS).To(Equal((2 * time.Second).Nanoseconds()))
-		// The one that a partial implementation gets wrong: tool_calls is a
-		// separate subquery over a separate table, and org-wide it is 3.
+		// tool_calls comes from the same matched CTE as everything else, so
+		// the subject filter scopes it too; org-wide it is 3.
 		Expect(stats.ToolCalls).To(Equal(1))
 	})
 
@@ -207,7 +206,7 @@ var _ = Describe("Driver.AggregateSpanStats", func() {
 		// nobody: it keeps counting in the org-wide totals it has always
 		// counted in, and joins no user's. The filter tightening the LEFT
 		// JOIN to an inner match is what makes the second half true.
-		insertTurn("trace-orphan", "", 1_000, 100, 9.0, 7*time.Second)
+		insertTurn("trace-orphan", "", 1_000, 100, 9.0, 7*time.Second, 0)
 
 		orgWide, err := pgDriver.AggregateSpanStats(ctx, orgID, nil, nil, "")
 		Expect(err).NotTo(HaveOccurred())
@@ -264,8 +263,8 @@ var _ = Describe("Driver.AggregateSpanStats", func() {
 		_, err = pgDriver.DB().Exec(ctx, `
 			INSERT INTO span_turns_20260615
 			    (org_id, trace_id, session_id, started_at, duration_ns,
-			     total_input_tokens, total_output_tokens, total_cost_usd)
-			VALUES ($1, 'trace-alice-elsewhere', $2, $3, 0, 5000, 500, 50.0)`,
+			     total_input_tokens, total_output_tokens, total_cost_usd, tool_calls)
+			VALUES ($1, 'trace-alice-elsewhere', $2, $3, 0, 5000, 500, 50.0, 1)`,
 			mustUUID(otherOrg), mustUUID(res.SessionID), base)
 		Expect(err).NotTo(HaveOccurred())
 		_, err = pgDriver.DB().Exec(ctx, `

--- a/pkg/storage/postgres/spans.go
+++ b/pkg/storage/postgres/spans.go
@@ -103,6 +103,7 @@ func writeSpanSet(
 			CacheCreationTokens: turn.CacheCreationTokens,
 			TotalCostUsd:        costNumeric,
 			Source:              turn.Source,
+			ToolCalls:           int64(turn.ToolCalls),
 			DeriveSeq:           deriveSeq,
 			Fidelity:            rollupFidelity(spanTiers),
 		}


### PR DESCRIPTION
Fixes PCC-936.

Skeletons are back on the console and the /stats experience is slow enough it breaks everything. 

## Root cause

`/v1/stats` cost was almost entirely the `tool_calls` subquery, which counted `kind='tool'` rows in the wide `spans_20260615` table per request: ~20x the row volume of `span_turns` (95k vs 4.6k over a 30d window on the hosted org), rows carrying `input`/`output`/`usage` JSONB, and in-place re-derive rewrites clearing visibility-map bits so the `(org_id, kind, started_at)` index degrades into random heap fetches. On cold shared-Postgres cache that is seconds of I/O, and the Insights page pays it twice (current + previous period in parallel). Measured against the hosted org API: 1.2 to 3.9s per cold call with identical window shapes.

## Fix

Fold the count at derive time instead: `SpanTurn.ToolCalls` joins the other turn totals in the emit fold, lands in `span_turns` via the existing single-writer upsert, participates in the change-feed content hash, and the aggregate sums it from the matched CTE. `/v1/stats` now touches only the narrow turn table plus the sessions join.

Attribution shift, deliberate: tool calls are windowed on their turn's `started_at` rather than each tool span's own timestamp, matching how every other stats figure is attributed (the handler doc already promises the numbers agree with the trace views).

The migration backfills existing rows from a grouped count over spans; later re-derives self-heal the column. Including the column in the content hash re-emits every turn row once on the next derive pass, which feed consumers tolerate by design.

## Verification

Bench DB at 2x hosted scale (9,000 turns / 179,811 tool spans / 738 MB spans table, every span row rewritten once to reproduce the re-derive visibility degradation):

| Check | Result |
|---|---|
| SUM(tool_calls) vs COUNT(spans kind='tool'), full range | 179,811 both |
| Migration backfill from zeroed column | 0 mismatches across 9,000 turns |
| Old vs new aggregate, 30d window | 93,821 both |
| Old query | 88,128 buffers (~688 MB, parallel seq scan on spans), 155 ms warm local |
| New query | 767 buffers (~6 MB, all cache hits), 4.5 ms |
| `GET /v1/stats` e2e via `tapes serve api`, 30d window | 3.5 to 15 ms |

The new working set fits in shared_buffers permanently, so the cold-cache volatility goes away by construction.

Tests: derive corpus test pins the per-turn fold; postgres suite covers the rollup-sourced aggregate, upsert plumbing, and content-hash inclusion. No response-shape change; the OpenAPI prose ("span-grain trace rollup sums") becomes more accurate.

## Rebase notes (after #310 landed)

The branch was originally cut from a stale mirror of main; rebased onto current main. Composes cleanly with #310's `auth_subject` scoping — and simplifies it: with `tool_calls` in the matched CTE, the subject filter scopes every figure through one predicate, so the separately-scoped tool-span subquery leg (and its uncorrelated-subplan workaround) is gone. #310's span_stats specs now express tool counts through the turn rollup, same totals asserted.

## Rolling-deploy note

A pre-change derive worker still running after the migration writes turns with `tool_calls = 0` until that session re-derives (its content_hash differs under new code, so any later derive pass self-heals it). The backfill UPDATE is deliberately idempotent (`IS DISTINCT FROM` guard): once all workers are on the new binary, re-run it verbatim — or run `tapes dev rederive` — to close the window. Documented in the migration header.