### PR TITLE
📚 docs: document separate API and ingest endpoints

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ Seeding is a client operation, so it lives in
 and derived just like live sessions, so it shows up in `tapesctl sessions list`:
 
 ```bash
-tapesctl seed --tapes-url http://localhost:8081
+tapesctl seed --api-url http://localhost:8081
 ```
 
 To reset demo data, use a fresh database behind the API server.
@@ -72,7 +72,7 @@ To reset demo data, use a fresh database behind the API server.
   - `make build-local` sets this automatically
 - `make format`/`make check`/`make test` require Docker for Dagger
 - Demo seeding docs
-  - Use `tapesctl seed --tapes-url http://localhost:8081` to seed demo sessions
+  - Use `tapesctl seed --api-url http://localhost:8081` to seed demo sessions
   - Use a fresh Postgres database behind the API when reseeding
 
 ## Example commands
@@ -85,8 +85,8 @@ make build-local
 ./build/tapes local
 
 # Seed demo data through a running API (tapesctl), then browse it in the deck UI
-tapesctl seed --tapes-url http://localhost:8081
-tapesctl sessions list --tapes-url http://localhost:8081
+tapesctl seed --api-url http://localhost:8081
+tapesctl sessions list --api-url http://localhost:8081
 
 # Run tests with the Postgres service provisioned by Dagger
 make test

--- a/README.md
+++ b/README.md
@@ -99,24 +99,20 @@ concerns, and they live in [`tapesctl`](https://github.com/papercomputeco/tapesc
 curl -sSfL https://download.tapes.dev/tapesctl/install | bash
 ```
 
-`tapesctl` never guesses a server. Name this one once so the read commands
-below work without repeating the flag:
-
-```bash
-tapesctl config set tapes-url http://localhost:8081
-```
+`tapesctl` defaults reads to `http://localhost:8081` and capture to
+`http://localhost:8082`; flags, environment variables, and config override them.
 
 Start with demo data so every command below has something to show — this path
 works end to end before you wire up a real agent:
 
 ```bash
-tapesctl seed --tapes-url http://localhost:8081
+tapesctl seed --api-url http://localhost:8081
 ```
 
 List captured sessions and their ids:
 
 ```bash
-tapesctl sessions list --tapes-url http://localhost:8081
+tapesctl sessions list --api-url http://localhost:8081
 ```
 
 Export a captured session as JSONL — the API's session→traces→spans projection
@@ -126,7 +122,7 @@ that cassette. The full span tree is included by default; pass
 `--detail traces` for turn headers only:
 
 ```bash
-tapesctl export <session-id> --tapes-url http://localhost:8081 -o session.jsonl
+tapesctl export <session-id> --api-url http://localhost:8081 -o session.jsonl
 tapesctl export <session-id> --detail traces
 ```
 
@@ -135,7 +131,7 @@ the proxy:
 
 ```bash
 tapes local down --wipe && tapes local up   # recreate the DB, clearing the demo
-tapesctl start claude --tapes-url http://localhost:8082
+tapesctl start claude --ingest-url http://localhost:8082
 ```
 
 `tapesctl start` launches the agent under a just-in-time capture proxy and ships

--- a/docs/cassette-walkthrough.md
+++ b/docs/cassette-walkthrough.md
@@ -110,7 +110,7 @@ cassette fall back to memory and say so.
 `tapesctl` reads the same discovery surface and generates a subcommand per
 cassette, with a method per OpenAPI operation. Because the nouns have to exist
 before the command line is parsed, point discovery at the server with the
-`TAPES_API_URL` environment variable (the `--tapes-url` flag also works, on any
+`TAPES_API_URL` environment variable (the `--api-url` flag also works, on any
 subcommand):
 
 ```bash

--- a/docs/cassette-walkthrough.md
+++ b/docs/cassette-walkthrough.md
@@ -110,11 +110,11 @@ cassette fall back to memory and say so.
 `tapesctl` reads the same discovery surface and generates a subcommand per
 cassette, with a method per OpenAPI operation. Because the nouns have to exist
 before the command line is parsed, point discovery at the server with the
-`TAPES_URL` environment variable (the `--tapes-url` flag also works, on any
+`TAPES_API_URL` environment variable (the `--tapes-url` flag also works, on any
 subcommand):
 
 ```bash
-export TAPES_URL=http://localhost:8081
+export TAPES_API_URL=http://localhost:8081
 
 tapesctl cassettes                 # `hello-world` has appeared
 tapesctl cassettes hello-world --help
@@ -162,14 +162,14 @@ docker run -d --name hw-derive --network tapes-hello-world_default \
 Run a harness under capture, pointed at the ingest server:
 
 ```bash
-tapesctl start --tapes-url http://localhost:8082 claude -- -p "Reply with exactly: ok"
+tapesctl start --ingest-url http://localhost:8082 claude -- -p "Reply with exactly: ok"
 ```
 
 After the derive worker's debounce (about twenty seconds), the session, its
 trace, and its spans are readable from the same API that serves the cassette:
 
 ```bash
-tapesctl sessions list          # TAPES_URL still points at :8081
+tapesctl sessions list          # TAPES_API_URL still points at :8081
 curl -s "localhost:8081/v1/sessions?limit=5" | jq '.items[].display_title'
 ```
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -60,13 +60,13 @@ curl -sSfL https://download.tapes.dev/tapesctl/install | bash
 
 ```bash
 tapesctl start claude --ingest-url http://localhost:8082
-tapesctl sessions list --tapes-url http://localhost:8081
+tapesctl sessions list --api-url http://localhost:8081
 tapesctl export <session-id> --detail spans -o session.jsonl
-tapesctl seed --tapes-url http://localhost:8081
+tapesctl seed --api-url http://localhost:8081
 tapesctl skill sync <name> --claude
 ```
 
-The capture commands (`start`, `capture`, `sync`) address the private ingest API on `:8082` through `--ingest-url` / `TAPES_INGEST_URL`; read commands use the read API on `:8081` through `--tapes-url` / `TAPES_API_URL`. Both ports are their local defaults.
+The capture commands (`start`, `capture`, `sync`) address the private ingest API on `:8082` through `--ingest-url` / `TAPES_INGEST_URL`; read commands use the read API on `:8081` through `--api-url` / `TAPES_API_URL`. Both ports are their local defaults.
 
 Arguments after `--` go directly to the agent. See [Agent integrations](./integrations.md) and the [`tapesctl` README](https://github.com/papercomputeco/tapesctl) for the full surface.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -59,14 +59,14 @@ curl -sSfL https://download.tapes.dev/tapesctl/install | bash
 ```
 
 ```bash
-tapesctl start claude --tapes-url http://localhost:8082
+tapesctl start claude --ingest-url http://localhost:8082
 tapesctl sessions list --tapes-url http://localhost:8081
 tapesctl export <session-id> --detail spans -o session.jsonl
 tapesctl seed --tapes-url http://localhost:8081
 tapesctl skill sync <name> --claude
 ```
 
-The capture commands (`start`, `capture`, `sync`) address the private ingest API on `:8082`; the read commands address the read API on `:8081`. A command that needs a server takes `--tapes-url`, falling back to `TAPES_URL` and then to `tapesctl config set tapes-url`. The flag is rendered in the help of commands that make no HTTP call at all — `config`, `skill list`, `skill sync`, `version`, `plugin uninstall` — because it propagates from the top level; those commands ignore it.
+The capture commands (`start`, `capture`, `sync`) address the private ingest API on `:8082` through `--ingest-url` / `TAPES_INGEST_URL`; read commands use the read API on `:8081` through `--tapes-url` / `TAPES_API_URL`. Both ports are their local defaults.
 
 Arguments after `--` go directly to the agent. See [Agent integrations](./integrations.md) and the [`tapesctl` README](https://github.com/papercomputeco/tapesctl) for the full surface.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -128,7 +128,7 @@ Three differences from the server's rules are worth stating outright:
 - **There is no project-local layer.** The client always reads
   `~/.tapes/config.toml`, whatever directory you run it from. A `.tapes/` in the
   current directory configures the server and is invisible to the client.
-- **The API default is explicit.** `--tapes-url`, `TAPES_API_URL`, and
+- **The API default is explicit.** `--api-url`, `TAPES_API_URL`, and
   `tapes-url` configure reads; absent all three it uses `http://localhost:8081`.
 - **Ingest has its own setting.** `--ingest-url`, `TAPES_INGEST_URL`, and
   `ingest-url` configure capture; absent all three it uses

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -111,14 +111,14 @@ Store provider secrets with `tapes auth openai` or `tapes auth anthropic`, or us
 
 ```toml
 # ~/.tapes/config.toml
-tapes-url = "http://localhost:8081"
+api-url = "http://localhost:8081"
 ingest-url = "http://localhost:8082"
 ```
 
 Write them with:
 
 ```bash
-tapesctl config set tapes-url http://localhost:8081
+tapesctl config set api-url http://localhost:8081
 tapesctl config set ingest-url http://localhost:8082
 tapesctl config path
 ```
@@ -129,7 +129,7 @@ Three differences from the server's rules are worth stating outright:
   `~/.tapes/config.toml`, whatever directory you run it from. A `.tapes/` in the
   current directory configures the server and is invisible to the client.
 - **The API default is explicit.** `--api-url`, `TAPES_API_URL`, and
-  `tapes-url` configure reads; absent all three it uses `http://localhost:8081`.
+  `api-url` configure reads; absent all three it uses `http://localhost:8081`.
 - **Ingest has its own setting.** `--ingest-url`, `TAPES_INGEST_URL`, and
   `ingest-url` configure capture; absent all three it uses
   `http://localhost:8082`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -107,19 +107,19 @@ Store provider secrets with `tapes auth openai` or `tapes auth anthropic`, or us
 
 ## The client's configuration
 
-`tapesctl` keeps one file, `~/.tapes/config.toml`, and reads exactly one key
-from it:
+`tapesctl` keeps API and ingest URLs in `~/.tapes/config.toml`:
 
 ```toml
 # ~/.tapes/config.toml
 tapes-url = "http://localhost:8081"
+ingest-url = "http://localhost:8082"
 ```
 
-Write it with:
+Write them with:
 
 ```bash
 tapesctl config set tapes-url http://localhost:8081
-tapesctl config get tapes-url
+tapesctl config set ingest-url http://localhost:8082
 tapesctl config path
 ```
 
@@ -128,14 +128,11 @@ Three differences from the server's rules are worth stating outright:
 - **There is no project-local layer.** The client always reads
   `~/.tapes/config.toml`, whatever directory you run it from. A `.tapes/` in the
   current directory configures the server and is invisible to the client.
-- **The chain has three links, not four.** A `--tapes-url` flag beats the
-  `TAPES_URL` environment variable, which beats the configured value. With none
-  of the three, a command that needs a server fails and names all three sources
-  rather than guessing a host.
-- **One URL covers two servers.** The read commands want the read API and the
-  capture commands want the ingest API, so whichever you configure, the other
-  needs `--tapes-url` on the command line. See
-  [Two ports, two jobs](./introduction.md#two-ports-two-jobs).
+- **The API default is explicit.** `--tapes-url`, `TAPES_API_URL`, and
+  `tapes-url` configure reads; absent all three it uses `http://localhost:8081`.
+- **Ingest has its own setting.** `--ingest-url`, `TAPES_INGEST_URL`, and
+  `ingest-url` configure capture; absent all three it uses
+  `http://localhost:8082`.
 
 `config set` edits the file in place, so comments, ordering, and keys the client
 does not know about survive it. `config get` lists only keys it knows *and* that

--- a/docs/data.md
+++ b/docs/data.md
@@ -18,14 +18,14 @@ This reports the selected `.tapes/` directory, provider and upstream, read API r
 Reading the data model is a client operation, so it lives in [`tapesctl`](https://github.com/papercomputeco/tapesctl):
 
 ```bash
-tapesctl sessions list --tapes-url http://localhost:8081
+tapesctl sessions list --api-url http://localhost:8081
 tapesctl sessions list --limit 20
 tapesctl sessions get <session-id>
 tapesctl sessions traces <session-id>
 tapesctl sessions raw-turns <session-id>
 ```
 
-Each prints the server's JSON verbatim, so it composes with `jq`. `--tapes-url` falls back to `TAPES_API_URL`, and then to the value from `tapesctl config set tapes-url`. A running read API is required; start one with `tapes serve`.
+Each prints the server's JSON verbatim, so it composes with `jq`. `--api-url` falls back to `TAPES_API_URL`, and then to the value from `tapesctl config set tapes-url`. A running read API is required; start one with `tapes serve`.
 
 The `<session-id>` these take is the Tapes session id from `sessions list`. It
 is not the harness session id `tapesctl start` prints when it exits.
@@ -65,7 +65,7 @@ has no export endpoint.
 ```bash
 tapesctl export <session-id> -o session.jsonl
 tapesctl export <session-id> --detail traces
-tapesctl export <session-id> --tapes-url http://localhost:8081
+tapesctl export <session-id> --api-url http://localhost:8081
 ```
 
 Detail modes:

--- a/docs/data.md
+++ b/docs/data.md
@@ -25,7 +25,7 @@ tapesctl sessions traces <session-id>
 tapesctl sessions raw-turns <session-id>
 ```
 
-Each prints the server's JSON verbatim, so it composes with `jq`. `--api-url` falls back to `TAPES_API_URL`, and then to the value from `tapesctl config set tapes-url`. A running read API is required; start one with `tapes serve`.
+Each prints the server's JSON verbatim, so it composes with `jq`. `--api-url` falls back to `TAPES_API_URL`, and then to the value from `tapesctl config set api-url`. A running read API is required; start one with `tapes serve`.
 
 The `<session-id>` these take is the Tapes session id from `sessions list`. It
 is not the harness session id `tapesctl start` prints when it exits.

--- a/docs/data.md
+++ b/docs/data.md
@@ -25,7 +25,7 @@ tapesctl sessions traces <session-id>
 tapesctl sessions raw-turns <session-id>
 ```
 
-Each prints the server's JSON verbatim, so it composes with `jq`. `--tapes-url` falls back to `TAPES_URL`, and then to the value from `tapesctl config set tapes-url`. A running read API is required; start one with `tapes serve`.
+Each prints the server's JSON verbatim, so it composes with `jq`. `--tapes-url` falls back to `TAPES_API_URL`, and then to the value from `tapesctl config set tapes-url`. A running read API is required; start one with `tapes serve`.
 
 The `<session-id>` these take is the Tapes session id from `sessions list`. It
 is not the harness session id `tapesctl start` prints when it exits.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -84,7 +84,7 @@ tapesctl sessions list
 ```
 
 Capture commands address the **ingest** port instead, and take it explicitly:
-`tapesctl start claude --tapes-url http://localhost:8082`. See
+`tapesctl start claude --ingest-url http://localhost:8082`. See
 [Agent integrations](./integrations.md).
 
 ## OpenAI embeddings

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -70,11 +70,8 @@ curl http://localhost:8081/ping
 tapes status
 ```
 
-Point the client at the read API once, so the read commands need no flag:
-
-```bash
-tapesctl config set tapes-url http://localhost:8081
-```
+The client defaults reads to this API and capture to the ingest service on
+`http://localhost:8082`.
 
 Seed representative capture data through the normal ingest and derive path:
 
@@ -83,9 +80,8 @@ tapesctl seed
 tapesctl sessions list
 ```
 
-Capture commands address the **ingest** port instead, and take it explicitly:
-`tapesctl start claude --ingest-url http://localhost:8082`. See
-[Agent integrations](./integrations.md).
+Capture commands address the **ingest** port instead. Override its local default
+with `--ingest-url` or `TAPES_INGEST_URL`. See [Agent integrations](./integrations.md).
 
 ## OpenAI embeddings
 

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -41,13 +41,13 @@ and skill generation — and is not part of capturing an agent.
 ## Claude Code
 
 ```bash
-tapesctl start claude --tapes-url http://localhost:8082
+tapesctl start claude --ingest-url http://localhost:8082
 ```
 
 `tapesctl` starts a loopback capture proxy, sets Claude Code's `ANTHROPIC_BASE_URL` to it, launches `claude`, and ships the captured turns to the server. Pass Claude flags after `--`:
 
 ```bash
-tapesctl start claude --tapes-url http://localhost:8082 -- --worktree
+tapesctl start claude --ingest-url http://localhost:8082 -- --worktree
 ```
 
 Claude sessions also produce transcripts on disk, which carry the subagent
@@ -55,7 +55,7 @@ structure the wire traffic alone cannot show. `start` tails them live. For a
 session no capture was running for, sweep them afterwards:
 
 ```bash
-tapesctl sync --tapes-url http://localhost:8082
+tapesctl sync --ingest-url http://localhost:8082
 ```
 
 `sync` sweeps the last seven days by default; `--since-days 0` sweeps
@@ -73,7 +73,7 @@ ANTHROPIC_BASE_URL=http://localhost:8080 claude
 The terminal CLI is launched like Claude:
 
 ```bash
-tapesctl start codex --tapes-url http://localhost:8082
+tapesctl start codex --ingest-url http://localhost:8082
 ```
 
 The ChatGPT desktop app launches itself, so it is captured through lifecycle
@@ -82,7 +82,7 @@ session in the app:
 
 ```bash
 tapesctl plugin install codex-app
-tapesctl capture codex-app --tapes-url http://localhost:8082
+tapesctl capture codex-app --ingest-url http://localhost:8082
 ```
 
 `plugin install codex-app` writes the handoff file and points the app's Codex
@@ -101,7 +101,7 @@ rather than a convenience:
 
 ```bash
 tapesctl plugin install pi
-tapesctl start pi --tapes-url http://localhost:8082
+tapesctl start pi --ingest-url http://localhost:8082
 ```
 
 `start pi` refuses to run when the extension is absent, before anything is bound
@@ -109,7 +109,7 @@ or launched. pi redirects several providers to one endpoint, so it is the one
 harness that takes `--schema`:
 
 ```bash
-tapesctl start pi --tapes-url http://localhost:8082 --schema openai
+tapesctl start pi --ingest-url http://localhost:8082 --schema openai
 ```
 
 `--schema` on `claude` or `codex` is an error rather than a silent no-op: each

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -141,7 +141,7 @@ The read API health endpoint is separate from the proxy and from ingest:
 ```bash
 curl http://localhost:8081/ping
 tapes status
-tapesctl sessions list --tapes-url http://localhost:8081
+tapesctl sessions list --api-url http://localhost:8081
 ```
 
 A captured session appears in that list. `start` prints the harness's own

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -54,7 +54,7 @@ tapesctl config set tapes-url http://localhost:8081
 ```
 
 That writes `tapes-url` to `~/.tapes/config.toml`. A `--tapes-url` flag beats
-`TAPES_URL`, which beats the configured value; with none of the three, commands
+`TAPES_API_URL`, which beats the configured value; with none of the three, commands
 that need a server fail rather than guess a host.
 
 ### Seed and read
@@ -78,9 +78,9 @@ When ready to capture real work, launch a supported agent through the client,
 pointed at the **ingest** port:
 
 ```bash
-tapesctl start claude --tapes-url http://localhost:8082
+tapesctl start claude --ingest-url http://localhost:8082
 # or
-tapesctl start codex --tapes-url http://localhost:8082
+tapesctl start codex --ingest-url http://localhost:8082
 ```
 
 `tapesctl start` launches the agent under a just-in-time capture proxy, routes its provider traffic through it, and ships the captured turns to the server.

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -46,16 +46,9 @@ that costs you a whole session:
 | `8081` | read API | `sessions`, `traces`, `spans`, `search`, `export`, `seed` |
 | `8082` | private ingest API | `start`, `capture`, `sync` |
 
-`tapesctl` reads one configured server URL, so configure the read API — the one
-most commands want — and pass the ingest URL explicitly when capturing:
-
-```bash
-tapesctl config set tapes-url http://localhost:8081
-```
-
-That writes `tapes-url` to `~/.tapes/config.toml`. A `--tapes-url` flag beats
-`TAPES_API_URL`, which beats the configured value; with none of the three, commands
-that need a server fail rather than guess a host.
+`tapesctl` keeps the two endpoints separate and defaults them to these local
+ports. Override reads with `--api-url`, `TAPES_API_URL`, or `tapes-url`; override
+capture with `--ingest-url`, `TAPES_INGEST_URL`, or `ingest-url`.
 
 ### Seed and read
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -47,7 +47,7 @@ that costs you a whole session:
 | `8082` | private ingest API | `start`, `capture`, `sync` |
 
 `tapesctl` keeps the two endpoints separate and defaults them to these local
-ports. Override reads with `--api-url`, `TAPES_API_URL`, or `tapes-url`; override
+ports. Override reads with `--api-url`, `TAPES_API_URL`, or `api-url`; override
 capture with `--ingest-url`, `TAPES_INGEST_URL`, or `ingest-url`.
 
 ### Seed and read

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -49,7 +49,7 @@ The bundled local setup configures PostgreSQL and Ollama. Capture or seed data
 before browsing:
 
 ```bash
-tapesctl seed --tapes-url http://localhost:8081
+tapesctl seed --api-url http://localhost:8081
 ```
 
 ## Scope

--- a/pkg/cassette/examples/hello-world/README.md
+++ b/pkg/cassette/examples/hello-world/README.md
@@ -59,7 +59,7 @@ tapes serve --cassettes=http://127.0.0.1:9999/openapi
 ```
 
 `tapesctl` turns the discovered surface into commands
-(`TAPES_URL=http://localhost:8081 tapesctl cassettes hello-world get-hello`); the
+(`TAPES_API_URL=http://localhost:8081 tapesctl cassettes hello-world get-hello`); the
 [Running a cassette locally](../../../../docs/cassette-walkthrough.md)
 guide walks this whole directory end to end.
 


### PR DESCRIPTION
# 👨🏼

Refs PCC-1234

# 🤖

Updates Tapes documentation for the separate local read and ingest endpoints.

- Documents `http://localhost:8081` as the read API default and `http://localhost:8082` as the ingest default.
- Uses `--api-url` / `TAPES_API_URL` / `api-url` for reads.
- Uses `--ingest-url` / `TAPES_INGEST_URL` / `ingest-url` for capture.
- Updates configuration, installation, cassette, integration, and command examples, including the hello-world cassette.
