### PR TITLE
🔧 fix: title sessions from plugin-prefixed prompts

### DIFF
--- a/api/sessions_display_title_test.go
+++ b/api/sessions_display_title_test.go
@@ -41,6 +41,21 @@ var _ = Describe("resolveSessionDisplayTitle", func() {
 		s := base
 		s.Preview = `{"channel_link":"https://example.com"}`
 		Expect(resolveSessionDisplayTitle(s)).To(Equal("clearing-exa"))
+		s.Preview = `["first", "second"]`
+		Expect(resolveSessionDisplayTitle(s)).To(Equal("clearing-exa"))
+	})
+
+	It("skips a JSON preview classified before it was truncated", func() {
+		s := base
+		s.Preview = `{"payload":"a truncated fragment`
+		s.PreviewIsJSON = true
+		Expect(resolveSessionDisplayTitle(s)).To(Equal("clearing-exa"))
+	})
+
+	It("keeps a Markdown plugin invocation as prose rather than mistaking it for JSON", func() {
+		s := base
+		s.Preview = "[@visualize](plugin://visualize@openai-bundled) Explore this dataset"
+		Expect(resolveSessionDisplayTitle(s)).To(Equal(s.Preview))
 	})
 
 	It("falls back to the harness id slice when nothing human is set", func() {

--- a/api/sessions_handlers.go
+++ b/api/sessions_handlers.go
@@ -186,9 +186,10 @@ type SessionDetailResponse struct {
 //	-> Name (harness slug / coalesced) — last human-ish label
 //	-> a short harness_session_id slice, then the session id — never empty
 //
-// Preview is already scaffolding-stripped by the deriver; the JSON guard
-// mirrors the Console's prior client-side rule for attribution-gap sessions
-// whose first captured node is a tool_result rather than prose.
+// Preview is already scaffolding-stripped by the deriver. PreviewIsJSON is
+// classified from the full prompt before storage truncates the preview; the
+// local validity check also covers untruncated records constructed by other
+// storage implementations and tests.
 func resolveSessionDisplayTitle(s storage.SessionRecord) string {
 	if t := strings.TrimSpace(s.DisplayName); t != "" {
 		return t
@@ -196,7 +197,7 @@ func resolveSessionDisplayTitle(s storage.SessionRecord) string {
 	if t := strings.TrimSpace(s.DerivedTitle); t != "" {
 		return t
 	}
-	if t := strings.TrimSpace(s.Preview); t != "" && !looksLikeJSONPreview(t) {
+	if t := strings.TrimSpace(s.Preview); t != "" && !s.PreviewIsJSON && !looksLikeJSONPreview(t) {
 		return t
 	}
 	if t := strings.TrimSpace(s.Name); t != "" {
@@ -212,11 +213,17 @@ func resolveSessionDisplayTitle(s storage.SessionRecord) string {
 	return s.ID
 }
 
-// looksLikeJSONPreview is a cheap guard for previews that are really
-// tool-result payloads rather than user prose (a leading { or [).
+// looksLikeJSONPreview guards against previews that are really tool-result
+// payloads rather than user prose. The opening delimiter is only a fast path:
+// Markdown-style plugin invocations also begin with "[" (for example,
+// [@visualize](plugin://...)), so require the whole preview to be valid JSON
+// before suppressing it as a display-title candidate.
 func looksLikeJSONPreview(s string) bool {
 	t := strings.TrimLeft(s, " \t\r\n")
-	return strings.HasPrefix(t, "{") || strings.HasPrefix(t, "[")
+	if !strings.HasPrefix(t, "{") && !strings.HasPrefix(t, "[") {
+		return false
+	}
+	return json.Valid([]byte(t))
 }
 
 // shortHarnessSessionID is the last-resort label: a 12-char slice of the

--- a/docs/data.md
+++ b/docs/data.md
@@ -30,6 +30,15 @@ Each prints the server's JSON verbatim, so it composes with `jq`. `--tapes-url` 
 The `<session-id>` these take is the Tapes session id from `sessions list`. It
 is not the harness session id `tapesctl start` prints when it exits.
 
+Session responses include `display_title`, the label clients should render. It
+prefers a user rename, then a generated title, then the first human prompt
+preview before falling back to harness identity. Prompt previews omit a leading
+Codex App plugin invocation such as `[@visualize](plugin://visualize@openai-bundled)`;
+the user's request remains as the human-facing title. Valid JSON object or array
+previews are treated as tool payloads and skipped rather than shown as titles.
+This classification uses the complete prompt, so JSON payloads remain skipped
+when their displayed preview is truncated.
+
 ## Browse in a browser
 
 The API binary can serve a small same-origin UI at `/`, in the style of

--- a/pkg/merkle/projection.go
+++ b/pkg/merkle/projection.go
@@ -184,6 +184,13 @@ var previewWrapperTags = map[string]bool{
 	"command-args": true,
 }
 
+// leadingPluginInvocation matches the Markdown link that Codex App prepends
+// when the user explicitly invokes a plugin. It is harness routing metadata,
+// not part of the user's request, so human-facing previews omit it. Keep the
+// match anchored and scheme-specific: ordinary Markdown links and plugin links
+// quoted later in the request are user content and must survive unchanged.
+var leadingPluginInvocation = regexp.MustCompile(`^[ \t\r\n]*\[@[^\]\r\n]+\]\(plugin://[^)\r\n]+\)[ \t\r\n]*`)
+
 // PreviewText projects one content block's Text for a human-facing turn
 // preview: unwrap the content-bearing harness wrappers (keep their inner
 // text) and strip every other harness span whole, then normalize
@@ -203,6 +210,9 @@ func PreviewText(text string) string {
 		} else {
 			text = stripTaggedSpan(text, tag)
 		}
+	}
+	for leadingPluginInvocation.MatchString(text) {
+		text = leadingPluginInvocation.ReplaceAllString(text, "")
 	}
 	return normalizeWhitespace(text)
 }

--- a/pkg/merkle/projection_test.go
+++ b/pkg/merkle/projection_test.go
@@ -394,4 +394,20 @@ var _ = Describe("PreviewText", func() {
 		Expect(merkle.PreviewText("<command-args>truncated goal text")).
 			To(Equal("truncated goal text"))
 	})
+
+	It("strips leading plugin invocations while keeping the human request", func() {
+		Expect(merkle.PreviewText(
+			"[@visualize](plugin://visualize@openai-bundled) Turn this dataset into an interactive explorer")).
+			To(Equal("Turn this dataset into an interactive explorer"))
+		Expect(merkle.PreviewText(
+			"[@first](plugin://first@example) [@second](plugin://second@example) Compare both plugins")).
+			To(Equal("Compare both plugins"))
+	})
+
+	It("preserves ordinary Markdown links and plugin links outside the invocation prefix", func() {
+		Expect(merkle.PreviewText("Read [the docs](https://example.com) first")).
+			To(Equal("Read [the docs](https://example.com) first"))
+		Expect(merkle.PreviewText("Explain [@visualize](plugin://visualize@openai-bundled) syntax")).
+			To(Equal("Explain [@visualize](plugin://visualize@openai-bundled) syntax"))
+	})
 })

--- a/pkg/storage/postgres/session_reads.go
+++ b/pkg/storage/postgres/session_reads.go
@@ -171,8 +171,15 @@ func (d *Driver) attachPreviews(ctx context.Context, records []storage.SessionRe
 		return
 	}
 	for i := range records {
-		records[i].Preview = previews[records[i].ID]
+		preview := previews[records[i].ID]
+		records[i].Preview = preview.text
+		records[i].PreviewIsJSON = preview.isJSON
 	}
+}
+
+type sessionPreview struct {
+	text   string
+	isJSON bool
 }
 
 // getSessionPreviews fetches the first turn's user prompt for each
@@ -184,7 +191,7 @@ func (d *Driver) attachPreviews(ctx context.Context, records []storage.SessionRe
 // session_id) also sidesteps the legacy node path's cross-session
 // content-collapse, where a shared-content node could be attributed to
 // the wrong session.
-func (d *Driver) getSessionPreviews(ctx context.Context, sessions []storage.SessionRecord) (map[string]string, error) {
+func (d *Driver) getSessionPreviews(ctx context.Context, sessions []storage.SessionRecord) (map[string]sessionPreview, error) {
 	if len(sessions) == 0 {
 		return nil, nil
 	}
@@ -212,18 +219,19 @@ ORDER BY session_id, (synthetic = '' AND TRIM(user_prompt) <> '') DESC, started_
 	}
 	defer rows.Close()
 
-	out := make(map[string]string, len(sessions))
+	out := make(map[string]sessionPreview, len(sessions))
 	for rows.Next() {
 		var sessionID, userPrompt string
 		if err := rows.Scan(&sessionID, &userPrompt); err != nil {
 			continue
 		}
 		text := strings.TrimSpace(userPrompt)
+		isJSON := json.Valid([]byte(text))
 		if utf8.RuneCountInString(text) > sessionPreviewMaxRunes {
 			runes := []rune(text)
 			text = string(runes[:sessionPreviewMaxRunes])
 		}
-		out[sessionID] = text
+		out[sessionID] = sessionPreview{text: text, isJSON: isJSON}
 	}
 	return out, rows.Err()
 }

--- a/pkg/storage/postgres/session_reads_test.go
+++ b/pkg/storage/postgres/session_reads_test.go
@@ -2,6 +2,7 @@ package postgres_test
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -600,5 +601,19 @@ var _ = Describe("Driver.GetSessionRecord preview", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(rec).NotTo(BeNil())
 		Expect(rec.Preview).To(BeEmpty())
+	})
+
+	It("classifies valid JSON before truncating its preview", func() {
+		orgID := newTestOrgID()
+		const id = "01900000-0000-7000-8000-0000000000c3"
+		insertSession(orgID, id, "sess-json-preview")
+		prompt := `{"payload":"` + strings.Repeat("x", 160) + `"}`
+		insertTurn(orgID, id, "trc-1", prompt, "", 0)
+
+		rec, err := pgDriver.GetSessionRecord(ctx, orgID, id)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rec).NotTo(BeNil())
+		Expect([]rune(rec.Preview)).To(HaveLen(120))
+		Expect(rec.PreviewIsJSON).To(BeTrue())
 	})
 })

--- a/pkg/storage/session_record.go
+++ b/pkg/storage/session_record.go
@@ -58,9 +58,10 @@ type SessionRecord struct {
 	// KindCounts the per-call_kind span tally (sessions.tasks /
 	// sessions.kind_counts), both JSONB served verbatim on the composite
 	// traces response. Nil until the session derives.
-	Tasks      json.RawMessage
-	KindCounts json.RawMessage
-	Preview    string // first user turn text, truncated; empty when unavailable
+	Tasks         json.RawMessage
+	KindCounts    json.RawMessage
+	Preview       string // first user turn text, truncated; empty when unavailable
+	PreviewIsJSON bool   // full prompt was valid JSON before preview truncation
 	// AuthSubject is the gateway-stamped JWT subject (the WorkOS user id)
 	// captured at ingest. Empty for rows captured before the edge began
 	// stamping the x-paper-auth-subject header.


### PR DESCRIPTION
## Summary

- Generate human-friendly titles for sessions whose prompts begin with ChatGPT plugin invocation links.
- Treat previews as tool payloads only when the complete preview is valid JSON.
- Preserve ordinary Markdown links and plugin references that occur later in user prose.
- Document the preview normalization behavior.

## How it works

Preview projection strips one or more leading Markdown links whose destinations use the `plugin://` scheme. The remaining user prompt becomes the title-generation preview.

At title resolution, previews beginning with `{` or `[` are suppressed only when the complete preview is valid JSON. Markdown plugin invocations beginning with `[` therefore continue through title generation.

## Behavior matrix

| Prompt preview | Before | After |
|---|---|---|
| Leading `plugin://` invocation | Session ID fallback | Title from the user prompt |
| Multiple leading plugin invocations | Session ID fallback | Title from the remaining prompt |
| Valid JSON tool payload | Suppressed | Suppressed |
| Ordinary Markdown link | Preserved | Preserved |
| Plugin link later in prose | Preserved | Preserved |

## Test plan

- [x] Run `nix develop --command make check`
- [x] Add projection coverage for single and multiple leading plugin invocations
- [x] Add title-resolution coverage for bracket-prefixed Markdown
- [x] Verify generation, module tidiness, lint, parity, tests, and extproc checks

Fixes PCC-1229
