### PR TITLE
✨ feat: End to end docker compose open core

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,3 +1,5 @@
+name: tapes
+
 services:
   postgres:
     image: public.ecr.aws/g4e5l3z3/papercomputeco/postgres:17.7-pgduckdb-1.1.1
@@ -6,33 +8,92 @@ services:
       POSTGRES_USER: tapes
       POSTGRES_PASSWORD: tapes
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
     volumes:
       - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -h 127.0.0.1 -U tapes -d tapes"]
+      interval: 1s
+      timeout: 3s
+      retries: 30
 
   ollama:
     image: ollama/ollama
     ports:
-      - "11434:11434"
+      - "127.0.0.1:11434:11434"
     volumes:
       - ~/.ollama:/root/.ollama
+
+  skills:
+    image: public.ecr.aws/g4e5l3z3/papercomputeco/skills-cassette:latest
+    environment:
+      CASSETTE_CORE_URL: http://tapes.svc:8081
+      CASSETTE_LLM_PROVIDER: ollama
+      CASSETTE_LLM_BASE_URL: http://ollama:11434
+      TAPES_DATABASE_URL: postgres://tapes:tapes@postgres:5432/tapes?sslmode=disable
+    ports:
+      - "127.0.0.1:9999:9998"
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  search:
+    image: public.ecr.aws/g4e5l3z3/papercomputeco/search-cassette:latest
+    environment:
+      CASSETTE_EMBEDDING_PROVIDER: ollama
+      CASSETTE_EMBEDDING_TARGET: http://ollama:11434
+      CASSETTE_WAIT_FOR_DB: "true"
+      TAPES_DATABASE_URL: postgres://tapes:tapes@postgres:5432/tapes?sslmode=disable
+    ports:
+      - "127.0.0.1:9998:9998"
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  export:
+    image: public.ecr.aws/g4e5l3z3/papercomputeco/export-cassette:latest
+    environment:
+      CASSETTE_NAME: export
+      CASSETTE_LISTEN: 0.0.0.0:9998
+      TAPES_DATABASE_URL: postgres://tapes:tapes@postgres:5432/tapes?sslmode=disable
+    ports:
+      - "127.0.0.1:9997:9998"
+    depends_on:
+      postgres:
+        condition: service_healthy
 
   tapes:
     build:
       dockerfile: Dockerfile
-    depends_on:
-      - postgres
-      - ollama
-    ports:
-      - "8080:8080"
-      - "8081:8081"
     command: >-
       serve
+      --provider ollama
       --upstream http://ollama:11434
       --postgres postgres://tapes:tapes@postgres:5432/tapes?sslmode=disable
-      --debug
+      --cassettes http://skills:9998/openapi,http://search:9998/openapi,http://export:9998/openapi
+      --cassette-refresh 10s
+      --log-level=debug
+    ports:
+      - "127.0.0.1:8080:8080"
+      - "127.0.0.1:8081:8081"
+      - "127.0.0.1:8082:8082"
     volumes:
       - tapes-data:/data
+    networks:
+      default:
+        aliases:
+          - tapes.svc
+    depends_on:
+      postgres:
+        condition: service_healthy
+      skills:
+        condition: service_started
+      search:
+        condition: service_started
+      export:
+        condition: service_started
+      ollama:
+        condition: service_started
 
 volumes:
   postgres-data:


### PR DESCRIPTION
End toe end open core tapes docker compose stack with the skills-cassette, search-cassette, and export-cassette.

```sh
docker compose up --build -d
```
```sh
tapesctl start claude
tapesctl sessions list
```
```json5
{
  "items": [
    {
      "auth_subject": "local:jpmcb",
      "display_title": "woof.",
      // etc. etc.
    }
  ]
}
```

Refs PCC-1221