### PR TITLE
🔧 fix: the README's capture example points at ingest, not the read API

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,13 @@ concerns, and they live in [`tapesctl`](https://github.com/papercomputeco/tapesc
 curl -sSfL https://download.tapes.dev/tapesctl/install | bash
 ```
 
+`tapesctl` never guesses a server. Name this one once so the read commands
+below work without repeating the flag:
+
+```bash
+tapesctl config set tapes-url http://localhost:8081
+```
+
 Start with demo data so every command below has something to show — this path
 works end to end before you wire up a real agent:
 
@@ -124,11 +131,6 @@ List captured sessions and their ids:
 
 ```bash
 tapesctl sessions list --tapes-url http://localhost:8081
-```
-
-Browse sessions and drill into a single session in the deck TUI:
-
-```bash
 ```
 
 Export a captured session as JSONL — the API's session→traces→spans projection
@@ -154,12 +156,16 @@ the proxy:
 
 ```bash
 tapes local down --wipe && tapes local up   # recreate the DB, clearing the demo
-tapesctl start claude --tapes-url http://localhost:8081
+tapesctl start claude --tapes-url http://localhost:8082
 ```
 
 `tapesctl start` launches the agent under a just-in-time capture proxy and ships
-the turns to this server. See the [agent guides](https://tapes.dev/docs/) for
-Claude Code, OpenCode, and more.
+the turns to this server. Capture addresses the private ingest API on `8082`,
+not the read API on `8081` — a capture pointed at the read port reports success
+and stores nothing. `start` launches `claude`, `codex`, and `pi`; the Codex
+desktop app launches itself and is captured with `tapesctl capture codex-app`.
+See [Agent integrations](https://tapes.dev/docs/integrations/) for the full
+matrix and the plugin each lane needs first.
 
 ## License
 


### PR DESCRIPTION
`tapesctl start` addresses the private ingest API on `8082`. The README sent it to `8081`, the read API, where `/v1/ingest` is not registered — so a reader following the quickstart got a capture that reported success, exited 0, and stored nothing. The same defect was corrected across `docs/` in the docs flatten (#308); the README was missed, and it is the page most readers arrive at first.

The correction states both ports and the failure mode inline, because the symptom of the wrong one is silence rather than an error.

Three other claims the README outlived:

- **The deck TUI section** survived as a heading over an empty code block. Deck was removed with no CLI replacement — the console owns session browsing (per `AGENTS.md`).
- **`start opencode` is withdrawn** and refused. The harnesses `start` launches are `claude`, `codex`, and `pi`; the Codex desktop app launches itself and is captured through `capture codex-app`. Matches the lane table in `docs/integrations.md`.
- **`search` and the second `export` example** ran without a server, which fails on a fresh machine. A one-time `tapesctl config set tapes-url` now precedes them, matching what the installation docs teach.

Every absolute link in the touched file was curl-verified 200 against the live site.

related to PCC-1186