### PR TITLE
📚 docs: the README points at the docs home that exists

### DIFF
--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -23,7 +23,7 @@ func New(
 	// Project source directory.
 	//
 	// +defaultPath="/"
-	// +ignore=[".git", ".direnv", ".devenv", "build", "tmp", "tapes.dev/node_modules", "tapes.dev/.astro"]
+	// +ignore=[".git", ".direnv", ".devenv", "build", "tmp"]
 	source *dagger.Directory,
 ) *Tapes {
 	return &Tapes{

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   ·
   <a href="https://tapes.dev/">Download</a>
   ·
-  <a href="https://tapes.dev/guides/">Documentation</a>
+  <a href="https://tapes.dev/docs/">Documentation</a>
   ·
   <a href="CONTRIBUTING.md">Contributing</a>
 </p>
@@ -158,5 +158,5 @@ tapesctl start claude --tapes-url http://localhost:8081
 ```
 
 `tapesctl start` launches the agent under a just-in-time capture proxy and ships
-the turns to this server. See the [agent guides](https://tapes.dev/guides) for
+the turns to this server. See the [agent guides](https://tapes.dev/docs/) for
 Claude Code, OpenCode, and more.


### PR DESCRIPTION
The Documentation badge and the agent-guides link pointed at `/guides/`, which now 301s — both move to `https://tapes.dev/docs/`, verified 200 live. Also removes two dead entries from the dagger source ignore list that referenced the site directory deleted with the docs flatten (module loads clean without them).

related to PCC-1186

🤖 Generated with [Claude Code](https://claude.com/claude-code)