### PR TITLE
🔧 fix: cross-compile Docker images natively

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,9 @@
 # -----------------------------------------------------------------------------
 # Build stage
 # -----------------------------------------------------------------------------
-FROM golang:1.26-bookworm AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26-bookworm AS builder
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /src
 
@@ -16,6 +18,8 @@ COPY . .
 
 ARG LDFLAGS="-s -w"
 RUN CGO_ENABLED=0 \
+    GOOS=${TARGETOS:-linux} \
+    GOARCH=${TARGETARCH} \
     GOEXPERIMENT="jsonv2" \
     go build \
     -ldflags="${LDFLAGS} -extldflags '-static'" \
@@ -27,16 +31,12 @@ RUN CGO_ENABLED=0 \
 # -----------------------------------------------------------------------------
 FROM alpine:3.20
 
-RUN apk add --no-cache ca-certificates
-
-# Create non-root user
-RUN addgroup -g 1000 tapes && \
-    adduser -u 1000 -G tapes -s /bin/sh -D tapes
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 WORKDIR /app
 
 COPY --from=builder /bin/tapes /app/tapes
 
-USER tapes
+USER 1000:1000
 EXPOSE 8080
 ENTRYPOINT ["/app/tapes"]

--- a/Dockerfile.extproc
+++ b/Dockerfile.extproc
@@ -7,7 +7,7 @@
 # process rather than becoming another `tapes serve` subcommand.
 
 # Build the tapes-extproc binary
-FROM golang:1.26 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG LDFLAGS="-s -w"


### PR DESCRIPTION
# 👨🏼


# 🤖

---

## Summary
- run Go builder stages on `BUILDPLATFORM` and compile for `TARGETOS`/`TARGETARCH`
- remove target-platform runtime `RUN` steps so multi-arch releases do not invoke QEMU
- retain CA certificates and the existing numeric non-root UID

## Validation
- `docker buildx build --platform linux/amd64 ...` from a `linux/arm64` builder
- `git diff --check`
