### PR TITLE
🔧 fix(spanembed): probe embedding state per candidate via LATERAL join

### DIFF
--- a/pkg/spanembed/store.go
+++ b/pkg/spanembed/store.go
@@ -321,10 +321,20 @@ func (s *Store) ensureFailuresTable(ctx context.Context) error {
 
 // ListCandidates pages every main llm span (keyset-ordered) joined with its
 // current embedding state and any recorded failure. All of a span's chunk rows
-// share one content hash and model, so the embedding join collapses them to a
-// single row; the failure table is already one row per span. The caller decides
-// per candidate whether an embed is due — content hashing happens in Go, so the
-// query stays a cheap indexable join.
+// share one content hash and model, so the per-span aggregate collapses them to
+// a single row; the failure table is already one row per span. The caller
+// decides per candidate whether an embed is due — content hashing happens in
+// Go, so the query stays a cheap indexable join.
+//
+// The embedding lookup is a correlated LATERAL subquery, and that shape is
+// load-bearing. Postgres badly underestimates the row-value cursor comparison
+// (it assumes ~1 row whatever the cursor), so given a non-correlated
+// GROUP-BY-the-whole-embedding-table subquery it hash-joins against it and
+// materializes every remaining span — TOASTed payloads included — to return
+// one page. That is O(corpus) payload bytes per page, per pass, and it wedged
+// the largest tenant for days. The LATERAL form pins the only sane plan: walk
+// the spans PK in cursor order, probe the embedding PK per span, stop at
+// LIMIT.
 func (s *Store) ListCandidates(ctx context.Context, after Key, limit int) ([]Candidate, error) {
 	table := s.table.Sanitize()
 	query := fmt.Sprintf(`
@@ -332,13 +342,11 @@ func (s *Store) ListCandidates(ctx context.Context, after Key, limit int) ([]Can
 		       COALESCE(e.content_hash, ''), COALESCE(e.model, ''),
 		       COALESCE(f.content_hash, ''), COALESCE(f.model, '')
 		FROM spans_20260615 s
-		LEFT JOIN (
-			SELECT org_id, trace_id, span_id,
-			       max(content_hash) AS content_hash, max(model) AS model
-			FROM %s
-			GROUP BY org_id, trace_id, span_id
-		) e
-		  ON e.org_id = s.org_id AND e.trace_id = s.trace_id AND e.span_id = s.span_id
+		LEFT JOIN LATERAL (
+			SELECT max(content_hash) AS content_hash, max(model) AS model
+			FROM %s se
+			WHERE se.org_id = s.org_id AND se.trace_id = s.trace_id AND se.span_id = s.span_id
+		) e ON true
 		LEFT JOIN %s f
 		  ON f.org_id = s.org_id AND f.trace_id = s.trace_id AND f.span_id = s.span_id
 		WHERE s.kind = 'llm' AND s.call_kind = 'main'

--- a/pkg/spanembed/store_test.go
+++ b/pkg/spanembed/store_test.go
@@ -264,6 +264,50 @@ var _ = Describe("Store", func() {
 			Expect(hits[0].Score).To(BeNumerically("~", 1.0, 1e-4))
 		})
 
+		It("lists a chunked span as one candidate and surfaces failure state, across pages", func() {
+			insertSpan("llm_a", "llm", "main", `[{"type":"text","text":"alpha content"}]`, "")
+			insertSpan("llm_b", "llm", "main", `[{"type":"text","text":"beta content"}]`, "")
+			store := newStore(3)
+
+			// Span A: three chunk rows sharing one hash+model must collapse
+			// to a single candidate. Span B: a recorded failure must surface
+			// on its candidate.
+			Expect(store.UpsertSpanChunks(ctx, spanembed.ChunkRecord{
+				OrgID: org, TraceID: traceA, SpanID: "llm_a", Model: "m", ContentHash: "ha",
+				Embeddings: [][]float32{{1, 0, 0}, {0, 1, 0}, {0, 0, 1}},
+			})).To(Succeed())
+			Expect(store.RecordFailure(ctx, spanembed.FailureRecord{
+				OrgID: org, TraceID: traceA, SpanID: "llm_b", Model: "m",
+				ContentHash: "hb", Reason: "oversize",
+			})).To(Succeed())
+
+			candidates, err := store.ListCandidates(ctx, spanembed.Key{}, 100)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(candidates).To(HaveLen(2))
+			Expect(candidates[0].SpanID).To(Equal("llm_a"))
+			Expect(candidates[0].ExistingHash).To(Equal("ha"))
+			Expect(candidates[0].ExistingModel).To(Equal("m"))
+			Expect(candidates[0].ExistingFailHash).To(BeEmpty())
+			Expect(candidates[1].SpanID).To(Equal("llm_b"))
+			Expect(candidates[1].ExistingHash).To(BeEmpty())
+			Expect(candidates[1].ExistingFailHash).To(Equal("hb"))
+			Expect(candidates[1].ExistingFailModel).To(Equal("m"))
+
+			// Keyset pagination: a page of one, resumed from its key, yields
+			// exactly the remaining span.
+			page, err := store.ListCandidates(ctx, spanembed.Key{}, 1)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(page).To(HaveLen(1))
+			Expect(page[0].SpanID).To(Equal("llm_a"))
+			page, err = store.ListCandidates(ctx, page[0].Key(), 1)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(page).To(HaveLen(1))
+			Expect(page[0].SpanID).To(Equal("llm_b"))
+			page, err = store.ListCandidates(ctx, page[0].Key(), 1)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(page).To(BeEmpty())
+		})
+
 		It("prunes orphaned failure rows when the span no longer exists", func() {
 			store := newStore(3)
 			Expect(store.RecordFailure(ctx, spanembed.FailureRecord{


### PR DESCRIPTION
🤖

## Summary

- The largest paper tenant has had the embed worker frozen for weeks: its first pass after the v0.35.0 rollout ran 7¾ hours without completing, and under load a single `ListCandidates` page query was observed running **35 minutes** before a pod drain canceled it (Postgres log, 2026-08-13 20:21 UTC, session start 19:46).
- Root cause: Postgres estimates the keyset cursor comparison `(org_id, trace_id, span_id) > (...)` at ~1 row regardless of cursor position. With the embedding join written as a non-correlated `GROUP BY` over the whole `span_embeddings` table, that misestimate makes the planner hash-join and materialize **every remaining span — TOASTed `input`/`output` payloads included — to return one LIMIT-100 page**, spilling to temp (~3.2 GB of buffer traffic per page, ~1,300 pages per pass). The misestimate is structural, not stale stats: the table had been autoanalyzed minutes before the EXPLAIN below.
- Fix: rewrite the embedding-state lookup as a correlated `LEFT JOIN LATERAL` aggregate, which leaves the planner only the index-ordered plan — walk the spans PK from the cursor, probe the embedding PK per span, stop at LIMIT.
- Semantics are unchanged: an aggregate without `GROUP BY` always returns exactly one row, so never-embedded spans still surface with empty hash/model, and a span's chunk rows still collapse to one candidate.
- This is the first, minimal slice of PCC-1203 — no schema change. The SQL-side content-hash gate, per-page metrics flush + pass deadline, the staleness alert, and the change-feed cursor fix follow as separate PRs per the plan on the issue.

## Measured on the affected tenant

Same page, same data, 130k embeddable spans (`EXPLAIN (ANALYZE, BUFFERS)`, production, 2026-08-14):

| query shape | first page |
|---|---|
| `GROUP BY` subquery (current) | **120,100 ms** — 398k buffers, 4-batch hash spill to temp |
| `LATERAL` probe (this PR) | **106 ms** — 853 buffers |

A full pass drops from ~20–40 hours — longer than the deploy cadence, so it restarted from zero on every rollout and never finished — to minutes.

## Test plan

- [x] New regression spec pins exactly what the rewrite must preserve: a 3-chunk span collapses to one candidate, failure rows surface `ExistingFailHash`/`ExistingFailModel`, and keyset pagination pages to exhaustion — green against the Dagger Postgres service.
- [x] `make check` (generate, go-mod-tidy, lint, parity, test) — green locally on this exact commit.
- [ ] After deploy: `tapes_embed_worker_last_success_timestamp_seconds{namespace="tenant-zro54"}` leaves 0 and passes complete within minutes.

Related to PCC-1203
